### PR TITLE
libkmod: Properly treat erroneous modules.builtin.modinfo files

### DIFF
--- a/libkmod/libkmod-builtin.c
+++ b/libkmod/libkmod-builtin.c
@@ -210,8 +210,10 @@ static bool kmod_builtin_iter_get_modname(struct kmod_builtin_iter *iter,
 	size_t linesz, len;
 	off_t offset;
 
-	if (iter->pos == iter->size)
-		return false;
+	if (iter->pos == iter->size) {
+		sv_errno = EINVAL;
+		goto fail;
+	}
 
 	line = NULL;
 
@@ -225,7 +227,7 @@ static bool kmod_builtin_iter_get_modname(struct kmod_builtin_iter *iter,
 
 	dot = strchr(line, '.');
 	if (!dot) {
-		sv_errno = errno;
+		sv_errno = EINVAL;
 		ERR(iter->ctx, "kmod_builtin_iter_get_modname: unexpected string without modname prefix\n");
 		goto fail;
 	}

--- a/libkmod/libkmod-builtin.c
+++ b/libkmod/libkmod-builtin.c
@@ -141,6 +141,10 @@ static off_t get_string(struct kmod_builtin_iter *iter, off_t offset,
 	}
 
 	if (linesz) {
+		if (iter->buf[linesz - 1] != '\0') {
+			sv_errno = EINVAL;
+			goto fail;
+		}
 		*line = iter->buf;
 		*size = linesz;
 	}


### PR DESCRIPTION
The file modules.builtin.modinfo is supposed to consist of NUL terminated strings. If the file contains a string which is not properly NUL terminated, treat it as error. Also make sure that errors never end up with errno being 0. These code paths negate the errno value to get a negative value to propagate the fact that an error occurred. -0 would be 0 again so errors are not detected.

Proof of Concept:

1. Create a copy of module files of currently running system
```
IMGDIR=$(mktemp -d)
KDIR=/lib/modules/$(uname -r)
mkdir -p $IMGDIR/$KDIR
cp $KDIR/modules.* $IMGDIR/$KDIR
```

2. Create a modules.builtin.modinfo file without terminating NUL
```
dd if=/dev/zero bs=8192 count=1 | tr '\0' 'A' > $IMGDIR/$KDIR/modules.builtin.modinfo
```

3. Run modinfo for an existing built-in module (rapl in my case)
```
modinfo -b $IMGDIR rapl
```

The modinfo process crashes due to an invalid free later in codepath. To be precise here due to this line:
https://github.com/kmod-project/kmod/blob/9fc3aa152950dc0cbb2d8705d732089634a3795f/libkmod/libkmod-module.c#L2523
The `strings` variable is not initialized to NULL, which is okay because a negative return value of `kmod_builtin_get_modinfo` is supposed to indicate an error in which case `strings` is never set. But due to missing `errno` assignment, the return value is 0, implying that everything is okay.