### PR TITLE
depmod: Improve P argument check

### DIFF
--- a/tools/depmod.c
+++ b/tools/depmod.c
@@ -2960,7 +2960,7 @@ static int do_depmod(int argc, char *argv[])
 			out = stdout;
 			break;
 		case 'P':
-			if (optarg[1] != '\0') {
+			if (strlen(optarg) != 1) {
 				CRIT("-P only takes a single char\n");
 				goto cmdline_failed;
 			}


### PR DESCRIPTION
The command line option P takes one argument, which is supposed to contain exactly one character. The current check performs an out of boundary read if an empty string is supplied.

Proof of Concept:

1. Create poc.c

```c
#include <err.h>
#include <unistd.h>

int main(void) {
  char *argv[] = { "depmod", "-P", "", NULL };
  char *envp[] = { "", NULL };
  if (execvpe("depmod", argv, envp) != 0)
    err(1, "execvpe");
  return 0;
}
```

2. Compile poc

```
gcc -D_GNU_SOURCE -o poc poc.c
```

3. Run poc

```
./poc
```

No error message is shown, because the check passes successfully
due to an empty string in environment.