### PR TITLE
libkmod: Improve st_size checks on 32 bit systems

### DIFF
--- a/libkmod/libkmod-builtin.c
+++ b/libkmod/libkmod-builtin.c
@@ -7,6 +7,7 @@
 #include <sys/stat.h>
 
 #include <unistd.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -66,6 +67,11 @@ static struct kmod_builtin_iter *kmod_builtin_iter_new(struct kmod_ctx *ctx)
 
 	if (fstat(file, &sb) < 0) {
 		sv_errno = errno;
+		goto fail;
+	}
+
+	if (sb.st_size > INTPTR_MAX) {
+		sv_errno = ENOMEM;
 		goto fail;
 	}
 

--- a/libkmod/libkmod-file.c
+++ b/libkmod/libkmod-file.c
@@ -4,6 +4,7 @@
  */
 
 #include <errno.h>
+#include <limits.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -31,6 +32,9 @@ static int load_reg(struct kmod_file *file)
 		return -errno;
 
 	file->size = st.st_size;
+	if ((uintmax_t)file->size > SIZE_MAX)
+		return -ENOMEM;
+
 	file->memory = mmap(NULL, file->size, PROT_READ, MAP_PRIVATE,
 			    file->fd, 0);
 	if (file->memory == MAP_FAILED) {

--- a/libkmod/libkmod-index.c
+++ b/libkmod/libkmod-index.c
@@ -8,6 +8,7 @@
 #include <errno.h>
 #include <fnmatch.h>
 #include <inttypes.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -754,15 +755,20 @@ int index_mm_open(const struct kmod_ctx *ctx, const char *filename,
 		goto fail_open;
 	}
 
-	if (fstat(fd, &st) < 0 || (size_t) st.st_size < sizeof(hdr)) {
+	if (fstat(fd, &st) < 0 || st.st_size < (off_t) sizeof(hdr)) {
 		err = -EINVAL;
+		goto fail_nommap;
+	}
+
+	if ((uintmax_t)st.st_size > SIZE_MAX) {
+		err = -ENOMEM;
 		goto fail_nommap;
 	}
 
 	idx->mm = mmap(NULL, st.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
 	if (idx->mm == MAP_FAILED) {
-		ERR(ctx, "mmap(NULL, %"PRIu64", PROT_READ, %d, MAP_PRIVATE, 0): %m\n",
-							st.st_size, fd);
+		ERR(ctx, "mmap(NULL, %"PRIu64", PROT_READ, MAP_PRIVATE, %d, 0): %m\n",
+							(uint64_t) st.st_size, fd);
 		err = -errno;
 		goto fail_nommap;
 	}


### PR DESCRIPTION
Since off_t can (and most likely will) be 64 bit on 32 bit systems, check its actual value before casting it to 32 bit size_t.