### PR TITLE
configure.ac: fix link with -llzma

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -88,7 +88,7 @@ AC_ARG_WITH([zstd],
 	AS_HELP_STRING([--with-zstd], [handle Zstandard-compressed modules @<:@default=disabled@:>@]),
 	[], [with_zstd=no])
 AS_IF([test "x$with_zstd" != "xno"], [
-	PKG_CHECK_MODULES([libzstd], [libzstd >= 1.4.4])
+	PKG_CHECK_MODULES([libzstd], [libzstd >= 1.4.4], [LIBS="$LIBS $libzstd_LIBS"])
 	AC_DEFINE([ENABLE_ZSTD], [1], [Enable Zstandard for modules.])
 ], [
 	AC_MSG_NOTICE([Zstandard support not requested])
@@ -99,7 +99,7 @@ AC_ARG_WITH([xz],
 	AS_HELP_STRING([--with-xz], [handle Xz-compressed modules @<:@default=disabled@:>@]),
 	[], [with_xz=no])
 AS_IF([test "x$with_xz" != "xno"], [
-	PKG_CHECK_MODULES([liblzma], [liblzma >= 4.99])
+	PKG_CHECK_MODULES([liblzma], [liblzma >= 4.99], [LIBS="$LIBS $liblzma_LIBS"])
 	AC_DEFINE([ENABLE_XZ], [1], [Enable Xz for modules.])
 ], [
 	AC_MSG_NOTICE([Xz support not requested])
@@ -110,7 +110,7 @@ AC_ARG_WITH([zlib],
 	AS_HELP_STRING([--with-zlib], [handle gzipped modules @<:@default=disabled@:>@]),
 	[], [with_zlib=no])
 AS_IF([test "x$with_zlib" != "xno"], [
-	PKG_CHECK_MODULES([zlib], [zlib])
+	PKG_CHECK_MODULES([zlib], [zlib], [LIBS="$LIBS $zlib_LIBS"])
 	AC_DEFINE([ENABLE_ZLIB], [1], [Enable zlib for modules.])
 ], [
 	AC_MSG_NOTICE([zlib support not requested])
@@ -121,7 +121,7 @@ AC_ARG_WITH([openssl],
 	AS_HELP_STRING([--with-openssl], [handle PKCS7 signatures @<:@default=disabled@:>@]),
 	[], [with_openssl=no])
 AS_IF([test "x$with_openssl" != "xno"], [
-	PKG_CHECK_MODULES([libcrypto], [libcrypto >= 1.1.0])
+	PKG_CHECK_MODULES([libcrypto], [libcrypto >= 1.1.0], [LIBS="$LIBS $libcrypto_LIBS"])
 	AC_DEFINE([ENABLE_OPENSSL], [1], [Enable openssl for modinfo.])
 ], [
 	AC_MSG_NOTICE([openssl support not requested])


### PR DESCRIPTION
Add `liblzma_LIBS` to `LIBS` to avoid the following build failure when building with a static-only `liblzma.a`:

```
/home/autobuild/autobuild/instance-5/output-1/host/lib/gcc/xtensa-buildroot-linux-uclibc/11.3.0/../../../../xtensa-buildroot-linux-uclibc/bin/ld: libkmod/.libs/libkmod-internal.a(libkmod-file.o):(.text.xz_uncompress+0x10): undefined reference to `lzma_code'
```

Fixes:
 - http://autobuild.buildroot.org/results/83a4a7ecc77f39639d3e5bc8554bd01a62a3ede0