### PR TITLE
Revamp the docs, build with meson and in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,7 @@ jobs:
           - name: 'archlinux:base-devel'
           - name: 'fedora:latest'
           - name: 'alpine:latest'
+            meson_setup: '-D docs=false'
           - name: 'debian:unstable'
 
     container:
@@ -69,7 +70,7 @@ jobs:
 
       - name: configure (meson)
         if: ${{ matrix.build == 'meson' }}
-        run: mkdir build && cd build && meson setup --native-file ../build-dev.ini -D build-tests=true . ..
+        run: mkdir build && cd build && meson setup --native-file ../build-dev.ini -D build-tests=true ${{ matrix.container.meson_setup }} . ..
 
       - name: configure (autotools)
         if: ${{ matrix.build == 'autotools' }}

--- a/Makefile.am
+++ b/Makefile.am
@@ -17,6 +17,7 @@ export GCC_COLORS
 
 # meson bits
 EXTRA_DIST += \
+	libkmod/docs/meson.build \
 	man/meson.build \
 	meson.build \
 	meson_options.txt \

--- a/Makefile.am
+++ b/Makefile.am
@@ -23,6 +23,7 @@ EXTRA_DIST += \
 	meson_options.txt \
 	testsuite/meson.build \
 	scripts/build-scdoc.sh \
+	scripts/check-gtkdoc.sh \
 	scripts/kmod-symlink.sh
 
 AM_CPPFLAGS = \

--- a/autogen.sh
+++ b/autogen.sh
@@ -27,6 +27,7 @@ cd $oldpwd
 
 hackargs="\
 --enable-debug \
+--enable-gtk-doc \
 --with-zstd \
 --with-xz \
 --with-zlib \

--- a/build-dev.ini
+++ b/build-dev.ini
@@ -1,5 +1,6 @@
 [project options]
 debug-messages = true
+docs = true
 zstd = 'enabled'
 xz = 'enabled'
 zlib = 'enabled'

--- a/libkmod/docs/meson.build
+++ b/libkmod/docs/meson.build
@@ -1,0 +1,22 @@
+gnome = import('gnome')
+
+version_file = configure_file(
+  input: 'version.xml.in',
+  output: 'version.xml',
+  configuration: cdata,
+)
+
+gnome.gtkdoc(
+  'libkmod',
+  content_files : version_file,
+  ignore_headers : [
+    '@0@/libkmod/libkmod-index.h'.format(meson.project_source_root()),
+    '@0@/libkmod/libkmod-internal-file.h'.format(meson.project_source_root()),
+    '@0@/libkmod/libkmod-internal.h'.format(meson.project_source_root()),
+  ],
+  scan_args : '--ignore-decorators="KMOD_EXPORT"',
+  src_dir : '@0@/libkmod/'.format(meson.project_source_root()),
+  namespace : 'kmod',
+  module_version : '3',
+  main_xml : 'libkmod-docs.xml',
+)

--- a/libkmod/docs/meson.build
+++ b/libkmod/docs/meson.build
@@ -6,7 +6,7 @@ version_file = configure_file(
   configuration: cdata,
 )
 
-gnome.gtkdoc(
+built_docs = gnome.gtkdoc(
   'libkmod',
   content_files : version_file,
   ignore_headers : [
@@ -19,4 +19,11 @@ gnome.gtkdoc(
   namespace : 'kmod',
   module_version : '3',
   main_xml : 'libkmod-docs.xml',
+)
+
+test(
+  'test-gtkdoc',
+  check_gtkdoc,
+  args : meson.current_build_dir(),
+  depends : built_docs,
 )

--- a/meson.build
+++ b/meson.build
@@ -423,6 +423,7 @@ if get_option('manpages')
 endif
 
 if get_option('docs')
+  check_gtkdoc = find_program('scripts/check-gtkdoc.sh')
   subdir('libkmod/docs')
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -433,11 +433,11 @@ summary({
 }, section : 'Directories')
 
 summary({
-  'tools'       : get_option('tools'),
-  'logging'     : get_option('logging'),
-  'debug'       : get_option('debug-messages'),
-  'build-tests' : get_option('build-tests'),
-  'man'         : get_option('manpages'),
+  'tools'           : get_option('tools'),
+  'logging'         : get_option('logging'),
+  'debug-messages'  : get_option('debug-messages'),
+  'build-tests'     : get_option('build-tests'),
+  'manpages'        : get_option('manpages'),
 }, section : 'Options')
 
 summary({

--- a/meson.build
+++ b/meson.build
@@ -422,6 +422,10 @@ if get_option('manpages')
   subdir('man')
 endif
 
+if get_option('docs')
+  subdir('libkmod/docs')
+endif
+
 summary({
   'moduledir'   : moduledir,
   'prefix'      : get_option('prefix'),
@@ -438,6 +442,7 @@ summary({
   'debug-messages'  : get_option('debug-messages'),
   'build-tests'     : get_option('build-tests'),
   'manpages'        : get_option('manpages'),
+  'docs'            : get_option('docs'),
 }, section : 'Options')
 
 summary({

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -85,3 +85,10 @@ option(
   value : true,
   description : 'Build the manpages. Default: true',
 )
+
+option(
+  'docs',
+  type : 'boolean',
+  value : false,
+  description : 'Build the documentation. Default: false',
+)

--- a/scripts/check-gtkdoc.sh
+++ b/scripts/check-gtkdoc.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -euo pipefail
+
+err=0
+
+warn() {
+    (( ++err ))
+    echo
+    echo "WARNING: $1."
+    echo "See file below for more details."
+    echo
+    echo "$2:"
+    cat "$2"
+    echo
+}
+
+cd "$1"
+
+grep -q '100%' 'libkmod-undocumented.txt' || warn 'Some APIs are missing documentation' 'libkmod-undocumented.txt'
+
+(( $(wc -l < 'libkmod-unused.txt') == 0)) || warn 'APIs are missing from the libkmod-section.txt index' 'libkmod-unused.txt'
+
+exit "$err"


### PR DESCRIPTION
The series build on the previous [add meson build](https://github.com/kmod-project/kmod/pull/86) and goes a step further.

Overall we have:
 - the (gtk-)doc decorations are moved the the public header (9k -> 44K), so they're available w/o the html (280K) 
AFAICT only Debian builds the html docs (thank you), so this will benefit the wider ecosystem.

 - some old/invalid options are removed from the autotools build

 - everything is documented... apart from the XXX commits

 - handful of polish consistency/grammar commits applied

 - meson build is added

 - building is enabled in hackargs and thus CI

If we can get the final pieces documented, I can add simple `meson test` which complains when new entries are added without a doc.