### PR TITLE
Codespell fixes, CI action and couple of action updates

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -1,0 +1,2 @@
+caf
+parm

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+# To use this config on you editor, follow the instructions at:
+# http://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+tab_width = 8
+
+[*.{c,h}]
+indent_style = tab
+max_line_length = 80
+
+[{Makefile*,*.mk}]
+indent_style = tab
+
+[*.yml]
+indent_style = space
+indent_size = 2
+
+[*.patch]
+trim_trailing_whitespace = false
+
+[{meson.build,meson_options.txt}]
+indent_style = space
+indent_size = 2

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+    groups:
+      all-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,16 @@
+name: Check spelling with codespell
+
+on:
+  push:
+    branches: [master, ci-test]
+  pull_request:
+    branches: [master]
+
+jobs:
+  spellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: codespell-project/actions-codespell@v2
+        with:
+          ignore_words_file: .codespellignore

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -10,7 +10,7 @@ jobs:
   spellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: codespell-project/actions-codespell@v2
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: codespell-project/actions-codespell@94259cd8be02ad2903ba34a22d9c13de21a74461 # v2.0
         with:
           ignore_words_file: .codespellignore

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   spellcheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
       image: ${{ matrix.container }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - uses: ./.github/actions/setup-ubuntu
         if: ${{ startsWith(matrix.container, 'ubuntu') }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,8 @@ on:
     branches: [master, ci-test]
   pull_request:
     branches: [master]
+  schedule:
+    - cron: "30 2 * * 0"
 
 permissions:
   contents: read

--- a/NEWS
+++ b/NEWS
@@ -91,7 +91,7 @@ kmod 32
 	  to update the mapping
 
 	- Teach kmod to load modprobe.d/depmod.d configuration from ${prefix}/lib
-	  and allow it to be overriden during build with --with-distconfdir=DIR
+	  and allow it to be overridden during build with --with-distconfdir=DIR
 
 	- Make kernel modules directory configurable. This allows distro to
 	  make kmod use only files from /usr regardless of having a compat
@@ -147,7 +147,7 @@ kmod 31
 	- Make modprobe fallback to syslog when stderr is not available, as was
 	  documented in the man page, but not implemented
 
-	- Better explaing `modprobe -r` and how it differentiates from rmmod
+	- Better explaining `modprobe -r` and how it differentiates from rmmod
 
 	- depmod learned a `-o <dir>` option to allow using a separate output
 	  directory. With this, it's possible to split the output files from
@@ -200,7 +200,7 @@ kmod 30
 	  module name, without considering the aliases. Other than that search
 	  order is similar to kmod_module_new_from_lookup().
 
-	- modinfo learned the --modname option to explicitely show information
+	- modinfo learned the --modname option to explicitly show information
 	  about the module, even if there is an alias with the same name. This
 	  allows showing information about e.g. kernel/lib/crc32.ko, even if
 	  kernel also exports a crc32 alias in modules.alias:
@@ -225,7 +225,7 @@ kmod 30
 	  The wait behavior provided by the kernel when not passing O_NONBLOCK
 	  to delete_module() was removed in v3.13 due to not be used and the
 	  consequences of having to support it in the kernel. However there may
-	  be some users, particularly on testsuites for individual susbsystems, that
+	  be some users, particularly on testsuites for individual subsystems, that
 	  would want that. So provide a userspace implementation inside modprobe for
 	  such users. "rmmod" doesn't have a --wait as it remains a bare minimal over
 	  the API provided by the kernel. In future the --wait behavior can be added
@@ -415,7 +415,7 @@ kmod 26
 		  sig_key:        51:C4:0C:6D:7E:A5:6C:D8:8F:B4:3A:DF:91:78:4F:18:BC:D5:E4:C5
 		  sig_hashalgo:   sha256
 
-	  If kmod is not linked to openssl we just start printing "unknonwn" in the
+	  If kmod is not linked to openssl we just start printing "unknown" in the
 	  sig_hashalgo field rather than the bogus value.
 
 
@@ -493,7 +493,7 @@ kmod 22
 =======
 
 - Tools:
-	- Change defaul log level for tools to WARNING rather than ERROR and update
+	- Change default log level for tools to WARNING rather than ERROR and update
 	  some log levels for current messages
 
 	- depmod doesn't fallback to uname if a bad version is passed in the command
@@ -958,7 +958,7 @@ matched more than one module.
   The only missing things are the options '--showconfig' and '-t / -l'. These
   last ones have been deprecated long ago and they will be removed from
   modprobe. A lot of effort has been put on kmod-modprobe to ensure it
-  maintains compabitility with modprobe.
+  maintains compatibility with modprobe.
 
 - linux-modules@vger.kernel.org became the official mailing list for kmod
 

--- a/libkmod/libkmod-module.c
+++ b/libkmod/libkmod-module.c
@@ -857,7 +857,7 @@ static int do_finit_module(struct kmod_module *mod, unsigned int flags,
 	/*
 	 * When module is not compressed or its compression type matches the
 	 * one in use by the kernel, there is no need to read the file
-	 * in userspace. Otherwise, re-use ENOSYS to trigger the same fallback
+	 * in userspace. Otherwise, reuse ENOSYS to trigger the same fallback
 	 * as when finit_module() is not supported.
 	 */
 	compression = kmod_file_get_compression(mod->file);

--- a/libkmod/libkmod.c
+++ b/libkmod/libkmod.c
@@ -457,7 +457,7 @@ static int kmod_lookup_alias_from_alias_bin(struct kmod_ctx *ctx,
 	struct index_value *realnames, *realname;
 
 	if (ctx->indexes[index_number] != NULL) {
-		DBG(ctx, "use mmaped index '%s' for name=%s\n",
+		DBG(ctx, "use mmapped index '%s' for name=%s\n",
 			index_files[index_number].fn, name);
 		realnames = index_mm_searchwild(ctx->indexes[index_number],
 									name);
@@ -523,7 +523,7 @@ static char *lookup_builtin_file(struct kmod_ctx *ctx, const char *name)
 	char *line;
 
 	if (ctx->indexes[KMOD_INDEX_MODULES_BUILTIN]) {
-		DBG(ctx, "use mmaped index '%s' modname=%s\n",
+		DBG(ctx, "use mmapped index '%s' modname=%s\n",
 				index_files[KMOD_INDEX_MODULES_BUILTIN].fn,
 				name);
 		line = index_mm_search(ctx->indexes[KMOD_INDEX_MODULES_BUILTIN],
@@ -618,7 +618,7 @@ char *kmod_search_moddep(struct kmod_ctx *ctx, const char *name)
 	char *line;
 
 	if (ctx->indexes[KMOD_INDEX_MODULES_DEP]) {
-		DBG(ctx, "use mmaped index '%s' modname=%s\n",
+		DBG(ctx, "use mmapped index '%s' modname=%s\n",
 				index_files[KMOD_INDEX_MODULES_DEP].fn, name);
 		return index_mm_search(ctx->indexes[KMOD_INDEX_MODULES_DEP],
 									name);
@@ -874,7 +874,7 @@ KMOD_EXPORT int kmod_validate_resources(struct kmod_ctx *ctx)
  *
  * If user will do more than one or two lookups, insertions, deletions, most
  * likely it's good to call this function first. Particularly in a daemon like
- * udev that on bootup issues hundreds of calls to lookup the index, calling
+ * udev that on boot issues hundreds of calls to lookup the index, calling
  * this function will speedup the searches.
  *
  * Returns: 0 on success or < 0 otherwise.
@@ -977,7 +977,7 @@ KMOD_EXPORT int kmod_dump_index(struct kmod_ctx *ctx, enum kmod_index type,
 		return -ENOENT;
 
 	if (ctx->indexes[type] != NULL) {
-		DBG(ctx, "use mmaped index '%s'\n", index_files[type].fn);
+		DBG(ctx, "use mmapped index '%s'\n", index_files[type].fn);
 		index_mm_dump(ctx->indexes[type], fd,
 						index_files[type].prefix);
 	} else {

--- a/tools/depmod.c
+++ b/tools/depmod.c
@@ -2865,7 +2865,7 @@ static int depfile_up_to_date_dir(DIR *d, time_t mtime, size_t baselen, char *pa
 	return err;
 }
 
-/* uptodate: 1, outdated: 0, errors < 0 */
+/* up-to-date: 1, outdated: 0, errors < 0 */
 static int depfile_up_to_date(const char *dirname)
 {
 	char path[PATH_MAX + 1];


### PR DESCRIPTION
This builds up on the previous codespell typo fixes by addressing the remaining ones - note the github action flagged a few more, that a local run did not.

Then we add codespell CI action, alongside a `.editorconfig` so the former is properly formatted. Followed by dependabot.yml to ensure the actions are up-to date (NOTE: repo config is needed, see inline comment), apply some security tweaks (use hashes for actions, restrict permissions) and finally we enable schedule-based runs.

Technically this could be split in multiple PRs - 3 or so - although it  seemed like an overkill, considering how tiny things are. That said, if it makes things clearer, I don't mind splitting.