### PR TITLE
meson: Add build-tests to build-dev.ini

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: configure (meson)
         if: ${{ matrix.build == 'meson' }}
-        run: mkdir build && cd build && meson setup --native-file ../build-dev.ini -D build-tests=true . ..
+        run: mkdir build && cd build && meson setup --native-file ../build-dev.ini . ..
 
       - name: configure (autotools)
         if: ${{ matrix.build == 'autotools' }}

--- a/build-dev.ini
+++ b/build-dev.ini
@@ -1,4 +1,5 @@
 [project options]
+build-tests = true
 debug-messages = true
 zstd = 'enabled'
 xz = 'enabled'


### PR DESCRIPTION
Developers are supposed to run tests to test their code.  CI continues to pass it in the command line as it may need to disable it.