### PR TITLE
shared: use proper data types in freadline_wrapped

### DIFF
--- a/shared/util.c
+++ b/shared/util.c
@@ -285,8 +285,8 @@ int read_str_ulong(int fd, unsigned long *value, int base)
  */
 char *freadline_wrapped(FILE *fp, unsigned int *linenum)
 {
-	int size = 256;
-	int i = 0, n = 0;
+	size_t i = 0, size = 256;
+	unsigned int n = 0;
 	_cleanup_free_ char *buf = malloc(size);
 
 	if (buf == NULL)


### PR DESCRIPTION
Do not use signed data types if unsigned arithmetic is expected, i.e. use size_t if processing sizes and unsigned int for line numbers due to given API of freadline_wrapped.

This fixes a possible signed integer overflow on 64 bit systems.

Proof of Concept:

1. Create a file with a line longer than 2 GB
`dd if=/dev/zero bs=1024 count=2097153 | tr '\0' 'a' > /lib/modules/$(uname -r)/modules.weakdep`

2. Run lsmod compiled with -fsanitize=undefined
`lsmod`

You will get an error like:
`shared/util.c:330:10: runtime error: signed integer overflow: 1073741824 * 2 cannot be represented in type 'int'`

