### PR TITLE
Use portable implementation for basename API

### DIFF
--- a/libkmod/libkmod-config.c
+++ b/libkmod/libkmod-config.c
@@ -794,7 +794,7 @@ static int conf_files_insert_sorted(struct kmod_ctx *ctx,
 	bool is_single = false;
 
 	if (name == NULL) {
-		name = basename(path);
+		name = gnu_basename(path);
 		is_single = true;
 	}
 

--- a/shared/util.c
+++ b/shared/util.c
@@ -172,9 +172,9 @@ char *modname_normalize(const char *modname, char buf[static PATH_MAX], size_t *
 
 char *path_to_modname(const char *path, char buf[static PATH_MAX], size_t *len)
 {
-	char *modname;
+	const char *modname;
 
-	modname = basename(path);
+	modname = gnu_basename(path);
 	if (modname == NULL || modname[0] == '\0')
 		return NULL;
 

--- a/shared/util.h
+++ b/shared/util.h
@@ -5,6 +5,7 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <time.h>
@@ -75,6 +76,12 @@ do {						\
 	} *__p = (typeof(__p)) (ptr);		\
 	__p->__v = (val);			\
 } while(0)
+
+static _always_inline_ const char *gnu_basename(const char *s)
+{
+  const char *p = strrchr(s, '/');
+  return p ? p+1 : s;
+}
 
 static _always_inline_ unsigned int ALIGN_POWER2(unsigned int u)
 {

--- a/testsuite/testsuite.c
+++ b/testsuite/testsuite.c
@@ -70,7 +70,7 @@ static void help(void)
 
 	printf("Usage:\n"
 	       "\t%s [options] <test>\n"
-	       "Options:\n", basename(progname));
+	       "Options:\n", gnu_basename(progname));
 
 	for (itr = options, itr_short = options_short;
 				itr->name != NULL; itr++, itr_short++)

--- a/tools/depmod.c
+++ b/tools/depmod.c
@@ -762,7 +762,7 @@ static int cfg_files_insert_sorted(struct cfg_file ***p_files, size_t *p_n_files
 	if (name != NULL)
 		namelen = strlen(name);
 	else {
-		name = basename(dir);
+		name = gnu_basename(dir);
 		namelen = strlen(name);
 		dirlen -= namelen + 1;
 	}

--- a/tools/kmod.c
+++ b/tools/kmod.c
@@ -68,7 +68,7 @@ static int kmod_help(int argc, char *argv[])
 			"Options:\n"
 			"\t-V, --version     show version\n"
 			"\t-h, --help        show this help\n\n"
-			"Commands:\n", basename(argv[0]));
+			"Commands:\n", gnu_basename(argv[0]));
 
 	for (i = 0; i < ARRAY_SIZE(kmod_cmds); i++) {
 		if (kmod_cmds[i]->help != NULL) {
@@ -156,7 +156,7 @@ static int handle_kmod_compat_commands(int argc, char *argv[])
 	const char *cmd;
 	size_t i;
 
-	cmd = basename(argv[0]);
+	cmd = gnu_basename(argv[0]);
 
 	for (i = 0; i < ARRAY_SIZE(kmod_compat_cmds); i++) {
 		if (streq(kmod_compat_cmds[i]->name, cmd))


### PR DESCRIPTION
musl has removed the non-prototype declaration of basename from string.h [1] which now results in build errors with clang-17+ compiler

include libgen.h for using the posix declaration of the funciton.

Fixes
../git/tools/kmod.c:71:19: error: call to undeclared function 'basename'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
   71 |                         "Commands:\n", basename(argv[0]));
      |                                        ^

[1] https://git.musl-libc.org/cgit/musl/commit/?id=725e17ed6dff4d0cd22487bb64470881e86a92e7
Signed-off-by: Khem Raj <raj.khem@gmail.com>