### PR TITLE
libkmod: add fallback MODULE_INIT_COMPRESSED_FILE define

### DIFF
--- a/shared/missing.h
+++ b/shared/missing.h
@@ -15,6 +15,10 @@
 # define MODULE_INIT_IGNORE_VERMAGIC 2
 #endif
 
+#ifndef MODULE_INIT_COMPRESSED_FILE
+# define MODULE_INIT_COMPRESSED_FILE 4
+#endif
+
 #ifndef __NR_finit_module
 # define __NR_finit_module -1
 #endif


### PR DESCRIPTION
The symbol was somewhat recently introduced by the kernel and not all distributions may be have available.

The number is part of the ABI, so we can add a local fallback define.

Closes: https://github.com/kmod-project/kmod/issues/29

@lucasdemarchi not sure if you're keeping an eye here or I should send it over to the ML.