### PR TITLE
libkmod: rework index_files::prefix

### DIFF
--- a/libkmod/libkmod-index.c
+++ b/libkmod/libkmod-index.c
@@ -379,7 +379,7 @@ static void index_dump_node(struct index_node_f *node, struct strbuf *buf,
 	index_close(node);
 }
 
-void index_dump(struct index_file *in, int fd, const char *prefix)
+void index_dump(struct index_file *in, int fd, bool is_alias)
 {
 	struct index_node_f *root;
 	struct strbuf buf;
@@ -389,7 +389,7 @@ void index_dump(struct index_file *in, int fd, const char *prefix)
 		return;
 
 	strbuf_init(&buf);
-	strbuf_pushchars(&buf, prefix);
+	strbuf_pushchars(&buf, is_alias ? "alias " : "");
 	index_dump_node(root, &buf, fd);
 	strbuf_release(&buf);
 }
@@ -861,7 +861,7 @@ static void index_mm_dump_node(struct index_mm_node *node, struct strbuf *buf,
 	index_mm_free_node(node);
 }
 
-void index_mm_dump(struct index_mm *idx, int fd, const char *prefix)
+void index_mm_dump(struct index_mm *idx, int fd, bool is_alias)
 {
 	struct index_mm_node *root;
 	struct strbuf buf;
@@ -871,7 +871,7 @@ void index_mm_dump(struct index_mm *idx, int fd, const char *prefix)
 		return;
 
 	strbuf_init(&buf);
-	strbuf_pushchars(&buf, prefix);
+	strbuf_pushchars(&buf, is_alias ? "alias " : "");
 	index_mm_dump_node(root, &buf, fd);
 	strbuf_release(&buf);
 }

--- a/libkmod/libkmod-index.h
+++ b/libkmod/libkmod-index.h
@@ -19,7 +19,7 @@ struct index_file;
 struct index_file *index_file_open(const char *filename);
 void index_file_close(struct index_file *idx);
 char *index_search(struct index_file *idx, const char *key);
-void index_dump(struct index_file *in, int fd, const char *prefix);
+void index_dump(struct index_file *in, int fd, bool is_alias);
 struct index_value *index_searchwild(struct index_file *idx, const char *key);
 
 void index_values_free(struct index_value *values);
@@ -31,4 +31,4 @@ int index_mm_open(const struct kmod_ctx *ctx, const char *filename,
 void index_mm_close(struct index_mm *index);
 char *index_mm_search(struct index_mm *idx, const char *key);
 struct index_value *index_mm_searchwild(struct index_mm *idx, const char *key);
-void index_mm_dump(struct index_mm *idx, int fd, const char *prefix);
+void index_mm_dump(struct index_mm *idx, int fd, bool is_alias);

--- a/libkmod/libkmod.c
+++ b/libkmod/libkmod.c
@@ -30,13 +30,13 @@
 
 static const struct {
 	const char *fn;
-	const char *prefix;
+	bool is_alias;
 } index_files[] = {
-	[KMOD_INDEX_MODULES_DEP] = { .fn = "modules.dep", .prefix = "" },
-	[KMOD_INDEX_MODULES_ALIAS] = { .fn = "modules.alias", .prefix = "alias " },
-	[KMOD_INDEX_MODULES_SYMBOL] = { .fn = "modules.symbols", .prefix = "alias "},
-	[KMOD_INDEX_MODULES_BUILTIN_ALIAS] = { .fn = "modules.builtin.alias", .prefix = "" },
-	[KMOD_INDEX_MODULES_BUILTIN] = { .fn = "modules.builtin", .prefix = ""},
+	[KMOD_INDEX_MODULES_DEP] = { .fn = "modules.dep", },
+	[KMOD_INDEX_MODULES_ALIAS] = { .fn = "modules.alias", .is_alias = true, },
+	[KMOD_INDEX_MODULES_SYMBOL] = { .fn = "modules.symbols", .is_alias = true},
+	[KMOD_INDEX_MODULES_BUILTIN_ALIAS] = { .fn = "modules.builtin.alias", },
+	[KMOD_INDEX_MODULES_BUILTIN] = { .fn = "modules.builtin", },
 };
 
 static const char *const default_config_paths[] = {
@@ -827,7 +827,7 @@ KMOD_EXPORT int kmod_dump_index(struct kmod_ctx *ctx, enum kmod_index type,
 	if (ctx->indexes[type] != NULL) {
 		DBG(ctx, "use mmapped index '%s'\n", index_files[type].fn);
 		index_mm_dump(ctx->indexes[type], fd,
-						index_files[type].prefix);
+						index_files[type].is_alias);
 	} else {
 		char fn[PATH_MAX];
 		struct index_file *idx;
@@ -841,7 +841,7 @@ KMOD_EXPORT int kmod_dump_index(struct kmod_ctx *ctx, enum kmod_index type,
 		if (idx == NULL)
 			return -ENOSYS;
 
-		index_dump(idx, fd, index_files[type].prefix);
+		index_dump(idx, fd, index_files[type].is_alias);
 		index_file_close(idx);
 	}
 


### PR DESCRIPTION
Swap the empty or alias strings for a is_alias bool. Slightly smaller binary, simpler code and fewer pointers being dereferenced.