### PR TITLE
testsuite: use size_t with strbuf

### DIFF
--- a/testsuite/test-strbuf.c
+++ b/testsuite/test-strbuf.c
@@ -50,7 +50,7 @@ static int test_strbuf_pushchars(const struct test *t)
 	struct strbuf buf;
 	char *result1, *saveptr = NULL, *str, *result2;
 	const char *c;
-	int lastwordlen = 0;
+	size_t lastwordlen = 0;
 
 	strbuf_init(&buf);
 	str = strdup(TEXT);


### PR DESCRIPTION
We recently updated the API, but forgot to update the tests.

Fixes: 38943b2 ("shared: use size_t for strbuf")

---

Follow-up from https://github.com/kmod-project/kmod/pull/101#issuecomment-2334634793