### PR TITLE
Extend array checks

### DIFF
--- a/shared/array.c
+++ b/shared/array.c
@@ -28,6 +28,14 @@ static int array_realloc(struct array *array, size_t new_total)
 	return 0;
 }
 
+static void array_trim(struct array *array)
+{
+	if (array->count + array->step < array->total) {
+		/* ignore error */
+		array_realloc(array, array->total - array->step);
+	}
+}
+
 void array_init(struct array *array, size_t step)
 {
 	assert(step > 0);
@@ -70,11 +78,7 @@ void array_pop(struct array *array) {
 	if (array->count == 0)
 		return;
 	array->count--;
-	if (array->count + array->step < array->total) {
-		int r = array_realloc(array, array->total - array->step);
-		if (r < 0)
-			return;
-	}
+	array_trim(array);
 }
 
 void array_free_array(struct array *array) {
@@ -99,13 +103,7 @@ int array_remove_at(struct array *array, size_t pos)
 	if (pos < array->count)
 		memmove(array->array + pos, array->array + pos + 1,
 			sizeof(void *) * (array->count - pos));
-
-	if (array->count + array->step < array->total) {
-		int r = array_realloc(array, array->total - array->step);
-		/* ignore error */
-		if (r < 0)
-			return 0;
-	}
+	array_trim(array);
 
 	return 0;
 }

--- a/shared/array.c
+++ b/shared/array.c
@@ -78,7 +78,7 @@ void array_sort(struct array *array, int (*cmp)(const void *a, const void *b))
 	qsort(array->array, array->count, sizeof(void *), cmp);
 }
 
-int array_remove_at(struct array *array, unsigned int pos)
+int array_remove_at(struct array *array, size_t pos)
 {
 	if (array->count <= pos)
 		return -ENOENT;

--- a/shared/array.h
+++ b/shared/array.h
@@ -19,4 +19,4 @@ int array_append_unique(struct array *array, const void *element);
 void array_pop(struct array *array);
 void array_free_array(struct array *array);
 void array_sort(struct array *array, int (*cmp)(const void *a, const void *b));
-int array_remove_at(struct array *array, unsigned int pos);
+int array_remove_at(struct array *array, size_t pos);

--- a/testsuite/test-array.c
+++ b/testsuite/test-array.c
@@ -130,13 +130,16 @@ static int test_array_remove_at(const struct test *t)
 	assert_return(array.count == 2, EXIT_FAILURE);
 	assert_return(array.array[0] == c1, EXIT_FAILURE);
 	assert_return(array.array[1] == c2, EXIT_FAILURE);
+	assert_return(array.total == 4, EXIT_FAILURE);
 
 	array_remove_at(&array, 0);
 	assert_return(array.count == 1, EXIT_FAILURE);
 	assert_return(array.array[0] == c2, EXIT_FAILURE);
+	assert_return(array.total == 2, EXIT_FAILURE);
 
 	array_remove_at(&array, 0);
 	assert_return(array.count == 0, EXIT_FAILURE);
+	assert_return(array.total == 2, EXIT_FAILURE);
 
 	array_append(&array, c1);
 	array_append(&array, c2);
@@ -146,6 +149,7 @@ static int test_array_remove_at(const struct test *t)
 	assert_return(array.count == 2, EXIT_FAILURE);
 	assert_return(array.array[0] == c1, EXIT_FAILURE);
 	assert_return(array.array[1] == c3, EXIT_FAILURE);
+	assert_return(array.total == 4, EXIT_FAILURE);
 
 	array_free_array(&array);
 
@@ -174,6 +178,10 @@ static int test_array_pop(const struct test *t)
 	assert_return(array.array[1] == c2, EXIT_FAILURE);
 
 	array_pop(&array);
+	array_pop(&array);
+
+	assert_return(array.count == 0, EXIT_FAILURE);
+
 	array_pop(&array);
 
 	assert_return(array.count == 0, EXIT_FAILURE);


### PR DESCRIPTION
It takes either very small amount of available heap or huge files for these issues to be triggered. Nevertheless, depmod should not silently ignore array handling issues, but print error messages for easier diagnosis.

While at it, I extended test suite and hardened array handling code against popping an empty array.