### PR TITLE
Some clang-format inspired cleanups

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -266,7 +266,6 @@ CC_CHECK_FLAGS_APPEND(with_cflags, [CFLAGS], [\
 		       -Wno-overlength-strings \
 		       -Wno-unused-parameter \
 		       -Wno-missing-field-initializers \
-		       -Wno-unused-result \
 		       -Wnested-externs \
 		       -Wchar-subscripts \
 		       -Wtype-limits \

--- a/libkmod/libkmod-config.c
+++ b/libkmod/libkmod-config.c
@@ -1218,7 +1218,7 @@ static struct kmod_config_iter *kmod_config_iter_new(const struct kmod_ctx* ctx,
 KMOD_EXPORT struct kmod_config_iter *kmod_config_get_blacklists(const struct kmod_ctx *ctx)
 {
 	if (ctx == NULL)
-		return NULL;;
+		return NULL;
 
 	return kmod_config_iter_new(ctx, CONFIG_TYPE_BLACKLIST);
 }
@@ -1226,7 +1226,7 @@ KMOD_EXPORT struct kmod_config_iter *kmod_config_get_blacklists(const struct kmo
 KMOD_EXPORT struct kmod_config_iter *kmod_config_get_install_commands(const struct kmod_ctx *ctx)
 {
 	if (ctx == NULL)
-		return NULL;;
+		return NULL;
 
 	return kmod_config_iter_new(ctx, CONFIG_TYPE_INSTALL);
 }
@@ -1234,7 +1234,7 @@ KMOD_EXPORT struct kmod_config_iter *kmod_config_get_install_commands(const stru
 KMOD_EXPORT struct kmod_config_iter *kmod_config_get_remove_commands(const struct kmod_ctx *ctx)
 {
 	if (ctx == NULL)
-		return NULL;;
+		return NULL;
 
 	return kmod_config_iter_new(ctx, CONFIG_TYPE_REMOVE);
 }
@@ -1242,7 +1242,7 @@ KMOD_EXPORT struct kmod_config_iter *kmod_config_get_remove_commands(const struc
 KMOD_EXPORT struct kmod_config_iter *kmod_config_get_aliases(const struct kmod_ctx *ctx)
 {
 	if (ctx == NULL)
-		return NULL;;
+		return NULL;
 
 	return kmod_config_iter_new(ctx, CONFIG_TYPE_ALIAS);
 }
@@ -1250,7 +1250,7 @@ KMOD_EXPORT struct kmod_config_iter *kmod_config_get_aliases(const struct kmod_c
 KMOD_EXPORT struct kmod_config_iter *kmod_config_get_options(const struct kmod_ctx *ctx)
 {
 	if (ctx == NULL)
-		return NULL;;
+		return NULL;
 
 	return kmod_config_iter_new(ctx, CONFIG_TYPE_OPTION);
 }
@@ -1258,7 +1258,7 @@ KMOD_EXPORT struct kmod_config_iter *kmod_config_get_options(const struct kmod_c
 KMOD_EXPORT struct kmod_config_iter *kmod_config_get_softdeps(const struct kmod_ctx *ctx)
 {
 	if (ctx == NULL)
-		return NULL;;
+		return NULL;
 
 	return kmod_config_iter_new(ctx, CONFIG_TYPE_SOFTDEP);
 }
@@ -1266,7 +1266,7 @@ KMOD_EXPORT struct kmod_config_iter *kmod_config_get_softdeps(const struct kmod_
 KMOD_EXPORT struct kmod_config_iter *kmod_config_get_weakdeps(const struct kmod_ctx *ctx)
 {
 	if (ctx == NULL)
-		return NULL;;
+		return NULL;
 
 	return kmod_config_iter_new(ctx, CONFIG_TYPE_WEAKDEP);
 }

--- a/libkmod/libkmod-elf.c
+++ b/libkmod/libkmod-elf.c
@@ -18,7 +18,7 @@ enum kmod_elf_class {
 	KMOD_ELF_32 = (1 << 1),
 	KMOD_ELF_64 = (1 << 2),
 	KMOD_ELF_LSB = (1 << 3),
-	KMOD_ELF_MSB = (1 << 4)
+	KMOD_ELF_MSB = (1 << 4),
 };
 
 /* as defined in module-init-tools */

--- a/libkmod/libkmod-file.c
+++ b/libkmod/libkmod-file.c
@@ -50,7 +50,7 @@ static const struct comp_type {
 	{sizeof(magic_zstd),	KMOD_FILE_COMPRESSION_ZSTD, magic_zstd, kmod_file_load_zstd},
 	{sizeof(magic_xz),	KMOD_FILE_COMPRESSION_XZ, magic_xz, kmod_file_load_xz},
 	{sizeof(magic_zlib),	KMOD_FILE_COMPRESSION_ZLIB, magic_zlib, kmod_file_load_zlib},
-	{0,			KMOD_FILE_COMPRESSION_NONE, NULL, load_reg}
+	{0,			KMOD_FILE_COMPRESSION_NONE, NULL, load_reg},
 };
 
 struct kmod_elf *kmod_file_get_elf(struct kmod_file *file)

--- a/libkmod/libkmod-internal.h
+++ b/libkmod/libkmod-internal.h
@@ -48,9 +48,9 @@ static _always_inline_ _printf_format_(2, 3) void
 #  endif
 #endif
 
-void kmod_log(const struct kmod_ctx *ctx,
+_printf_format_(6, 7) void kmod_log(const struct kmod_ctx *ctx,
 		int priority, const char *file, int line, const char *fn,
-		const char *format, ...) __attribute__((format(printf, 6, 7))) __attribute__((nonnull(1, 3, 5)));
+		const char *format, ...) __attribute__((nonnull(1, 3, 5)));
 
 struct list_node {
 	struct list_node *next, *prev;

--- a/libkmod/libkmod-internal.h
+++ b/libkmod/libkmod-internal.h
@@ -94,25 +94,25 @@ struct kmod_list *kmod_list_append_list(struct kmod_list *list1, struct kmod_lis
 		container_of(list_entry->node.prev, struct kmod_list, node)))
 
 /* libkmod.c */
-int kmod_lookup_alias_from_config(struct kmod_ctx *ctx, const char *name, struct kmod_list **list) __attribute__((nonnull(1, 2, 3)));
-int kmod_lookup_alias_from_symbols_file(struct kmod_ctx *ctx, const char *name, struct kmod_list **list) __attribute__((nonnull(1, 2, 3)));
-int kmod_lookup_alias_from_aliases_file(struct kmod_ctx *ctx, const char *name, struct kmod_list **list) __attribute__((nonnull(1, 2, 3)));
-int kmod_lookup_alias_from_moddep_file(struct kmod_ctx *ctx, const char *name, struct kmod_list **list) __attribute__((nonnull(1, 2, 3)));
-int kmod_lookup_alias_from_kernel_builtin_file(struct kmod_ctx *ctx, const char *name, struct kmod_list **list) __attribute__((nonnull(1, 2, 3)));
-int kmod_lookup_alias_from_builtin_file(struct kmod_ctx *ctx, const char *name, struct kmod_list **list) __attribute__((nonnull(1, 2, 3)));
-bool kmod_lookup_alias_is_builtin(struct kmod_ctx *ctx, const char *name) __attribute__((nonnull(1, 2)));
-int kmod_lookup_alias_from_commands(struct kmod_ctx *ctx, const char *name, struct kmod_list **list) __attribute__((nonnull(1, 2, 3)));
+_nonnull_all_ int kmod_lookup_alias_from_config(struct kmod_ctx *ctx, const char *name, struct kmod_list **list);
+_nonnull_all_ int kmod_lookup_alias_from_symbols_file(struct kmod_ctx *ctx, const char *name, struct kmod_list **list);
+_nonnull_all_ int kmod_lookup_alias_from_aliases_file(struct kmod_ctx *ctx, const char *name, struct kmod_list **list);
+_nonnull_all_ int kmod_lookup_alias_from_moddep_file(struct kmod_ctx *ctx, const char *name, struct kmod_list **list);
+_nonnull_all_ int kmod_lookup_alias_from_kernel_builtin_file(struct kmod_ctx *ctx, const char *name, struct kmod_list **list);
+_nonnull_all_ int kmod_lookup_alias_from_builtin_file(struct kmod_ctx *ctx, const char *name, struct kmod_list **list);
+_nonnull_all_ bool kmod_lookup_alias_is_builtin(struct kmod_ctx *ctx, const char *name);
+_nonnull_all_ int kmod_lookup_alias_from_commands(struct kmod_ctx *ctx, const char *name, struct kmod_list **list);
 void kmod_set_modules_visited(struct kmod_ctx *ctx, bool visited) __attribute__((nonnull((1))));
 void kmod_set_modules_required(struct kmod_ctx *ctx, bool required) __attribute__((nonnull((1))));
 
-char *kmod_search_moddep(struct kmod_ctx *ctx, const char *name) __attribute__((nonnull(1,2)));
+_nonnull_all_ char *kmod_search_moddep(struct kmod_ctx *ctx, const char *name);
 
-struct kmod_module *kmod_pool_get_module(struct kmod_ctx *ctx, const char *key) __attribute__((nonnull(1,2)));
-void kmod_pool_add_module(struct kmod_ctx *ctx, struct kmod_module *mod, const char *key) __attribute__((nonnull(1, 2, 3)));
-void kmod_pool_del_module(struct kmod_ctx *ctx, struct kmod_module *mod, const char *key) __attribute__((nonnull(1, 2, 3)));
+_nonnull_all_ struct kmod_module *kmod_pool_get_module(struct kmod_ctx *ctx, const char *key);
+_nonnull_all_ void kmod_pool_add_module(struct kmod_ctx *ctx, struct kmod_module *mod, const char *key);
+_nonnull_all_ void kmod_pool_del_module(struct kmod_ctx *ctx, struct kmod_module *mod, const char *key);
 
-const struct kmod_config *kmod_get_config(const struct kmod_ctx *ctx) __attribute__((nonnull(1)));
-enum kmod_file_compression_type kmod_get_kernel_compression(const struct kmod_ctx *ctx) __attribute__((nonnull(1)));
+_nonnull_all_ const struct kmod_config *kmod_get_config(const struct kmod_ctx *ctx);
+_nonnull_all_ enum kmod_file_compression_type kmod_get_kernel_compression(const struct kmod_ctx *ctx);
 
 /* libkmod-config.c */
 struct kmod_config_path {
@@ -133,42 +133,42 @@ struct kmod_config {
 	struct kmod_list *paths;
 };
 
-int kmod_config_new(struct kmod_ctx *ctx, struct kmod_config **config, const char * const *config_paths) __attribute__((nonnull(1, 2,3)));
-void kmod_config_free(struct kmod_config *config) __attribute__((nonnull(1)));
-const char *kmod_blacklist_get_modname(const struct kmod_list *l) __attribute__((nonnull(1)));
-const char *kmod_alias_get_name(const struct kmod_list *l) __attribute__((nonnull(1)));
-const char *kmod_alias_get_modname(const struct kmod_list *l) __attribute__((nonnull(1)));
-const char *kmod_option_get_options(const struct kmod_list *l) __attribute__((nonnull(1)));
-const char *kmod_option_get_modname(const struct kmod_list *l) __attribute__((nonnull(1)));
-const char *kmod_command_get_command(const struct kmod_list *l) __attribute__((nonnull(1)));
-const char *kmod_command_get_modname(const struct kmod_list *l) __attribute__((nonnull(1)));
+_nonnull_all_ int kmod_config_new(struct kmod_ctx *ctx, struct kmod_config **config, const char * const *config_paths);
+_nonnull_all_ void kmod_config_free(struct kmod_config *config);
+_nonnull_all_ const char *kmod_blacklist_get_modname(const struct kmod_list *l);
+_nonnull_all_ const char *kmod_alias_get_name(const struct kmod_list *l);
+_nonnull_all_ const char *kmod_alias_get_modname(const struct kmod_list *l);
+_nonnull_all_ const char *kmod_option_get_options(const struct kmod_list *l);
+_nonnull_all_ const char *kmod_option_get_modname(const struct kmod_list *l);
+_nonnull_all_ const char *kmod_command_get_command(const struct kmod_list *l);
+_nonnull_all_ const char *kmod_command_get_modname(const struct kmod_list *l);
 
-const char *kmod_softdep_get_name(const struct kmod_list *l) __attribute__((nonnull(1)));
-const char * const *kmod_softdep_get_pre(const struct kmod_list *l, unsigned int *count) __attribute__((nonnull(1, 2)));
+_nonnull_all_ const char *kmod_softdep_get_name(const struct kmod_list *l);
+_nonnull_all_ const char * const *kmod_softdep_get_pre(const struct kmod_list *l, unsigned int *count);
 const char * const *kmod_softdep_get_post(const struct kmod_list *l, unsigned int *count);
 
-const char *kmod_weakdep_get_name(const struct kmod_list *l) __attribute__((nonnull(1)));
-const char * const *kmod_weakdep_get_weak(const struct kmod_list *l, unsigned int *count) __attribute__((nonnull(1, 2)));
+_nonnull_all_ const char * kmod_weakdep_get_name(const struct kmod_list *l);
+_nonnull_all_ const char * const *kmod_weakdep_get_weak(const struct kmod_list *l, unsigned int *count);
 
 /* libkmod-module.c */
 int kmod_module_new_from_alias(struct kmod_ctx *ctx, const char *alias, const char *name, struct kmod_module **mod);
-int kmod_module_parse_depline(struct kmod_module *mod, char *line) __attribute__((nonnull(1, 2)));
+_nonnull_all_ int kmod_module_parse_depline(struct kmod_module *mod, char *line);
 void kmod_module_set_install_commands(struct kmod_module *mod, const char *cmd) __attribute__((nonnull(1)));
 void kmod_module_set_remove_commands(struct kmod_module *mod, const char *cmd) __attribute__((nonnull(1)));
 void kmod_module_set_visited(struct kmod_module *mod, bool visited) __attribute__((nonnull(1)));
 void kmod_module_set_builtin(struct kmod_module *mod, bool builtin) __attribute__((nonnull((1))));
 void kmod_module_set_required(struct kmod_module *mod, bool required) __attribute__((nonnull(1)));
-bool kmod_module_is_builtin(struct kmod_module *mod) __attribute__((nonnull(1)));
+_nonnull_all_ bool kmod_module_is_builtin(struct kmod_module *mod);
 
 /* libkmod-file.c */
-struct kmod_file *kmod_file_open(const struct kmod_ctx *ctx, const char *filename) __attribute__((nonnull(1,2)));
-struct kmod_elf *kmod_file_get_elf(struct kmod_file *file) __attribute__((nonnull(1)));
-int kmod_file_load_contents(struct kmod_file *file) __attribute__((nonnull(1)));
-void *kmod_file_get_contents(const struct kmod_file *file) __attribute__((nonnull(1)));
-off_t kmod_file_get_size(const struct kmod_file *file) __attribute__((nonnull(1)));
-enum kmod_file_compression_type kmod_file_get_compression(const struct kmod_file *file) __attribute__((nonnull(1)));
-int kmod_file_get_fd(const struct kmod_file *file) __attribute__((nonnull(1)));
-void kmod_file_unref(struct kmod_file *file) __attribute__((nonnull(1)));
+_nonnull_all_ struct kmod_file *kmod_file_open(const struct kmod_ctx *ctx, const char *filename);
+_nonnull_all_ struct kmod_elf *kmod_file_get_elf(struct kmod_file *file);
+_nonnull_all_ int kmod_file_load_contents(struct kmod_file *file);
+_nonnull_all_ void *kmod_file_get_contents(const struct kmod_file *file);
+_nonnull_all_ off_t kmod_file_get_size(const struct kmod_file *file);
+_nonnull_all_ enum kmod_file_compression_type kmod_file_get_compression(const struct kmod_file *file);
+_nonnull_all_ int kmod_file_get_fd(const struct kmod_file *file);
+_nonnull_all_ void kmod_file_unref(struct kmod_file *file);
 
 /* libkmod-elf.c */
 struct kmod_elf;
@@ -179,20 +179,20 @@ struct kmod_modversion {
 };
 
 struct kmod_elf *kmod_elf_new(const void *memory, off_t size);
-void kmod_elf_unref(struct kmod_elf *elf) __attribute__((nonnull(1)));
-const void *kmod_elf_get_memory(const struct kmod_elf *elf) __attribute__((nonnull(1)));
-int kmod_elf_get_strings(const struct kmod_elf *elf, const char *section, char ***array) __attribute__((nonnull(1,2,3)));
-int kmod_elf_get_modversions(const struct kmod_elf *elf, struct kmod_modversion **array) __attribute__((nonnull(1,2)));
-int kmod_elf_get_symbols(const struct kmod_elf *elf, struct kmod_modversion **array) __attribute__((nonnull(1,2)));
-int kmod_elf_get_dependency_symbols(const struct kmod_elf *elf, struct kmod_modversion **array) __attribute__((nonnull(1,2)));
-int kmod_elf_strip_section(struct kmod_elf *elf, const char *section) __attribute__((nonnull(1,2)));
-int kmod_elf_strip_vermagic(struct kmod_elf *elf) __attribute__((nonnull(1)));
+_nonnull_all_ void kmod_elf_unref(struct kmod_elf *elf);
+_nonnull_all_ const void *kmod_elf_get_memory(const struct kmod_elf *elf);
+_nonnull_all_ int kmod_elf_get_strings(const struct kmod_elf *elf, const char *section, char ***array);
+_nonnull_all_ int kmod_elf_get_modversions(const struct kmod_elf *elf, struct kmod_modversion **array);
+_nonnull_all_ int kmod_elf_get_symbols(const struct kmod_elf *elf, struct kmod_modversion **array);
+_nonnull_all_ int kmod_elf_get_dependency_symbols(const struct kmod_elf *elf, struct kmod_modversion **array);
+_nonnull_all_ int kmod_elf_strip_section(struct kmod_elf *elf, const char *section);
+_nonnull_all_ int kmod_elf_strip_vermagic(struct kmod_elf *elf);
 
 /*
  * Debug mock lib need to find section ".gnu.linkonce.this_module" in order to
  * get modname
  */
-int kmod_elf_get_section(const struct kmod_elf *elf, const char *section, const void **buf, uint64_t *buf_size) __attribute__((nonnull(1,2,3,4)));
+_nonnull_all_ int kmod_elf_get_section(const struct kmod_elf *elf, const char *section, const void **buf, uint64_t *buf_size);
 
 /* libkmod-signature.c */
 struct kmod_signature_info {
@@ -206,8 +206,8 @@ struct kmod_signature_info {
 	void (*free)(void *);
 	void *private;
 };
-bool kmod_module_signature_info(const struct kmod_file *file, struct kmod_signature_info *sig_info) __attribute__((nonnull(1, 2)));
-void kmod_module_signature_info_free(struct kmod_signature_info *sig_info) __attribute__((nonnull));
+_nonnull_all_ bool kmod_module_signature_info(const struct kmod_file *file, struct kmod_signature_info *sig_info);
+_nonnull_all_ void kmod_module_signature_info_free(struct kmod_signature_info *sig_info);
 
 /* libkmod-builtin.c */
-ssize_t kmod_builtin_get_modinfo(struct kmod_ctx *ctx, const char *modname, char ***modinfo) __attribute__((nonnull(1, 2, 3)));
+_nonnull_all_ ssize_t kmod_builtin_get_modinfo(struct kmod_ctx *ctx, const char *modname, char ***modinfo);

--- a/libkmod/libkmod-internal.h
+++ b/libkmod/libkmod-internal.h
@@ -48,9 +48,9 @@ static _always_inline_ _printf_format_(2, 3) void
 #  endif
 #endif
 
-_printf_format_(6, 7) void kmod_log(const struct kmod_ctx *ctx,
+_printf_format_(6, 7) _nonnull_(1, 3, 5) void kmod_log(const struct kmod_ctx *ctx,
 		int priority, const char *file, int line, const char *fn,
-		const char *format, ...) __attribute__((nonnull(1, 3, 5)));
+		const char *format, ...);
 
 struct list_node {
 	struct list_node *next, *prev;
@@ -68,15 +68,15 @@ enum kmod_file_compression_type {
 	KMOD_FILE_COMPRESSION_ZLIB,
 };
 
-struct kmod_list *kmod_list_append(struct kmod_list *list, const void *data) __attribute__((nonnull(2)));
-struct kmod_list *kmod_list_prepend(struct kmod_list *list, const void *data) __attribute__((nonnull(2)));
+_nonnull_(2) struct kmod_list *kmod_list_append(struct kmod_list *list, const void *data);
+_nonnull_(2) struct kmod_list *kmod_list_prepend(struct kmod_list *list, const void *data);
 struct kmod_list *kmod_list_remove(struct kmod_list *list);
-struct kmod_list *kmod_list_remove_data(struct kmod_list *list,
-					const void *data) __attribute__((nonnull(2)));
+_nonnull_(2) struct kmod_list *kmod_list_remove_data(struct kmod_list *list,
+					const void *data);
 struct kmod_list *kmod_list_remove_n_latest(struct kmod_list *list,
 						unsigned int n);
-struct kmod_list *kmod_list_insert_after(struct kmod_list *list, const void *data) __attribute__((nonnull(2)));
-struct kmod_list *kmod_list_insert_before(struct kmod_list *list, const void *data) __attribute__((nonnull(2)));
+_nonnull_(2) struct kmod_list *kmod_list_insert_after(struct kmod_list *list, const void *data);
+_nonnull_(2) struct kmod_list *kmod_list_insert_before(struct kmod_list *list, const void *data);
 struct kmod_list *kmod_list_append_list(struct kmod_list *list1, struct kmod_list *list2);
 
 #undef kmod_list_foreach
@@ -102,8 +102,8 @@ _nonnull_all_ int kmod_lookup_alias_from_kernel_builtin_file(struct kmod_ctx *ct
 _nonnull_all_ int kmod_lookup_alias_from_builtin_file(struct kmod_ctx *ctx, const char *name, struct kmod_list **list);
 _nonnull_all_ bool kmod_lookup_alias_is_builtin(struct kmod_ctx *ctx, const char *name);
 _nonnull_all_ int kmod_lookup_alias_from_commands(struct kmod_ctx *ctx, const char *name, struct kmod_list **list);
-void kmod_set_modules_visited(struct kmod_ctx *ctx, bool visited) __attribute__((nonnull((1))));
-void kmod_set_modules_required(struct kmod_ctx *ctx, bool required) __attribute__((nonnull((1))));
+_nonnull_(1) void kmod_set_modules_visited(struct kmod_ctx *ctx, bool visited);
+_nonnull_(1) void kmod_set_modules_required(struct kmod_ctx *ctx, bool required);
 
 _nonnull_all_ char *kmod_search_moddep(struct kmod_ctx *ctx, const char *name);
 
@@ -153,11 +153,11 @@ _nonnull_all_ const char * const *kmod_weakdep_get_weak(const struct kmod_list *
 /* libkmod-module.c */
 int kmod_module_new_from_alias(struct kmod_ctx *ctx, const char *alias, const char *name, struct kmod_module **mod);
 _nonnull_all_ int kmod_module_parse_depline(struct kmod_module *mod, char *line);
-void kmod_module_set_install_commands(struct kmod_module *mod, const char *cmd) __attribute__((nonnull(1)));
-void kmod_module_set_remove_commands(struct kmod_module *mod, const char *cmd) __attribute__((nonnull(1)));
-void kmod_module_set_visited(struct kmod_module *mod, bool visited) __attribute__((nonnull(1)));
-void kmod_module_set_builtin(struct kmod_module *mod, bool builtin) __attribute__((nonnull((1))));
-void kmod_module_set_required(struct kmod_module *mod, bool required) __attribute__((nonnull(1)));
+_nonnull_(1) void kmod_module_set_install_commands(struct kmod_module *mod, const char *cmd);
+_nonnull_(1) void kmod_module_set_remove_commands(struct kmod_module *mod, const char *cmd);
+_nonnull_(1)void kmod_module_set_visited(struct kmod_module *mod, bool visited);
+_nonnull_(1) void kmod_module_set_builtin(struct kmod_module *mod, bool builtin);
+_nonnull_(1) void kmod_module_set_required(struct kmod_module *mod, bool required);
 _nonnull_all_ bool kmod_module_is_builtin(struct kmod_module *mod);
 
 /* libkmod-file.c */

--- a/libkmod/libkmod-internal.h
+++ b/libkmod/libkmod-internal.h
@@ -68,16 +68,16 @@ enum kmod_file_compression_type {
 	KMOD_FILE_COMPRESSION_ZLIB,
 };
 
-struct kmod_list *kmod_list_append(struct kmod_list *list, const void *data) _must_check_ __attribute__((nonnull(2)));
-struct kmod_list *kmod_list_prepend(struct kmod_list *list, const void *data) _must_check_ __attribute__((nonnull(2)));
-struct kmod_list *kmod_list_remove(struct kmod_list *list) _must_check_;
+struct kmod_list *kmod_list_append(struct kmod_list *list, const void *data) __attribute__((nonnull(2)));
+struct kmod_list *kmod_list_prepend(struct kmod_list *list, const void *data) __attribute__((nonnull(2)));
+struct kmod_list *kmod_list_remove(struct kmod_list *list);
 struct kmod_list *kmod_list_remove_data(struct kmod_list *list,
-					const void *data) _must_check_ __attribute__((nonnull(2)));
+					const void *data) __attribute__((nonnull(2)));
 struct kmod_list *kmod_list_remove_n_latest(struct kmod_list *list,
-						unsigned int n) _must_check_;
+						unsigned int n);
 struct kmod_list *kmod_list_insert_after(struct kmod_list *list, const void *data) __attribute__((nonnull(2)));
 struct kmod_list *kmod_list_insert_before(struct kmod_list *list, const void *data) __attribute__((nonnull(2)));
-struct kmod_list *kmod_list_append_list(struct kmod_list *list1, struct kmod_list *list2) _must_check_;
+struct kmod_list *kmod_list_append_list(struct kmod_list *list1, struct kmod_list *list2);
 
 #undef kmod_list_foreach
 #define kmod_list_foreach(list_entry, first_entry) \
@@ -161,13 +161,13 @@ void kmod_module_set_required(struct kmod_module *mod, bool required) __attribut
 bool kmod_module_is_builtin(struct kmod_module *mod) __attribute__((nonnull(1)));
 
 /* libkmod-file.c */
-struct kmod_file *kmod_file_open(const struct kmod_ctx *ctx, const char *filename) _must_check_ __attribute__((nonnull(1,2)));
+struct kmod_file *kmod_file_open(const struct kmod_ctx *ctx, const char *filename) __attribute__((nonnull(1,2)));
 struct kmod_elf *kmod_file_get_elf(struct kmod_file *file) __attribute__((nonnull(1)));
 int kmod_file_load_contents(struct kmod_file *file) __attribute__((nonnull(1)));
-void *kmod_file_get_contents(const struct kmod_file *file) _must_check_ __attribute__((nonnull(1)));
-off_t kmod_file_get_size(const struct kmod_file *file) _must_check_ __attribute__((nonnull(1)));
-enum kmod_file_compression_type kmod_file_get_compression(const struct kmod_file *file) _must_check_ __attribute__((nonnull(1)));
-int kmod_file_get_fd(const struct kmod_file *file) _must_check_ __attribute__((nonnull(1)));
+void *kmod_file_get_contents(const struct kmod_file *file) __attribute__((nonnull(1)));
+off_t kmod_file_get_size(const struct kmod_file *file) __attribute__((nonnull(1)));
+enum kmod_file_compression_type kmod_file_get_compression(const struct kmod_file *file) __attribute__((nonnull(1)));
+int kmod_file_get_fd(const struct kmod_file *file) __attribute__((nonnull(1)));
 void kmod_file_unref(struct kmod_file *file) __attribute__((nonnull(1)));
 
 /* libkmod-elf.c */
@@ -178,21 +178,21 @@ struct kmod_modversion {
 	char *symbol;
 };
 
-struct kmod_elf *kmod_elf_new(const void *memory, off_t size) _must_check_;
+struct kmod_elf *kmod_elf_new(const void *memory, off_t size);
 void kmod_elf_unref(struct kmod_elf *elf) __attribute__((nonnull(1)));
-const void *kmod_elf_get_memory(const struct kmod_elf *elf) _must_check_ __attribute__((nonnull(1)));
-int kmod_elf_get_strings(const struct kmod_elf *elf, const char *section, char ***array) _must_check_ __attribute__((nonnull(1,2,3)));
-int kmod_elf_get_modversions(const struct kmod_elf *elf, struct kmod_modversion **array) _must_check_ __attribute__((nonnull(1,2)));
-int kmod_elf_get_symbols(const struct kmod_elf *elf, struct kmod_modversion **array) _must_check_ __attribute__((nonnull(1,2)));
-int kmod_elf_get_dependency_symbols(const struct kmod_elf *elf, struct kmod_modversion **array) _must_check_ __attribute__((nonnull(1,2)));
-int kmod_elf_strip_section(struct kmod_elf *elf, const char *section) _must_check_ __attribute__((nonnull(1,2)));
-int kmod_elf_strip_vermagic(struct kmod_elf *elf) _must_check_ __attribute__((nonnull(1)));
+const void *kmod_elf_get_memory(const struct kmod_elf *elf) __attribute__((nonnull(1)));
+int kmod_elf_get_strings(const struct kmod_elf *elf, const char *section, char ***array) __attribute__((nonnull(1,2,3)));
+int kmod_elf_get_modversions(const struct kmod_elf *elf, struct kmod_modversion **array) __attribute__((nonnull(1,2)));
+int kmod_elf_get_symbols(const struct kmod_elf *elf, struct kmod_modversion **array) __attribute__((nonnull(1,2)));
+int kmod_elf_get_dependency_symbols(const struct kmod_elf *elf, struct kmod_modversion **array) __attribute__((nonnull(1,2)));
+int kmod_elf_strip_section(struct kmod_elf *elf, const char *section) __attribute__((nonnull(1,2)));
+int kmod_elf_strip_vermagic(struct kmod_elf *elf) __attribute__((nonnull(1)));
 
 /*
  * Debug mock lib need to find section ".gnu.linkonce.this_module" in order to
  * get modname
  */
-int kmod_elf_get_section(const struct kmod_elf *elf, const char *section, const void **buf, uint64_t *buf_size) _must_check_ __attribute__((nonnull(1,2,3,4)));
+int kmod_elf_get_section(const struct kmod_elf *elf, const char *section, const void **buf, uint64_t *buf_size) __attribute__((nonnull(1,2,3,4)));
 
 /* libkmod-signature.c */
 struct kmod_signature_info {
@@ -206,7 +206,7 @@ struct kmod_signature_info {
 	void (*free)(void *);
 	void *private;
 };
-bool kmod_module_signature_info(const struct kmod_file *file, struct kmod_signature_info *sig_info) _must_check_ __attribute__((nonnull(1, 2)));
+bool kmod_module_signature_info(const struct kmod_file *file, struct kmod_signature_info *sig_info) __attribute__((nonnull(1, 2)));
 void kmod_module_signature_info_free(struct kmod_signature_info *sig_info) __attribute__((nonnull));
 
 /* libkmod-builtin.c */

--- a/libkmod/libkmod-module.c
+++ b/libkmod/libkmod-module.c
@@ -411,7 +411,7 @@ KMOD_EXPORT struct kmod_module *kmod_module_ref(struct kmod_module *mod)
 	return mod;
 }
 
-typedef int (*lookup_func)(struct kmod_ctx *ctx, const char *name, struct kmod_list **list) __attribute__((nonnull(1, 2, 3)));
+typedef _nonnull_all_ int (*lookup_func)(struct kmod_ctx *ctx, const char *name, struct kmod_list **list);
 
 static int __kmod_module_new_from_lookup(struct kmod_ctx *ctx, const lookup_func lookup[],
 					 size_t lookup_count, const char *s,

--- a/libkmod/libkmod-signature.c
+++ b/libkmod/libkmod-signature.c
@@ -25,7 +25,7 @@
 enum pkey_algo {
 	PKEY_ALGO_DSA,
 	PKEY_ALGO_RSA,
-	PKEY_ALGO__LAST
+	PKEY_ALGO__LAST,
 };
 
 static const char *const pkey_algo[PKEY_ALGO__LAST] = {
@@ -43,7 +43,7 @@ enum pkey_hash_algo {
 	PKEY_HASH_SHA512,
 	PKEY_HASH_SHA224,
 	PKEY_HASH_SM3,
-	PKEY_HASH__LAST
+	PKEY_HASH__LAST,
 };
 
 const char *const pkey_hash_algo[PKEY_HASH__LAST] = {
@@ -62,7 +62,7 @@ enum pkey_id_type {
 	PKEY_ID_PGP,		/* OpenPGP generated key ID */
 	PKEY_ID_X509,		/* X.509 arbitrary subjectKeyIdentifier */
 	PKEY_ID_PKCS7,		/* Signature in PKCS#7 message */
-	PKEY_ID_TYPE__LAST
+	PKEY_ID_TYPE__LAST,
 };
 
 const char *const pkey_id_type[PKEY_ID_TYPE__LAST] = {

--- a/libkmod/libkmod.c
+++ b/libkmod/libkmod.c
@@ -45,7 +45,7 @@ static const char *const default_config_paths[] = {
 	"/usr/local/lib/modprobe.d",
 	DISTCONFDIR "/modprobe.d",
 	"/lib/modprobe.d",
-	NULL
+	NULL,
 };
 
 struct kmod_ctx {

--- a/libkmod/libkmod.h
+++ b/libkmod/libkmod.h
@@ -990,7 +990,7 @@ enum kmod_symbol_bind {
 	KMOD_SYMBOL_LOCAL = 'L',
 	KMOD_SYMBOL_GLOBAL = 'G',
 	KMOD_SYMBOL_WEAK = 'W',
-	KMOD_SYMBOL_UNDEF = 'U'
+	KMOD_SYMBOL_UNDEF = 'U',
 };
 
 /**

--- a/meson.build
+++ b/meson.build
@@ -136,7 +136,6 @@ add_project_arguments(
     '-Wno-overlength-strings',
     '-Wno-unused-parameter',
     '-Wno-missing-field-initializers',
-    '-Wno-unused-result',
     '-Wnested-externs',
     '-Wchar-subscripts',
     '-Wtype-limits',

--- a/shared/hash.c
+++ b/shared/hash.c
@@ -225,7 +225,7 @@ void *hash_find(const struct hash *hash, const char *key)
 	const struct hash_bucket *bucket = hash->buckets + pos;
 	const struct hash_entry se = {
 		.key = key,
-		.value = NULL
+		.value = NULL,
 	};
 	const struct hash_entry *entry;
 
@@ -248,7 +248,7 @@ int hash_del(struct hash *hash, const char *key)
 	struct hash_entry *entry, *entry_end;
 	const struct hash_entry se = {
 		.key = key,
-		.value = NULL
+		.value = NULL,
 	};
 
 	entry = bsearch(&se, bucket->entries, bucket->used,

--- a/shared/macro.h
+++ b/shared/macro.h
@@ -49,6 +49,7 @@
 #define _unused_ __attribute__((unused))
 #define _always_inline_ __inline__ __attribute__((always_inline))
 #define _cleanup_(x) __attribute__((cleanup(x)))
+#define _nonnull_(...) __attribute__((nonnull (__VA_ARGS__)))
 #define _nonnull_all_ __attribute__((nonnull))
 
 /* Define C11 noreturn without <stdnoreturn.h> and even on older gcc

--- a/shared/macro.h
+++ b/shared/macro.h
@@ -49,6 +49,7 @@
 #define _unused_ __attribute__((unused))
 #define _always_inline_ __inline__ __attribute__((always_inline))
 #define _cleanup_(x) __attribute__((cleanup(x)))
+#define _nonnull_all_ __attribute__((nonnull))
 
 /* Define C11 noreturn without <stdnoreturn.h> and even on older gcc
  * compiler versions */

--- a/shared/macro.h
+++ b/shared/macro.h
@@ -45,7 +45,6 @@
 
 /* Attributes */
 
-#define _must_check_ __attribute__((warn_unused_result))
 #define _printf_format_(a,b) __attribute__((format (printf, a, b)))
 #define _unused_ __attribute__((unused))
 #define _always_inline_ __inline__ __attribute__((always_inline))

--- a/shared/util.c
+++ b/shared/util.c
@@ -35,7 +35,7 @@ static const struct kmod_ext {
 #ifdef ENABLE_ZSTD
 	{".ko.zst", sizeof(".ko.zst") - 1},
 #endif
-	{ }
+	{ },
 };
 
 /* string handling functions and memory allocations                         */

--- a/shared/util.h
+++ b/shared/util.h
@@ -24,23 +24,23 @@ void *memdup(const void *p, size_t n) __attribute__((nonnull(1)));
 /* ************************************************************************ */
 #define KMOD_EXTENSION_UNCOMPRESSED ".ko"
 
-int alias_normalize(const char *alias, char buf[static PATH_MAX], size_t *len) _must_check_ __attribute__((nonnull(1,2)));
-int underscores(char *s) _must_check_;
+int alias_normalize(const char *alias, char buf[static PATH_MAX], size_t *len) __attribute__((nonnull(1,2)));
+int underscores(char *s);
 char *modname_normalize(const char *modname, char buf[static PATH_MAX], size_t *len) __attribute__((nonnull(1, 2)));
 char *path_to_modname(const char *path, char buf[static PATH_MAX], size_t *len) __attribute__((nonnull(2)));
 bool path_ends_with_kmod_ext(const char *path, size_t len) __attribute__((nonnull(1)));
 
 /* read-like and fread-like functions                                       */
 /* ************************************************************************ */
-ssize_t read_str_safe(int fd, char *buf, size_t buflen) _must_check_ __attribute__((nonnull(2)));
+ssize_t read_str_safe(int fd, char *buf, size_t buflen) __attribute__((nonnull(2)));
 ssize_t write_str_safe(int fd, const char *buf, size_t buflen) __attribute__((nonnull(2)));
-int read_str_long(int fd, long *value, int base) _must_check_ __attribute__((nonnull(2)));
-int read_str_ulong(int fd, unsigned long *value, int base) _must_check_ __attribute__((nonnull(2)));
+int read_str_long(int fd, long *value, int base) __attribute__((nonnull(2)));
+int read_str_ulong(int fd, unsigned long *value, int base) __attribute__((nonnull(2)));
 char *freadline_wrapped(FILE *fp, unsigned int *linenum) __attribute__((nonnull(1)));
 
 /* path handling functions                                                  */
 /* ************************************************************************ */
-char *path_make_absolute_cwd(const char *p) _must_check_ __attribute__((nonnull(1)));
+char *path_make_absolute_cwd(const char *p) __attribute__((nonnull(1)));
 int mkdir_p(const char *path, int len, mode_t mode);
 int mkdir_parents(const char *path, mode_t mode);
 unsigned long long stat_mstamp(const struct stat *st);

--- a/shared/util.h
+++ b/shared/util.h
@@ -18,7 +18,7 @@
 #define strstartswith(a, b) (strncmp(a, b, strlen(b)) == 0)
 #define strnstartswith(a, b, n) (strncmp(a, b, n) == 0)
 char *strchr_replace(char *s, char c, char r);
-void *memdup(const void *p, size_t n) __attribute__((nonnull(1)));
+_nonnull_all_ void *memdup(const void *p, size_t n);
 
 /* module-related functions                                                 */
 /* ************************************************************************ */
@@ -28,7 +28,7 @@ int alias_normalize(const char *alias, char buf[static PATH_MAX], size_t *len) _
 int underscores(char *s);
 char *modname_normalize(const char *modname, char buf[static PATH_MAX], size_t *len) __attribute__((nonnull(1, 2)));
 char *path_to_modname(const char *path, char buf[static PATH_MAX], size_t *len) __attribute__((nonnull(2)));
-bool path_ends_with_kmod_ext(const char *path, size_t len) __attribute__((nonnull(1)));
+_nonnull_all_ bool path_ends_with_kmod_ext(const char *path, size_t len);
 
 /* read-like and fread-like functions                                       */
 /* ************************************************************************ */
@@ -40,7 +40,7 @@ char *freadline_wrapped(FILE *fp, unsigned int *linenum) __attribute__((nonnull(
 
 /* path handling functions                                                  */
 /* ************************************************************************ */
-char *path_make_absolute_cwd(const char *p) __attribute__((nonnull(1)));
+_nonnull_all_ char *path_make_absolute_cwd(const char *p);
 int mkdir_p(const char *path, int len, mode_t mode);
 int mkdir_parents(const char *path, mode_t mode);
 unsigned long long stat_mstamp(const struct stat *st);

--- a/shared/util.h
+++ b/shared/util.h
@@ -24,19 +24,19 @@ _nonnull_all_ void *memdup(const void *p, size_t n);
 /* ************************************************************************ */
 #define KMOD_EXTENSION_UNCOMPRESSED ".ko"
 
-int alias_normalize(const char *alias, char buf[static PATH_MAX], size_t *len) __attribute__((nonnull(1,2)));
+_nonnull_(1, 2) int alias_normalize(const char *alias, char buf[static PATH_MAX], size_t *len);
 int underscores(char *s);
-char *modname_normalize(const char *modname, char buf[static PATH_MAX], size_t *len) __attribute__((nonnull(1, 2)));
-char *path_to_modname(const char *path, char buf[static PATH_MAX], size_t *len) __attribute__((nonnull(2)));
+_nonnull_(1, 2) char *modname_normalize(const char *modname, char buf[static PATH_MAX], size_t *len);
+_nonnull_(2) char *path_to_modname(const char *path, char buf[static PATH_MAX], size_t *len);
 _nonnull_all_ bool path_ends_with_kmod_ext(const char *path, size_t len);
 
 /* read-like and fread-like functions                                       */
 /* ************************************************************************ */
-ssize_t read_str_safe(int fd, char *buf, size_t buflen) __attribute__((nonnull(2)));
-ssize_t write_str_safe(int fd, const char *buf, size_t buflen) __attribute__((nonnull(2)));
-int read_str_long(int fd, long *value, int base) __attribute__((nonnull(2)));
-int read_str_ulong(int fd, unsigned long *value, int base) __attribute__((nonnull(2)));
-char *freadline_wrapped(FILE *fp, unsigned int *linenum) __attribute__((nonnull(1)));
+_nonnull_(2) ssize_t read_str_safe(int fd, char *buf, size_t buflen);
+_nonnull_(2) ssize_t write_str_safe(int fd, const char *buf, size_t buflen);
+_nonnull_(2) int read_str_long(int fd, long *value, int base);
+_nonnull_(2) int read_str_ulong(int fd, unsigned long *value, int base);
+_nonnull_(1) char *freadline_wrapped(FILE *fp, unsigned int *linenum);
 
 /* path handling functions                                                  */
 /* ************************************************************************ */

--- a/testsuite/test-depmod.c
+++ b/testsuite/test-depmod.c
@@ -38,7 +38,7 @@ DEFINE_TEST(depmod_modules_order_for_compressed,
 		.files = (const struct keyval[]) {
 			{ MODULES_ORDER_LIB_MODULES "/correct-modules.alias",
 			  MODULES_ORDER_LIB_MODULES "/modules.alias" },
-			{ }
+			{ },
 		},
 	});
 
@@ -70,7 +70,7 @@ DEFINE_TEST(depmod_modules_outdir,
 			  MODULES_OUTDIR_ROOTFS "/correct-modules.dep" },
 			{ MODULES_OUTDIR_LIB_MODULES_OUTPUT "/modules.alias",
 			  MODULES_OUTDIR_ROOTFS "/correct-modules.alias" },
-			{ }
+			{ },
 		},
 	});
 
@@ -97,7 +97,7 @@ DEFINE_TEST(depmod_search_order_simple,
 		.files = (const struct keyval[]) {
 			{ SEARCH_ORDER_SIMPLE_LIB_MODULES "/correct-modules.dep",
 			  SEARCH_ORDER_SIMPLE_LIB_MODULES "/modules.dep" },
-			{ }
+			{ },
 		},
 	});
 
@@ -124,7 +124,7 @@ DEFINE_TEST(depmod_search_order_same_prefix,
 		.files = (const struct keyval[]) {
 			{ SEARCH_ORDER_SAME_PREFIX_LIB_MODULES "/correct-modules.dep",
 			  SEARCH_ORDER_SAME_PREFIX_LIB_MODULES "/modules.dep" },
-			{ }
+			{ },
 		},
 	});
 
@@ -174,7 +174,7 @@ DEFINE_TEST(depmod_search_order_external_first,
 		.files = (const struct keyval[]) {
 			{ SEARCH_ORDER_EXTERNAL_FIRST_LIB_MODULES "/correct-modules.dep",
 			  SEARCH_ORDER_EXTERNAL_FIRST_LIB_MODULES "/modules.dep" },
-			{ }
+			{ },
 		},
 	});
 
@@ -201,7 +201,7 @@ DEFINE_TEST(depmod_search_order_external_last,
 		.files = (const struct keyval[]) {
 			{ SEARCH_ORDER_EXTERNAL_LAST_LIB_MODULES "/correct-modules.dep",
 			  SEARCH_ORDER_EXTERNAL_LAST_LIB_MODULES "/modules.dep" },
-			{ }
+			{ },
 		},
 	});
 
@@ -228,7 +228,7 @@ DEFINE_TEST(depmod_search_order_override,
 		.files = (const struct keyval[]) {
 			{ SEARCH_ORDER_OVERRIDE_LIB_MODULES "/correct-modules.dep",
 			  SEARCH_ORDER_OVERRIDE_LIB_MODULES "/modules.dep" },
-			{ }
+			{ },
 		},
 	});
 
@@ -255,7 +255,7 @@ DEFINE_TEST(depmod_check_weakdep,
 		.files = (const struct keyval[]) {
 			{ CHECK_WEAKDEP_LIB_MODULES "/correct-modules.weakdep",
 			  CHECK_WEAKDEP_LIB_MODULES "/modules.weakdep" },
-			{ }
+			{ },
 		},
 	});
 

--- a/testsuite/test-testsuite.c
+++ b/testsuite/test-testsuite.c
@@ -54,7 +54,7 @@ static int testsuite_rootfs_fopen(const struct test *t)
 
 	fp = fopen(MODULE_DIRECTORY "/a", "r");
 	if (fp == NULL)
-		return EXIT_FAILURE;;
+		return EXIT_FAILURE;
 
 	n = fscanf(fp, "%s", s);
 	if (n != 1)

--- a/testsuite/test-util.c
+++ b/testsuite/test-util.c
@@ -116,7 +116,7 @@ static int test_underscores(const struct test *t)
 		{ strdup("-aa-[bb]-cc-"), "_aa_[bb]_cc_" },
 		{ strdup("-aa-[b-b]-cc-"), "_aa_[b-b]_cc_" },
 		{ strdup("-aa-b[-]b-cc"), "_aa_b[-]b_cc" },
-		{ }
+		{ },
 	}, *iter;
 
 	for (iter = &teststr[0]; iter->val != NULL; iter++) {
@@ -152,7 +152,7 @@ static int test_path_ends_with_kmod_ext(const struct test *t)
 		{ "/bla.ko.", false },
 		{ "/bla.koz", false },
 		{ "/b", false },
-		{ }
+		{ },
 	}, *iter;
 
 	for (iter = &teststr[0]; iter->val != NULL; iter++) {
@@ -193,7 +193,7 @@ DEFINE_TEST(test_write_str_safe,
 		.files = (const struct keyval[]) {
 			{ TEST_WRITE_STR_SAFE_PATH ".txt",
 			  TEST_WRITE_STR_SAFE_PATH "-correct.txt" },
-			{ }
+			{ },
 		},
 	});
 

--- a/testsuite/test-weakdep.c
+++ b/testsuite/test-weakdep.c
@@ -20,13 +20,13 @@
 
 static const char *const test_weakdep_config_paths[] = {
 	TEST_WEAKDEP_ROOTFS "etc/modprobe.d",
-	NULL
+	NULL,
 };
 
 static const char *const mod_name[] = {
 	"mod-loop-b",
 	"mod-weakdep",
-	NULL
+	NULL,
 };
 
 static int test_weakdep(const struct test *t)

--- a/testsuite/testsuite.c
+++ b/testsuite/testsuite.c
@@ -36,7 +36,7 @@ static const char options_short[] = "lhn";
 static const struct option options[] = {
 	{ "list", no_argument, 0, 'l' },
 	{ "help", no_argument, 0, 'h' },
-	{ NULL, 0, 0, 0 }
+	{ NULL, 0, 0, 0 },
 };
 
 #define TEST_TIMEOUT_USEC 2 * USEC_PER_SEC

--- a/testsuite/testsuite.h
+++ b/testsuite/testsuite.h
@@ -171,10 +171,3 @@ int test_run(const struct test *t);
 		exit(EXIT_SUCCESS);								\
 	}											\
 
-#ifdef noreturn
-# define __noreturn noreturn
-#elif __STDC_VERSION__ >= 201112L
-# define __noreturn _Noreturn
-#else
-# define __noreturn __attribute__((noreturn))
-#endif

--- a/tools/depmod.c
+++ b/tools/depmod.c
@@ -407,7 +407,7 @@ struct cfg_override {
 enum search_type {
 	SEARCH_PATH,
 	SEARCH_BUILTIN,
-	SEARCH_EXTERNAL
+	SEARCH_EXTERNAL,
 };
 
 struct cfg_search {

--- a/tools/depmod.c
+++ b/tools/depmod.c
@@ -44,7 +44,7 @@ static const char *const default_cfg_paths[] = {
 	"/usr/local/lib/depmod.d",
 	DISTCONFDIR "/depmod.d",
 	"/lib/depmod.d",
-	NULL
+	NULL,
 };
 
 static const char cmdopts_s[] = "aAb:o:C:E:F:euqrvnP:wmVh";
@@ -68,7 +68,7 @@ static const struct option cmdopts[] = {
 	{ "map", no_argument, 0, 'm' }, /* deprecated */
 	{ "version", no_argument, 0, 'V' },
 	{ "help", no_argument, 0, 'h' },
-	{ }
+	{ },
 };
 
 static void help(void)
@@ -2579,7 +2579,7 @@ static int depmod_output(struct depmod *depmod, FILE *out)
 		{ "modules.builtin.bin", output_builtin_bin },
 		{ "modules.builtin.alias.bin", output_builtin_alias_bin },
 		{ "modules.devname", output_devname },
-		{ }
+		{ },
 	};
 	const char *dname = depmod->cfg->outdirname;
 	int dfd, err = 0;

--- a/tools/insmod.c
+++ b/tools/insmod.c
@@ -19,7 +19,7 @@ static const char cmdopts_s[] = "psfVh";
 static const struct option cmdopts[] = {
 	{"version", no_argument, 0, 'V'},
 	{"help", no_argument, 0, 'h'},
-	{NULL, 0, 0, 0}
+	{NULL, 0, 0, 0},
 };
 
 static void help(void)

--- a/tools/kmod.c
+++ b/tools/kmod.c
@@ -20,7 +20,7 @@ static const char options_s[] = "+hV";
 static const struct option options[] = {
 	{ "help", no_argument, NULL, 'h' },
 	{ "version", no_argument, NULL, 'V' },
-	{}
+	{},
 };
 
 static const struct kmod_cmd kmod_cmd_help;

--- a/tools/modinfo.c
+++ b/tools/modinfo.c
@@ -338,7 +338,7 @@ static const struct option cmdopts[] = {
 	{"basedir", required_argument, 0, 'b'},
 	{"version", no_argument, 0, 'V'},
 	{"help", no_argument, 0, 'h'},
-	{NULL, 0, 0, 0}
+	{NULL, 0, 0, 0},
 };
 
 static void help(void)

--- a/tools/modprobe.c
+++ b/tools/modprobe.c
@@ -84,7 +84,7 @@ static const struct option cmdopts[] = {
 	{"verbose", no_argument, 0, 'v'},
 	{"version", no_argument, 0, 'V'},
 	{"help", no_argument, 0, 'h'},
-	{NULL, 0, 0, 0}
+	{NULL, 0, 0, 0},
 };
 
 static void help(void)

--- a/tools/rmmod.c
+++ b/tools/rmmod.c
@@ -31,7 +31,7 @@ static const struct option cmdopts[] = {
 	{"verbose", no_argument, 0, 'v'},
 	{"version", no_argument, 0, 'V'},
 	{"help", no_argument, 0, 'h'},
-	{NULL, 0, 0, 0}
+	{NULL, 0, 0, 0},
 };
 
 static void help(void)


### PR DESCRIPTION
Forking some of the cleanups/ideas from https://github.com/kmod-project/kmod/pull/91

Namely:
 - `s/;;//` in a handful of places, from Lucas
 - add trailing commas for multi-line arrays/enums, so clang-format doesn't foobar them
 - remove unused `_noreturn` macro
 - remove _must_check and -Wno-unused-result - see commit for details
 - remove open-coded `_print_format_`
 - add `_nonnull_*` variants, place them on the left hand side of the function return type
 
I threw the series together, although I'm more than happy to split it. Let me know if there's any preferences.