### PR TITLE
libkmod: Improve signature parser on 32 bit archs

### DIFF
--- a/libkmod/libkmod-signature.c
+++ b/libkmod/libkmod-signature.c
@@ -326,7 +326,7 @@ bool kmod_module_signature_info(const struct kmod_file *file, struct kmod_signat
 		return false;
 	sig_len = be32toh(get_unaligned(&modsig->sig_len));
 	if (sig_len == 0 ||
-	    size < (int64_t)(modsig->signer_len + modsig->key_id_len + sig_len))
+	    size < (int64_t)sig_len + modsig->signer_len + modsig->key_id_len)
 		return false;
 
 	switch (modsig->id_type) {


### PR DESCRIPTION
During signature parser validation it is not enough to cast the end result to 64 bit, because on 32 bit systems size_t is an unsigned 32 bit integer, which implies that this will be the data type used to evaluate the expression BEFORE casting it due to C standard.

Since the unsigned 32 bit calculation can overflow, cast the size_t to int64_t, which makes the whole calculation safe.

This has no negative impact on 64 bit systems because the size_t value is read as an unsigned 32 bit value from module.

Proof of Concept:

1. Compile kmod with address sanitizer (32 bit)

2. Get an uncompressed module (I've tested on Debian 12 i686)

```
cp /lib/modules/6.1.0-23-686-pae/kernel/arch/x86/crypto/aesni-intel.ko poc.ko
```

3. Prepare signature which overflows checks on 32 bit systems

```
echo 'Af//AAAA////AH5Nb2R1bGUgc2lnbmF0dXJlIGFwcGVuZGVkfgo=' > sig.b64
base64 -d sig.b64 > sig.raw
```

4. Put signature at end of next 4096 aligned address after end of file so ASAN will definitely crash

```
OFFSET=$(expr $(ls -ls poc.ko | awk '{ print $1 }') '*' 1024 - 38)
dd if=sig.raw of=poc.ko bs=1 seek=$OFFSET conv=notrunc
```

5. Run modinfo

```
modinfo ./poc.ko
```