### PR TITLE
depmod: Fix out of boundary write with long paths

### DIFF
--- a/tools/depmod.c
+++ b/tools/depmod.c
@@ -2855,7 +2855,7 @@ static int depfile_up_to_date_dir(DIR *d, time_t mtime, size_t baselen, char *pa
 /* uptodate: 1, outdated: 0, errors < 0 */
 static int depfile_up_to_date(const char *dirname)
 {
-	char path[PATH_MAX];
+	char path[PATH_MAX + 1];
 	DIR *d = opendir(dirname);
 	struct stat st;
 	size_t baselen;


### PR DESCRIPTION
If a root path is specified which is PATH_MAX - 1 characters long and option -A is specified, then depfile_up_to_date_dir triggers an out of boundary write during slash addition.

Proof of Concept:

1. Compile kmod with address sanitizer (-fsanitize=address)

2. Prepare a successful modules.dep check
```
$ touch /tmp/modules.dep
```

3. Run depmod with PATH_MAX long root directory
```
$ depmod -A -b $(python -c 'print(4092*"/"+"tmp")')
```

Output is:
```
tools/depmod.c:2880:6: runtime error: index 4096 out of bounds for type 'char [4096]'
tools/depmod.c:2880:16: runtime error: store to address 0x77113210a100 with insufficient space for an object of type 'char'
=================================================================
==46129==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x77113210a100 at pc 0x6008892ee5b5 bp 0x7ffe648cd450 sp 0x7ffe648cd440
WRITE of size 1 at 0x77113210a100 thread T0
```