### PR TITLE
build: enable building & running tests from a subdir

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -255,6 +255,7 @@ CREATE_ROOTFS = $(AM_V_GEN) ( $(RM) -rf $(ROOTFS) && mkdir -p $(dir $(ROOTFS)) &
 build-module-playground:
 	$(AM_V_GEN)if test "$(top_srcdir)" != "$(top_builddir)"; then \
 		$(RM) -rf testsuite/module-playground && \
+		mkdir -p testsuite/ && \
 		cp -r $(top_srcdir)/$(MODULE_PLAYGROUND) $(top_builddir)/$(MODULE_PLAYGROUND) && \
 		find $(top_builddir)/$(MODULE_PLAYGROUND) -type d -exec chmod +w {} \; ; \
 		fi


### PR DESCRIPTION
During dpkg build, in a subdir, it is currently not possible to run
tests. Building testsuite/modules due to non-existance of the
testsuite directory under the build dir. Thus create it, when it is
not there.

Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@canonical.com>