### PR TITLE
libkmod: do not crash on unknown signature algorithm

### DIFF
--- a/libkmod/libkmod-signature.c
+++ b/libkmod/libkmod-signature.c
@@ -278,6 +278,9 @@ static bool fill_pkcs7(const char *mem, off_t size,
 	X509_ALGOR_get0(&o, NULL, NULL, dig_alg);
 
 	sig_info->hash_algo = pkey_hash_algo[obj_to_hash_algo(o)];
+	// hash algo has not been recognized
+	if (sig_info->hash_algo == NULL)
+		goto err3;
 	sig_info->id_type = pkey_id_type[modsig->id_type];
 
 	pvt = malloc(sizeof(*pvt));


### PR DESCRIPTION
Example kernel module:

https://file-store.rosalinux.ru/download/7281f97e0c04c0f818ad3f936706f4a407e8dc7e
(/lib/modules/5.15.67-generic-1rosa2021.1-x86_64/kernel/drivers/usb/host/xhci-pci.ko.zst)
It is signed with Streebog 512.

libkmod v30 crashed in libkmod-module.c:2413 in this code:

```c
n = kmod_module_info_append(list,
	"sig_hashalgo", strlen("sig_hashalgo"),
	sig_info.hash_algo, strlen(sig_info.hash_algo));
```

because strlen() got null.