### PR TITLE
Install kmod.pc in ${datadir}/pkgconfig

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -96,8 +96,8 @@ libkmod_libkmod_internal_la_LDFLAGS = $(AM_LDFLAGS) \
 libkmod_libkmod_internal_la_DEPENDENCIES  = $(libkmod_libkmod_la_DEPENDENCIES)
 libkmod_libkmod_internal_la_LIBADD = $(libkmod_libkmod_la_LIBADD)
 
-pkgconfigdir = $(libdir)/pkgconfig
-pkgconfig_DATA = libkmod/libkmod.pc tools/kmod.pc
+pkgconfig_DATA = libkmod/libkmod.pc
+noarch_pkgconfig_DATA = tools/kmod.pc
 
 bashcompletiondir=@bashcompletiondir@
 dist_bashcompletion_DATA = \

--- a/configure.ac
+++ b/configure.ac
@@ -231,6 +231,9 @@ GTK_DOC_CHECK([1.14],[--flavour no-tmpl-flat])
 ], [
 AM_CONDITIONAL([ENABLE_GTK_DOC], false)])
 
+PKG_INSTALLDIR
+PKG_NOARCH_INSTALLDIR
+
 #####################################################################
 # Default CFLAGS and LDFLAGS
 #####################################################################


### PR DESCRIPTION
The data in this file isn't related to installed libraries, so put it in an abi-neutral location.

pkg.m4 provides macros that also allow the user to override the location with configure switches.

Bug: https://bugs.gentoo.org/926431