### PR TITLE
shared: use size_t for strbuf

### DIFF
--- a/libkmod/libkmod-index.c
+++ b/libkmod/libkmod-index.c
@@ -352,7 +352,8 @@ static void index_dump_node(struct index_node_f *node, struct strbuf *buf,
 								int fd)
 {
 	struct index_value *v;
-	int ch, pushed;
+	size_t pushed;
+	int ch;
 
 	pushed = strbuf_pushchars(buf, node->prefix);
 
@@ -472,7 +473,7 @@ static void index_searchwild__all(struct index_node_f *node, int j,
 				  const char *subkey,
 				  struct index_value **out)
 {
-	int pushed = 0;
+	size_t pushed = 0;
 	int ch;
 
 	while (node->prefix[j]) {
@@ -831,7 +832,8 @@ static void index_mm_dump_node(struct index_mm_node *node, struct strbuf *buf,
 								int fd)
 {
 	struct index_mm_value *itr, *itr_end;
-	int ch, pushed;
+	size_t pushed;
+	int ch;
 
 	pushed = strbuf_pushchars(buf, node->prefix);
 
@@ -954,7 +956,7 @@ static void index_mm_searchwild_all(struct index_mm_node *node, int j,
 					  const char *subkey,
 					  struct index_value **out)
 {
-	int pushed = 0;
+	size_t pushed = 0;
 	int ch;
 
 	while (node->prefix[j]) {

--- a/shared/strbuf.c
+++ b/shared/strbuf.c
@@ -77,9 +77,9 @@ bool strbuf_pushchar(struct strbuf *buf, char ch)
 	return true;
 }
 
-unsigned strbuf_pushchars(struct strbuf *buf, const char *str)
+size_t strbuf_pushchars(struct strbuf *buf, const char *str)
 {
-	unsigned int len;
+	size_t len;
 
 	assert(str != NULL);
 	assert(buf != NULL);
@@ -101,7 +101,7 @@ void strbuf_popchar(struct strbuf *buf)
 	buf->used--;
 }
 
-void strbuf_popchars(struct strbuf *buf, unsigned n)
+void strbuf_popchars(struct strbuf *buf, size_t n)
 {
 	assert(buf->used >= n);
 	buf->used -= n;

--- a/shared/strbuf.h
+++ b/shared/strbuf.h
@@ -7,8 +7,8 @@
  */
 struct strbuf {
 	char *bytes;
-	unsigned size;
-	unsigned used;
+	size_t size;
+	size_t used;
 };
 
 void strbuf_init(struct strbuf *buf);
@@ -25,6 +25,6 @@ char *strbuf_steal(struct strbuf *buf);
 const char *strbuf_str(struct strbuf *buf);
 
 bool strbuf_pushchar(struct strbuf *buf, char ch);
-unsigned strbuf_pushchars(struct strbuf *buf, const char *str);
+size_t strbuf_pushchars(struct strbuf *buf, const char *str);
 void strbuf_popchar(struct strbuf *buf);
-void strbuf_popchars(struct strbuf *buf, unsigned n);
+void strbuf_popchars(struct strbuf *buf, size_t n);


### PR DESCRIPTION
The unsigned datatype could overflow on 64 bit systems with sufficiently large index files. Switch to size_t just to be safe.

Since the API of strbuf is not exported, this has no side-effect for libkmod users.