### PR TITLE
Verify absolute path creation

### DIFF
--- a/libkmod/libkmod.c
+++ b/libkmod/libkmod.c
@@ -288,6 +288,10 @@ KMOD_EXPORT struct kmod_ctx *kmod_new(const char *dirname,
 	ctx->log_priority = LOG_ERR;
 
 	ctx->dirname = get_kernel_release(dirname);
+	if (ctx->dirname == NULL) {
+		ERR(ctx, "could not retrieve directory\n");
+		goto fail;
+	}
 
 	/* environment overwrites config */
 	env = secure_getenv("KMOD_LOG");

--- a/tools/depmod.c
+++ b/tools/depmod.c
@@ -2937,11 +2937,19 @@ static int do_depmod(int argc, char *argv[])
 			if (root)
 				free(root);
 			root = path_make_absolute_cwd(optarg);
+			if (root == NULL) {
+				ERR("invalid image path %s\n", optarg);
+				goto cmdline_failed;
+			}
 			break;
 		case 'o':
 			if (out_root)
 				free(out_root);
 			out_root = path_make_absolute_cwd(optarg);
+			if (out_root == NULL) {
+				ERR("invalid output directory %s\n", optarg);
+				goto cmdline_failed;
+			}
 			break;
 		case 'C': {
 			size_t bytes = sizeof(char *) * (n_config_paths + 2);

--- a/tools/depmod.c
+++ b/tools/depmod.c
@@ -2934,8 +2934,7 @@ static int do_depmod(int argc, char *argv[])
 			maybe_all = 1;
 			break;
 		case 'b':
-			if (root)
-				free(root);
+			free(root);
 			root = path_make_absolute_cwd(optarg);
 			if (root == NULL) {
 				ERR("invalid image path %s\n", optarg);
@@ -2943,8 +2942,7 @@ static int do_depmod(int argc, char *argv[])
 			}
 			break;
 		case 'o':
-			if (out_root)
-				free(out_root);
+			free(out_root);
 			out_root = path_make_absolute_cwd(optarg);
 			if (out_root == NULL) {
 				ERR("invalid output directory %s\n", optarg);


### PR DESCRIPTION
If a relative path is supplied, the conversion to an absolute path can fail, e.g. if current working directory does not exist anymore.

Proof of Concept:

```
MYPATH=$(mktemp -d)
cd $MYPATH
rmdir $MYPATH
depmod -b relative
```

The depmod command actually processes system files, because turning `relative` into an absolute path failed and returned `NULL`. `NULL` in turn is interpreted as default, i.e. to use default paths.