### PR TITLE
ci: add multilib (Arch, Debian, Ubuntu) and enable werror=true

### DIFF
--- a/.github/actions/setup-archlinux/action.yml
+++ b/.github/actions/setup-archlinux/action.yml
@@ -6,6 +6,8 @@ runs:
     - name: Install dependencies
       shell: bash
       run: |
+        # Enable multilib, for building 32bit binaries
+        echo -e '[multilib]\nInclude = /etc/pacman.d/mirrorlist' >> /etc/pacman.conf
         # Semi-regularly the packager key may have (temporarily) expired.
         # Somewhat robust solution is to wipe the local keyring and
         # regenerate/reinstall it prior to any other packages on the system.
@@ -15,6 +17,7 @@ runs:
         pacman --noconfirm -Sy archlinux-keyring
 
         pacman --noconfirm -Su \
+          multilib-devel \
           linux-headers \
           meson \
           scdoc \

--- a/.github/actions/setup-debian/action.yml
+++ b/.github/actions/setup-debian/action.yml
@@ -11,6 +11,7 @@ runs:
           build-essential \
           autoconf \
           automake \
+          gcc-multilib \
           git \
           gtk-doc-tools \
           libssl-dev \

--- a/.github/actions/setup-debian/action.yml
+++ b/.github/actions/setup-debian/action.yml
@@ -15,7 +15,6 @@ runs:
           gtk-doc-tools \
           libssl-dev \
           liblzma-dev \
-          libssl-dev \
           libtool \
           libzstd-dev \
           linux-headers-generic \

--- a/.github/actions/setup-ubuntu/action.yml
+++ b/.github/actions/setup-ubuntu/action.yml
@@ -11,6 +11,7 @@ runs:
           build-essential \
           autoconf \
           automake \
+          gcc-multilib \
           git \
           gtk-doc-tools \
           libssl-dev \

--- a/.github/actions/setup-ubuntu/action.yml
+++ b/.github/actions/setup-ubuntu/action.yml
@@ -15,7 +15,6 @@ runs:
           gtk-doc-tools \
           libssl-dev \
           liblzma-dev \
-          libssl-dev \
           libtool \
           libzstd-dev \
           linux-headers-generic \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,12 +19,16 @@ jobs:
         build: ['meson', 'autotools']
         container:
           - name: 'ubuntu:22.04'
+            multilib: 'true'
           - name: 'ubuntu:24.04'
+            multilib: 'true'
           - name: 'archlinux:base-devel'
+            multilib: 'true'
           - name: 'fedora:latest'
           - name: 'alpine:latest'
             meson_setup: '-D docs=false'
           - name: 'debian:unstable'
+            multilib: 'true'
 
     container:
       image: ${{ matrix.container.name }}
@@ -107,3 +111,15 @@ jobs:
       - name: distcheck (autotools)
         if: ${{ matrix.build == 'autotools' }}
         run: cd build && make distcheck
+
+      - name: configure (32bit) (meson)
+        if: ${{ matrix.build == 'meson' && matrix.container.multilib == 'true' }}
+        run: mkdir build32 && cd build32 && CC='gcc -m32' meson setup . ..
+
+      - name: build (32bit) (meson)
+        if: ${{ matrix.build == 'meson' && matrix.container.multilib == 'true' }}
+        run: cd build32 && meson compile
+
+      - name: test (32bit) (meson)
+        if: ${{ matrix.build == 'meson' && matrix.container.multilib == 'true' }}
+        run: cd build32 && meson test

--- a/build-dev.ini
+++ b/build-dev.ini
@@ -6,6 +6,7 @@ zstd = 'enabled'
 xz = 'enabled'
 zlib = 'enabled'
 openssl = 'enabled'
+werror = true
 
 [built-in options]
 buildtype = 'debugoptimized'


### PR DESCRIPTION
This adds a few simple 32bit permutation in the matrix and promotes all warnings to errors.

At first I though about enabling openssl + compression, although I don't think the extra churn (both downloads and yaml)  is worth it. These three should offer somewhat wide enough coverage as a start.

AFAICT there's no equivalent for Alpine, while Fedora should have one yet I have zero experience there.

Closes: https://github.com/kmod-project/kmod/issues/108