### PR TITLE
testsuite/path: keep 64 variants for _GLIBC_

### DIFF
--- a/.github/actions/setup-alpine/action.yml
+++ b/.github/actions/setup-alpine/action.yml
@@ -19,6 +19,7 @@ runs:
           meson \
           openssl-dev \
           scdoc \
+          tar \
           xz-dev \
           zlib-dev \
           zstd-dev

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,17 +19,11 @@ jobs:
         build: ['meson', 'autotools']
         container:
           - name: 'ubuntu:22.04'
-            test: 'true'
           - name: 'ubuntu:24.04'
-            test: 'true'
           - name: 'archlinux:base-devel'
-            test: 'true'
           - name: 'fedora:latest'
-            test: 'true'
           - name: 'alpine:latest'
-            test: 'false'
           - name: 'debian:unstable'
-            test: 'true'
 
     container:
       image: ${{ matrix.container.name }}
@@ -75,7 +69,7 @@ jobs:
 
       - name: configure (meson)
         if: ${{ matrix.build == 'meson' }}
-        run: mkdir build && cd build && meson setup --native-file ../build-dev.ini -D build-tests=${{ matrix.container.test }} . ..
+        run: mkdir build && cd build && meson setup --native-file ../build-dev.ini -D build-tests=true . ..
 
       - name: configure (autotools)
         if: ${{ matrix.build == 'autotools' }}
@@ -90,11 +84,11 @@ jobs:
         run: cd build && make -j$(nproc)
 
       - name: test (meson)
-        if: ${{ matrix.test == 'true' && matrix.build == 'meson' }}
+        if: ${{ matrix.build == 'meson' }}
         run: cd build && meson test
 
       - name: test (autotools)
-        if: ${{ matrix.test == 'true' && matrix.build == 'autotools' }}
+        if: ${{ matrix.build == 'autotools' }}
         run: cd build && make -j$(nproc) check
 
       - name: install (meson)
@@ -106,9 +100,9 @@ jobs:
         run: cd build && DESTDIR=$PWD/inst make install
 
       - name: distcheck (meson)
-        if: ${{ matrix.test == 'true' && matrix.build == 'meson' }}
+        if: ${{ matrix.build == 'meson' }}
         run: cd build && meson dist
 
       - name: distcheck (autotools)
-        if: ${{ matrix.test == 'true' && matrix.build == 'autotools' }}
+        if: ${{ matrix.build == 'autotools' }}
         run: cd build && make distcheck

--- a/configure.ac
+++ b/configure.ac
@@ -47,6 +47,10 @@ CC_CHECK_FUNC_BUILTIN([__builtin_types_compatible_p])
 CC_CHECK_FUNC_BUILTIN([__builtin_uaddl_overflow], [ ], [ ])
 CC_CHECK_FUNC_BUILTIN([__builtin_uaddll_overflow], [ ], [ ])
 
+# Non glibc compilers (musl and newer versions of bionic) do not need
+# the 64 LFS API wrapping.
+AC_CHECK_DECLS_ONCE([[__GLIBC__]], [], [], [[#include <features.h>]])
+
 # dietlibc doesn't have st.st_mtim struct member
 AC_CHECK_MEMBERS([struct stat.st_mtim], [], [], [#include <sys/stat.h>])
 

--- a/meson.build
+++ b/meson.build
@@ -61,6 +61,12 @@ foreach tuple : _builtins
   cdata.set10('HAVE_@0@'.format(builtin.to_upper()), have)
 endforeach
 
+# Check for __GLIBC__ as short-cut for the LFS64 wrappers
+glibc = cc.has_header_symbol('features.h', '__GLIBC__')
+# XXX: once meson only, rename the define to something more sensible ...
+# NEED_64_WRAPPERS perhaps?
+cdata.set10('HAVE_DECL___GLIBC__', glibc)
+
 # dietlibc doesn't have st.st_mtim struct member
 # XXX: we use both st_mtim and st_mtime ... unify and test
 foreach tuple : [['struct stat', 'st_mtim', '#include <sys/stat.h>']]

--- a/testsuite/path.c
+++ b/testsuite/path.c
@@ -184,11 +184,15 @@ WRAP_1ARG(DIR*, NULL, opendir);
 WRAP_1ARG(int, -1, chdir);
 
 WRAP_2ARGS(FILE*, NULL, fopen, const char*);
-WRAP_2ARGS(FILE*, NULL, fopen64, const char*);
 WRAP_2ARGS(int, -1, mkdir, mode_t);
 WRAP_2ARGS(int, -1, access, int);
 WRAP_2ARGS(int, -1, stat, struct stat*);
 WRAP_2ARGS(int, -1, lstat, struct stat*);
+
+WRAP_OPEN();
+
+#if HAVE_DECL___GLIBC__
+WRAP_2ARGS(FILE*, NULL, fopen64, const char*);
 WRAP_2ARGS(int, -1, stat64, struct stat64*);
 WRAP_2ARGS(int, -1, lstat64, struct stat64*);
 
@@ -199,11 +203,13 @@ WRAP_2ARGS(int, -1, __stat64_time64, struct __stat64_t64*);
 WRAP_2ARGS(int, -1, __lstat64_time64, struct __stat64_t64*);
 
 WRAP_OPEN(64);
-WRAP_OPEN();
+#endif
 
 #ifdef HAVE___XSTAT
 WRAP_VERSTAT(__x,);
 WRAP_VERSTAT(__lx,);
+#if HAVE_DECL___GLIBC__
 WRAP_VERSTAT(__x,64);
 WRAP_VERSTAT(__lx,64);
+#endif
 #endif


### PR DESCRIPTION
Since musl v1.2.4 and Alpine 3.18, circa May 2023, the LFS64 variants
are no longer exported by libc.so.

In addition musl headers provide relevant "#define foo64 foo" macros,
when _LARGEFILE64_SOURCE is defined and symbol resolution is deferred to
the runtime linker. See musl commit 246f1c811448 ("remove LFS64 symbol
aliases; replace with dynamic linker remapping") more details.

Earlier versions of musl had the symbols exposed by libc, although the
^^ macros were also available when _GNU_SOURCE is set, as our build
does.

Most importantly, we do not explicitly use the 64 variants and musl
doesn't implicitly pull them either. So in practise building with musl,
the binaries do not have any 64 references, thus there is no need to
wrap them.

AFAICT there is no obvious way of detecting musl, apart from the lack of
of __GLIBC__, so pull features.h (which defines it) and check on that.

There is a small chance the __GLIBC__ check will miss-fire on other
implementations like bionic, dietlibc or ulibc(-ng). We don't run the
tests on those platforms (although we could) so it should be fine.

With that we can install tar (for make distcheck) and enable the tests
in CI \o/

Closes: https://github.com/kmod-project/kmod/issues/65

---

Another alternative to `__GLIBC__` is to check each function individually, which means a lot more build system magic. Unless we decide to slim down the list a bit. At a glance, we don't use `lstat` so that can go? In addition the `__x` variants are defined in LSB as ABI yet it seems like glibc has stopped forwarding to them, as they dropped their declarations from the public headers.

Personally doing the cleanup && individual check sound like the better option. Although I don't have strong preferences.