### PR TITLE
lsmod, libkmod: handle module changes during execution

### DIFF
--- a/libkmod/libkmod-module.c
+++ b/libkmod/libkmod-module.c
@@ -2049,7 +2049,7 @@ KMOD_EXPORT int kmod_module_get_refcnt(const struct kmod_module *mod)
 	fd = open(path, O_RDONLY|O_CLOEXEC);
 	if (fd < 0) {
 		err = -errno;
-		DBG(mod->ctx, "could not open '%s': %s\n",
+		ERR(mod->ctx, "could not open '%s': %s\n",
 			path, strerror(errno));
 		return err;
 	}

--- a/tools/lsmod.c
+++ b/tools/lsmod.c
@@ -61,11 +61,19 @@ static int do_lsmod(int argc, char *argv[])
 		const char *name = kmod_module_get_name(mod);
 		int use_count = kmod_module_get_refcnt(mod);
 		long size = kmod_module_get_size(mod);
-		struct kmod_list *holders, *hitr;
+		struct kmod_list *holders = kmod_module_get_holders(mod), *hitr;
 		int first = 1;
 
+		if (holders == NULL || use_count < 0 || size < 0) {
+			fprintf(stderr, "Error: could not query module %s! Was the module unloaded?\n", name);
+			kmod_module_unref_list(holders);
+			kmod_module_unref(mod);
+			kmod_module_unref_list(list);
+			kmod_unref(ctx);
+			return EXIT_FAILURE;
+		}
+
 		printf("%-19s %8ld  %d", name, size, use_count);
-		holders = kmod_module_get_holders(mod);
 		kmod_list_foreach(hitr, holders) {
 			struct kmod_module *hm = kmod_module_get_module(hitr);
 


### PR DESCRIPTION
Kernel modules may be unloaded within the time window of checking `/proc/modules` and `/sys/module/*/*`. As a result,

* `-errno` is printed in place of size or reference count
* `EXIT_SUCCESS` is reported despite failure

Add checks for better error reporting.

Fixes #41.