### PR TITLE
libkmod: Fix memory leak on error path

### DIFF
--- a/libkmod/libkmod-builtin.c
+++ b/libkmod/libkmod-builtin.c
@@ -127,13 +127,18 @@ static off_t get_string(struct kmod_builtin_iter *iter, off_t offset,
 		offset += (off_t) partsz;
 
 		if (iter->bufsz < linesz + partsz) {
-			iter->bufsz = linesz + partsz;
-			iter->buf = realloc(iter->buf, iter->bufsz);
+			void *tmp;
+			size_t s;
 
-			if (!iter->buf) {
+			s = linesz + partsz;
+			tmp = realloc(iter->buf, s);
+
+			if (!tmp) {
 				sv_errno = errno;
 				goto fail;
 			}
+			iter->bufsz = s;
+			iter->buf = tmp;
 		}
 
 		strncpy(iter->buf + linesz, buf, partsz);


### PR DESCRIPTION
If realloc fails, do not override the still valid pointer with NULL. Otherwise freeing the iterator won't free the previously allocated buffer.