### PR TITLE
libkmod: check for NULL in kmod_get_dirname

### DIFF
--- a/libkmod/libkmod.c
+++ b/libkmod/libkmod.c
@@ -146,6 +146,8 @@ static void log_filep(void *data,
  */
 KMOD_EXPORT const char *kmod_get_dirname(const struct kmod_ctx *ctx)
 {
+	if (ctx == NULL)
+		return NULL;
 	return ctx->dirname;
 }
 


### PR DESCRIPTION
The other KMOD_EXPORT'ed functions protect against ctx being NULL. Add this to kmod_get_dirname purely for consistency reasons.