### PR TITLE
depmod: Introduce a outdir option

### DIFF
--- a/man/depmod.xml
+++ b/man/depmod.xml
@@ -45,6 +45,7 @@
     <cmdsynopsis>
       <command>depmod</command>
       <arg><option>-b <replaceable>basedir</replaceable></option></arg>
+      <arg><option>-o <replaceable>outdir</replaceable></option></arg>
       <arg><option>-e</option></arg>
       <arg><option>-E <replaceable>Module.symvers</replaceable></option></arg>
       <arg><option>-F <replaceable>System.map</replaceable></option></arg>
@@ -146,6 +147,24 @@
             directory name.  This <replaceable>basedir</replaceable> is
             stripped from the resulting <filename>modules.dep</filename> file,
             so it is ready to be moved into the normal location. Use this
+            option if you are a distribution vendor who needs to pre-generate
+            the meta-data files rather than running depmod again later.
+          </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>
+          <option>-o <replaceable>outdir</replaceable></option>
+        </term>
+        <term>
+          <option>--outdir <replaceable>outdir</replaceable></option>
+        </term>
+        <listitem>
+          <para>
+            If your modules are stored in a read-only location, you may want to
+            create the output meta-data files in another location. Setting
+            <replaceable>outdir</replaceable> serves as a root to that location
+            similar to how we use <replaceable>basedir</replaceable>. Use this
             option if you are a distribution vendor who needs to pre-generate
             the meta-data files rather than running depmod again later.
           </para>


### PR DESCRIPTION
This option is equivalent to basedir, with the small difference being that's where the meta-data files are generated. In other words, this allows us to have read-only input modules and modules.dep, while still being able to generate the meta-data files.

Signed-off-by: Emil Velikov <emil.velikov@collabora.com>
---

Hello team,

Here's a handy feature behind the request at
https://github.com/kmod-project/kmod/issues/13

This is my first time hacking on kmod, so hope I didn't make too many mistakes :-) There are a few TODO notes below where your input is greatly appreciated.

TODO:
 - Add tests - team, any pointers or requests?
 - Split the dirnamelen shorthand tenary operator change - is it worth it?