### PR TITLE
libkmod: remove internal kmod_list iterators

### DIFF
--- a/libkmod/libkmod-internal.h
+++ b/libkmod/libkmod-internal.h
@@ -79,20 +79,6 @@ _nonnull_(2) struct kmod_list *kmod_list_insert_after(struct kmod_list *list, co
 _nonnull_(2) struct kmod_list *kmod_list_insert_before(struct kmod_list *list, const void *data);
 _must_check_ struct kmod_list *kmod_list_append_list(struct kmod_list *list1, struct kmod_list *list2);
 
-#undef kmod_list_foreach
-#define kmod_list_foreach(list_entry, first_entry) \
-	for (list_entry = ((first_entry) == NULL) ? NULL : (first_entry); \
-		list_entry != NULL; \
-		list_entry = (list_entry->node.next == &((first_entry)->node)) ? NULL : \
-		container_of(list_entry->node.next, struct kmod_list, node))
-
-#undef kmod_list_foreach_reverse
-#define kmod_list_foreach_reverse(list_entry, first_entry) \
-	for (list_entry = (((first_entry) == NULL) ? NULL : container_of(first_entry->node.prev, struct kmod_list, node)); \
-		list_entry != NULL; \
-		list_entry = ((list_entry == first_entry) ? NULL :	\
-		container_of(list_entry->node.prev, struct kmod_list, node)))
-
 /* libkmod.c */
 _nonnull_all_ int kmod_lookup_alias_from_config(struct kmod_ctx *ctx, const char *name, struct kmod_list **list);
 _nonnull_all_ int kmod_lookup_alias_from_symbols_file(struct kmod_ctx *ctx, const char *name, struct kmod_list **list);


### PR DESCRIPTION
These were introduced to workaround since the compiler cannot properly optimise things, since the symbols have external linkage.

These days this is not so much an issue. For example comparing a gcc 14 build, with -O2 shows 24 bytes growth with this reverted.

Although in practise anyone looking for extreme optimisations - be that speed or size - should be using LTO and/or PGO.