### PR TITLE
Move string formatting of signature information from libkmod to modinfo tool

### DIFF
--- a/libkmod/libkmod-module.c
+++ b/libkmod/libkmod-module.c
@@ -2396,6 +2396,12 @@ KMOD_EXPORT int kmod_module_get_info(const struct kmod_module *mod, struct kmod_
 			goto list_error;
 		count++;
 
+		n = kmod_module_info_append(list, "sig_algo", strlen("sig_algo"),
+				sig_info.algo, strlen(sig_info.algo));
+		if (n == NULL)
+			goto list_error;
+		count++;
+
 		n = kmod_module_info_append(list,
 				"sig_hashalgo", strlen("sig_hashalgo"),
 				sig_info.hash_algo, strlen(sig_info.hash_algo));
@@ -2403,10 +2409,6 @@ KMOD_EXPORT int kmod_module_get_info(const struct kmod_module *mod, struct kmod_
 			goto list_error;
 		count++;
 
-		/*
-		 * Omit sig_info.algo for now, as these
-		 * are currently constant.
-		 */
 		n = kmod_module_info_append(list, "signature", strlen("signature"),
 						sig_info.sig,
 						sig_info.sig_len);

--- a/libkmod/libkmod-signature.c
+++ b/libkmod/libkmod-signature.c
@@ -141,6 +141,20 @@ static void pkcs7_free(void *s)
 	si->private = NULL;
 }
 
+static const char *obj_to_sig_algo(const ASN1_OBJECT *o)
+{
+	int nid = OBJ_obj2nid(o);
+
+	switch (nid) {
+	case NID_sha256WithRSAEncryption:
+		return "sha256WithRSAEncryption";
+	case NID_SM2_with_SM3:
+		return "SM2-with-SM3";
+	default:
+		return "unknown";
+	}
+}
+
 static int obj_to_hash_algo(const ASN1_OBJECT *o)
 {
 	int nid;
@@ -276,8 +290,10 @@ static bool fill_pkcs7(const char *mem, off_t size,
 		sig_info->signer_len = strlen(issuer_str);
 	}
 
-	X509_ALGOR_get0(&o, NULL, NULL, dig_alg);
+	X509_ALGOR_get0(&o, NULL, NULL, sig_alg);
+	sig_info->algo = obj_to_sig_algo(o);
 
+	X509_ALGOR_get0(&o, NULL, NULL, dig_alg);
 	hash_algo = obj_to_hash_algo(o);
 	if (hash_algo < 0)
 		goto err3;

--- a/libkmod/libkmod.h
+++ b/libkmod/libkmod.h
@@ -238,6 +238,7 @@ long kmod_module_get_size(const struct kmod_module *mod);
 int kmod_module_get_info(const struct kmod_module *mod, struct kmod_list **list);
 const char *kmod_module_info_get_key(const struct kmod_list *entry);
 const char *kmod_module_info_get_value(const struct kmod_list *entry);
+const char *kmod_module_info_get_value_n(const struct kmod_list *entry, size_t *valuelen);
 void kmod_module_info_free_list(struct kmod_list *list);
 
 int kmod_module_get_versions(const struct kmod_module *mod, struct kmod_list **list);

--- a/libkmod/libkmod.sym
+++ b/libkmod/libkmod.sym
@@ -92,3 +92,8 @@ LIBKMOD_22 {
 global:
 	kmod_get_dirname;
 } LIBKMOD_6;
+
+LIBKMOD_31 {
+global:
+	kmod_module_info_get_value_n;
+} LIBKMOD_22;

--- a/tools/modinfo.c
+++ b/tools/modinfo.c
@@ -168,6 +168,33 @@ end:
 	return err;
 }
 
+static char *hex_to_str(const char *hex, size_t len)
+{
+	char *str;
+	int i;
+	int j;
+	const size_t line_limit = 20;
+	size_t str_len;
+
+	str_len = len * 3; /* XX: or XX\0 */
+	str_len += ((str_len + line_limit - 1) / line_limit - 1) * 3; /* \n\t\t */
+
+	str = malloc(str_len);
+	if (str == NULL)
+		return NULL;
+
+	for (i = 0, j = 0; i < (int)len; i++) {
+		j += sprintf(str + j, "%02X", (unsigned char)hex[i]);
+		if (i < (int)len - 1) {
+			str[j++] = ':';
+
+			if ((i + 1) % line_limit == 0)
+				j += sprintf(str + j, "\n\t\t");
+		}
+	}
+	return str;
+}
+
 static int modinfo_do(struct kmod_module *mod)
 {
 	struct kmod_list *l, *list = NULL;
@@ -214,32 +241,35 @@ static int modinfo_do(struct kmod_module *mod)
 	}
 
 	kmod_list_foreach(l, list) {
+        size_t valuelen;
 		const char *key = kmod_module_info_get_key(l);
-		const char *value = kmod_module_info_get_value(l);
+		const char *value = kmod_module_info_get_value_n(l, &valuelen);
+		char *hex = NULL;
 		int keylen;
+
+		if ((streq(key, "sig_key") || streq(key, "signature")) && valuelen > 0) {
+			hex = hex_to_str(value, valuelen);
+			value = hex;
+		}
 
 		if (field != NULL) {
 			if (!streq(field, key))
 				continue;
 			/* filtered output contains no key, just value */
 			printf("%s%c", value, separator);
-			continue;
-		}
-
-		if (streq(key, "parm") || streq(key, "parmtype")) {
+		} else if (streq(key, "parm") || streq(key, "parmtype")) {
 			err = process_parm(key, value, &params);
 			if (err < 0)
 				goto end;
-			continue;
-		}
-
-		if (separator == '\0') {
+		} else if (separator == '\0') {
 			printf("%s=%s%c", key, value, separator);
-			continue;
+		} else {
+			keylen = strlen(key);
+			printf("%s:%-*s%s%c", key, 15 - keylen, "", value, separator);
 		}
 
-		keylen = strlen(key);
-		printf("%s:%-*s%s%c", key, 15 - keylen, "", value, separator);
+		if (hex)
+			free(hex);
 	}
 
 	if (field != NULL)


### PR DESCRIPTION
Also supports public key algorithms of kernel module signatures.

an example:
```
$ modinfo soundcore_signed.ko
filename:       /home/uudiin/soundcore_signed.ko
license:        GPL
author:         Alan Cox
description:    Core sound module
srcversion:     16262E0FC229CA1AC4DC130
depends:
retpoline:      Y
intree:         Y
name:           soundcore
vermagic:       5.10.134-13_rc1.an8.x86_64 SMP mod_unload modversions
sig_id:         PKCS#7
signer:         RFC8998 certificate signing key
sig_key:        40:E5:D9:9D:12:64:86:17:F2:8A:8E:54:A6:E0:72:C3:0C:01:9D:55
sig_algo:       SM2-with-SM3
sig_hashalgo:   sm3
signature:      30:45:02:21:00:F1:F8:4E:06:FF:AB:77:42:B7:8B:16:D6:C6:DF:43:
		5C:14:3A:B7:46:6D:08:7A:42:AB:6E:A0:A0:F6:53:F6:76:02:20:06:
		95:8D:0E:84:64:2D:1F:93:25:66:CF:72:8A:C2:71:78:CF:4A:28:77:
		CB:05:2E:BF:03:0D:CC:2D:95:19:A3
```