### PR TITLE
libkmod: support GOST signatures

### DIFF
--- a/libkmod/libkmod-signature.c
+++ b/libkmod/libkmod-signature.c
@@ -38,12 +38,14 @@
  */
 enum pkey_algo {
 	PKEY_ALGO_DSA,
+	PKEY_ALGO_RDSA,
 	PKEY_ALGO_RSA,
 	PKEY_ALGO__LAST
 };
 
 static const char *const pkey_algo[PKEY_ALGO__LAST] = {
 	[PKEY_ALGO_DSA]		= "DSA",
+	[PKEY_ALGO_RDSA]	= "RDSA",
 	[PKEY_ALGO_RSA]		= "RSA",
 };
 
@@ -57,6 +59,8 @@ enum pkey_hash_algo {
 	PKEY_HASH_SHA512,
 	PKEY_HASH_SHA224,
 	PKEY_HASH_SM3,
+	PKEY_HASH_STREEBOG256,
+	PKEY_HASH_STREEBOG512,
 	PKEY_HASH__LAST
 };
 
@@ -70,6 +74,8 @@ const char *const pkey_hash_algo[PKEY_HASH__LAST] = {
 	[PKEY_HASH_SHA512]	= "sha512",
 	[PKEY_HASH_SHA224]	= "sha224",
 	[PKEY_HASH_SM3]		= "sm3",
+	[PKEY_HASH_STREEBOG256] = "streebog256",
+	[PKEY_HASH_STREEBOG512] = "streebog512",
 };
 
 enum pkey_id_type {
@@ -166,6 +172,12 @@ static int obj_to_hash_algo(const ASN1_OBJECT *o)
 # ifndef OPENSSL_NO_SM3
 	case NID_sm3:
 		return PKEY_HASH_SM3;
+# endif
+# ifndef OPENSSL_NO_GOST
+	case NID_id_GostR3411_2012_256:
+		return PKEY_HASH_STREEBOG256;
+	case NID_id_GostR3411_2012_512:
+		return PKEY_HASH_STREEBOG512;
 # endif
 	default:
 		return -1;


### PR DESCRIPTION
Example kernel module:

https://file-store.rosalinux.ru/download/7281f97e0c04c0f818ad3f936706f4a407e8dc7e
(/lib/modules/5.15.67-generic-1rosa2021.1-x86_64/kernel/drivers/usb/host/xhci-pci.ko.zst)
It is signed with Streebog 512.

```
$ modinfo xhci_pci
filename:       /lib/modules/5.15.67-generic-1rosa2021.1-x86_64/kernel/drivers/usb/host/xhci-pci.ko.zst
license:        GPL
description:    xHCI PCI Host Controller Driver
firmware:       renesas_usb_fw.mem
srcversion:     56C9CEEC7526753A401AED0
alias:          pci:v*d*sv*sd*bc0Csc03i30*
alias:          pci:v00001912d00000015sv*sd*bc*sc*i*
alias:          pci:v00001912d00000014sv*sd*bc*sc*i*
depends:        xhci-pci-renesas
retpoline:      Y
intree:         Y
name:           xhci_pci
vermagic:       5.15.67-generic-1rosa2021.1-x86_64 SMP preempt mod_unload modversions
sig_id:         PKCS#7
signer:         Build time autogenerated GOST R 34.10-2012 kernel key
sig_key:        A6:FD:67:5D:C4:F1:E6:E4
sig_hashalgo:   streebog512
signature:      1F:54:A4:49:FE:EF:C8:DB:43:0A:35:4C:5B:0E:18:F3:78:61:F8:45:
		B3:1D:1D:12:EF:23:46:57:29:08:89:F9:63:65:5F:E6:07:57:62:D3:
		2F:8A:B3:28:86:E1:E6:B9:49:91:20:F5:2B:39:95:80:C5:70:0C:BE:
		E5:85:01:EA:B5:57:1C:A7:16:CE:63:91:D6:DF:16:2C:BC:08:79:00:
		CE:E4:46:65:2E:E6:64:B0:D5:B3:1F:75:64:D4:14:1E:88:01:4F:71:
		06:DE:E4:22:63:58:F3:76:5A:B1:11:E7:00:51:55:28:72:1F:6D:59:
		E4:18:E4:69:4B:57:EC:52
```

However, a simple patch of the Linux kernel is needed to load such modules:
https://abf.io/import/kernel-5.10/blob/4c7232ab3e/0001-crypto-support-loading-GOST-signed-kernel-modules.patch
It is very simple, but upstreamization may fail due to not very easy way to sign *.ko with GOST
(see https://abf.io/import/libressl and https://abf.io/import/kernel-5.10/blob/4c7232ab3e/0001-sign-file-full-functionality-with-modern-LibreSSL.patch)