### PR TITLE
modprobe: Write error messages to syslog if stderr is unavailable

### DIFF
--- a/tools/modprobe.c
+++ b/tools/modprobe.c
@@ -765,6 +765,7 @@ static int do_modprobe(int argc, char **orig_argv)
 	int do_show_modversions = 0;
 	int do_show_exports = 0;
 	int err;
+	struct stat stat_buf;
 
 	argv = prepend_options_from_env(&argc, orig_argv);
 	if (argv == NULL) {
@@ -882,6 +883,12 @@ static int do_modprobe(int argc, char **orig_argv)
 
 	args = argv + optind;
 	nargs = argc - optind;
+
+	if (!use_syslog &&
+	    (!stderr ||
+	     fileno(stderr) == -1 ||
+	     fstat(fileno(stderr), &stat_buf)))
+		use_syslog = 1;
 
 	log_open(use_syslog);
 


### PR DESCRIPTION
The man page modprobe(8) states for the --syslog option:
"This is also automatically enabled when stderr is unavailable."
but it wasn't happening.

This commit now makes modprobe write to syslog if stderr is closed.