### PR TITLE
tools: Check snprintf return value

### DIFF
--- a/tools/modinfo.c
+++ b/tools/modinfo.c
@@ -441,6 +441,7 @@ static int do_modinfo(int argc, char *argv[])
 
 	if (root != NULL || kversion != NULL) {
 		struct utsname u;
+		int n;
 		if (root == NULL)
 			root = "";
 		if (kversion == NULL) {
@@ -450,8 +451,14 @@ static int do_modinfo(int argc, char *argv[])
 			}
 			kversion = u.release;
 		}
-		snprintf(dirname_buf, sizeof(dirname_buf), "%s" MODULE_DIRECTORY "/%s",
-			 root, kversion);
+
+		n = snprintf(dirname_buf, sizeof(dirname_buf),
+		             "%s" MODULE_DIRECTORY "/%s", root, kversion);
+		if (n >= (int)sizeof(dirname_buf)) {
+			ERR("bad directory %s" MODULE_DIRECTORY
+			    "/%s: path too long\n", root, kversion);
+			return EXIT_FAILURE;
+		}
 		dirname = dirname_buf;
 	}
 

--- a/tools/modprobe.c
+++ b/tools/modprobe.c
@@ -977,6 +977,7 @@ static int do_modprobe(int argc, char **orig_argv)
 
 	if (root != NULL || kversion != NULL) {
 		struct utsname u;
+		int n;
 		if (root == NULL)
 			root = "";
 		if (kversion == NULL) {
@@ -987,9 +988,14 @@ static int do_modprobe(int argc, char **orig_argv)
 			}
 			kversion = u.release;
 		}
-		snprintf(dirname_buf, sizeof(dirname_buf),
-				"%s" MODULE_DIRECTORY "/%s", root,
-				kversion);
+		n = snprintf(dirname_buf, sizeof(dirname_buf),
+		             "%s" MODULE_DIRECTORY "/%s", root, kversion);
+		if (n >= (int)sizeof(dirname_buf)) {
+			ERR("bad directory %s" MODULE_DIRECTORY
+			    "/%s: path too long\n", root, kversion);
+			err = -1;
+			goto done;
+		}
 		dirname = dirname_buf;
 	}
 

--- a/tools/static-nodes.c
+++ b/tools/static-nodes.c
@@ -200,7 +200,13 @@ static int do_static_nodes(int argc, char *argv[])
 		goto finish;
 	}
 
-	snprintf(modules, sizeof(modules), MODULE_DIRECTORY "/%s/modules.devname", kernel.release);
+	r = snprintf(modules, sizeof(modules), MODULE_DIRECTORY "/%s/modules.devname", kernel.release);
+	if (r >= (int)sizeof(modules)) {
+		fprintf(stderr, "Error: could not open " MODULE_DIRECTORY "/%s/modules.devname - path too long\n",
+			kernel.release);
+		ret = EXIT_FAILURE;
+		goto finish;
+	}
 	in = fopen(modules, "re");
 	if (in == NULL) {
 		if (errno == ENOENT) {


### PR DESCRIPTION
If an excessively large root directory is supplied, subsequent operations might process unexpected parts in file system.

Inform user that supplied directory paths are too long and stop program execution.

Proof of Concept:

```
$ BDIR=$(python -c 'print(4096*"/")')
$ depmod -b $BDIR
$ modinfo -b $BDIR ext4
$ modprobe -d $BDIR ext4
```