### PR TITLE
Prep and enable clang-format

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,18 @@
+name: Check code style with clang-format
+
+on:
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  stylecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - run: git fetch --depth=1 origin ${{ github.event.pull_request.base.sha }}
+      - uses: yshui/git-clang-format-lint@a65b466f5903524aef27552f63c3906c0f73f184 # v1.16
+        with:
+          base: ${{ github.event.pull_request.base.sha }}

--- a/libkmod/libkmod-builtin.c
+++ b/libkmod/libkmod-builtin.c
@@ -32,8 +32,7 @@ struct kmod_builtin_info {
 	char *buf;
 };
 
-static bool kmod_builtin_info_init(struct kmod_builtin_info *info,
-				   struct kmod_ctx *ctx)
+static bool kmod_builtin_info_init(struct kmod_builtin_info *info, struct kmod_ctx *ctx)
 {
 	char path[PATH_MAX];
 	FILE *fp = NULL;
@@ -78,7 +77,7 @@ static ssize_t get_string(struct kmod_builtin_info *info)
 }
 
 static ssize_t get_strings(struct kmod_builtin_info *info, const char *modname,
-				struct strbuf *buf)
+			   struct strbuf *buf)
 {
 	const size_t modlen = strlen(modname);
 	ssize_t count, n;
@@ -100,7 +99,7 @@ static ssize_t get_strings(struct kmod_builtin_info *info, const char *modname,
 		if (dot == NULL) {
 			count = -EINVAL;
 			ERR(info->ctx, "get_strings: "
-			    "unexpected string without modname prefix\n");
+				       "unexpected string without modname prefix\n");
 			return count;
 		}
 		if (strncmp(line, modname, modlen) || line[modlen] != '.') {
@@ -113,11 +112,10 @@ static ssize_t get_strings(struct kmod_builtin_info *info, const char *modname,
 				continue;
 			break;
 		}
-		if (!strbuf_pushchars(buf, dot + 1) ||
-		    !strbuf_pushchar(buf, '\0')) {
+		if (!strbuf_pushchars(buf, dot + 1) || !strbuf_pushchar(buf, '\0')) {
 			count = -errno;
 			ERR(info->ctx, "get_strings: "
-			    "failed to append modinfo string\n");
+				       "failed to append modinfo string\n");
 			return count;
 		}
 		count++;
@@ -126,7 +124,7 @@ static ssize_t get_strings(struct kmod_builtin_info *info, const char *modname,
 	if (count == INTPTR_MAX) {
 		count = -ENOMEM;
 		ERR(info->ctx, "get_strings: "
-		    "too many modinfo strings encountered\n");
+			       "too many modinfo strings encountered\n");
 		return count;
 	}
 
@@ -142,8 +140,7 @@ static char **strbuf_to_vector(struct strbuf *buf, size_t count)
 	size_t n;
 
 	/* make sure that vector and strings fit into memory constraints */
-	if (SIZE_MAX / sizeof(char *) - 1 < count ||
-	    SIZE_MAX - buf->used < vecsz) {
+	if (SIZE_MAX / sizeof(char *) - 1 < count || SIZE_MAX - buf->used < vecsz) {
 		errno = ENOMEM;
 		return NULL;
 	}
@@ -166,7 +163,7 @@ static char **strbuf_to_vector(struct strbuf *buf, size_t count)
 
 /* array will be allocated with strings in a single malloc, just free *array */
 ssize_t kmod_builtin_get_modinfo(struct kmod_ctx *ctx, const char *modname,
-				char ***modinfo)
+				 char ***modinfo)
 {
 	struct kmod_builtin_info info;
 	struct strbuf buf;

--- a/libkmod/libkmod-config.c
+++ b/libkmod/libkmod-config.c
@@ -55,76 +55,84 @@ const char *kmod_blacklist_get_modname(const struct kmod_list *l)
 	return l->data;
 }
 
-const char *kmod_alias_get_name(const struct kmod_list *l) {
+const char *kmod_alias_get_name(const struct kmod_list *l)
+{
 	const struct kmod_alias *alias = l->data;
 	return alias->name;
 }
 
-const char *kmod_alias_get_modname(const struct kmod_list *l) {
+const char *kmod_alias_get_modname(const struct kmod_list *l)
+{
 	const struct kmod_alias *alias = l->data;
 	return alias->modname;
 }
 
-const char *kmod_option_get_options(const struct kmod_list *l) {
+const char *kmod_option_get_options(const struct kmod_list *l)
+{
 	const struct kmod_options *alias = l->data;
 	return alias->options;
 }
 
-const char *kmod_option_get_modname(const struct kmod_list *l) {
+const char *kmod_option_get_modname(const struct kmod_list *l)
+{
 	const struct kmod_options *alias = l->data;
 	return alias->modname;
 }
 
-const char *kmod_command_get_command(const struct kmod_list *l) {
+const char *kmod_command_get_command(const struct kmod_list *l)
+{
 	const struct kmod_command *alias = l->data;
 	return alias->command;
 }
 
-const char *kmod_command_get_modname(const struct kmod_list *l) {
+const char *kmod_command_get_modname(const struct kmod_list *l)
+{
 	const struct kmod_command *alias = l->data;
 	return alias->modname;
 }
 
-const char *kmod_softdep_get_name(const struct kmod_list *l) {
+const char *kmod_softdep_get_name(const struct kmod_list *l)
+{
 	const struct kmod_softdep *dep = l->data;
 	return dep->name;
 }
 
-const char * const *kmod_softdep_get_pre(const struct kmod_list *l, unsigned int *count) {
+const char *const *kmod_softdep_get_pre(const struct kmod_list *l, unsigned int *count)
+{
 	const struct kmod_softdep *dep = l->data;
 	*count = dep->n_pre;
 	return dep->pre;
 }
 
-const char * const *kmod_softdep_get_post(const struct kmod_list *l, unsigned int *count) {
+const char *const *kmod_softdep_get_post(const struct kmod_list *l, unsigned int *count)
+{
 	const struct kmod_softdep *dep = l->data;
 	*count = dep->n_post;
 	return dep->post;
 }
 
-const char *kmod_weakdep_get_name(const struct kmod_list *l) {
+const char *kmod_weakdep_get_name(const struct kmod_list *l)
+{
 	const struct kmod_weakdep *dep = l->data;
 	return dep->name;
 }
 
-const char * const *kmod_weakdep_get_weak(const struct kmod_list *l, unsigned int *count) {
+const char *const *kmod_weakdep_get_weak(const struct kmod_list *l, unsigned int *count)
+{
 	const struct kmod_weakdep *dep = l->data;
 	*count = dep->n_weak;
 	return dep->weak;
 }
-static int kmod_config_add_command(struct kmod_config *config,
-						const char *modname,
-						const char *command,
-						const char *command_name,
-						struct kmod_list **list)
+static int kmod_config_add_command(struct kmod_config *config, const char *modname,
+				   const char *command, const char *command_name,
+				   struct kmod_list **list)
 {
 	_cleanup_free_ struct kmod_command *cmd;
 	struct kmod_list *l;
 	size_t modnamelen = strlen(modname) + 1;
 	size_t commandlen = strlen(command) + 1;
 
-	DBG(config->ctx, "modname='%s' cmd='%s %s'\n", modname, command_name,
-								command);
+	DBG(config->ctx, "modname='%s' cmd='%s %s'\n", modname, command_name, command);
 
 	cmd = malloc(sizeof(*cmd) + modnamelen + commandlen);
 	if (!cmd)
@@ -143,9 +151,8 @@ static int kmod_config_add_command(struct kmod_config *config,
 	return 0;
 }
 
-static void kmod_config_free_command(struct kmod_config *config,
-					struct kmod_list *l,
-					struct kmod_list **list)
+static void kmod_config_free_command(struct kmod_config *config, struct kmod_list *l,
+				     struct kmod_list **list)
 {
 	struct kmod_command *cmd = l->data;
 
@@ -153,8 +160,8 @@ static void kmod_config_free_command(struct kmod_config *config,
 	*list = kmod_list_remove(l);
 }
 
-static int kmod_config_add_options(struct kmod_config *config,
-				const char *modname, const char *options)
+static int kmod_config_add_options(struct kmod_config *config, const char *modname,
+				   const char *options)
 {
 	_cleanup_free_ struct kmod_options *opt;
 	struct kmod_list *list;
@@ -182,8 +189,7 @@ static int kmod_config_add_options(struct kmod_config *config,
 	return 0;
 }
 
-static void kmod_config_free_options(struct kmod_config *config,
-							struct kmod_list *l)
+static void kmod_config_free_options(struct kmod_config *config, struct kmod_list *l)
 {
 	struct kmod_options *opt = l->data;
 
@@ -192,8 +198,8 @@ static void kmod_config_free_options(struct kmod_config *config,
 	config->options = kmod_list_remove(l);
 }
 
-static int kmod_config_add_alias(struct kmod_config *config,
-					const char *name, const char *modname)
+static int kmod_config_add_alias(struct kmod_config *config, const char *name,
+				 const char *modname)
 {
 	_cleanup_free_ struct kmod_alias *alias;
 	struct kmod_list *list;
@@ -219,8 +225,7 @@ static int kmod_config_add_alias(struct kmod_config *config,
 	return 0;
 }
 
-static void kmod_config_free_alias(struct kmod_config *config,
-							struct kmod_list *l)
+static void kmod_config_free_alias(struct kmod_config *config, struct kmod_list *l)
 {
 	struct kmod_alias *alias = l->data;
 
@@ -229,8 +234,7 @@ static void kmod_config_free_alias(struct kmod_config *config,
 	config->aliases = kmod_list_remove(l);
 }
 
-static int kmod_config_add_blacklist(struct kmod_config *config,
-							const char *modname)
+static int kmod_config_add_blacklist(struct kmod_config *config, const char *modname)
 {
 	_cleanup_free_ char *p;
 	struct kmod_list *list;
@@ -250,16 +254,14 @@ static int kmod_config_add_blacklist(struct kmod_config *config,
 	return 0;
 }
 
-static void kmod_config_free_blacklist(struct kmod_config *config,
-							struct kmod_list *l)
+static void kmod_config_free_blacklist(struct kmod_config *config, struct kmod_list *l)
 {
 	free(l->data);
 	config->blacklists = kmod_list_remove(l);
 }
 
-static int kmod_config_add_softdep(struct kmod_config *config,
-							const char *modname,
-							const char *line)
+static int kmod_config_add_softdep(struct kmod_config *config, const char *modname,
+				   const char *line)
 {
 	struct kmod_list *list;
 	struct kmod_softdep *dep;
@@ -274,7 +276,7 @@ static int kmod_config_add_softdep(struct kmod_config *config,
 	DBG(config->ctx, "modname=%s\n", modname);
 
 	/* analyze and count */
-	for (p = s = line; ; s++) {
+	for (p = s = line;; s++) {
 		size_t plen;
 
 		if (*s != '\0') {
@@ -295,10 +297,10 @@ static int kmod_config_add_softdep(struct kmod_config *config,
 		plen = s - p;
 
 		if (plen == sizeof("pre:") - 1 &&
-				memcmp(p, "pre:", sizeof("pre:") - 1) == 0)
+		    memcmp(p, "pre:", sizeof("pre:") - 1) == 0)
 			mode = S_PRE;
 		else if (plen == sizeof("post:") - 1 &&
-				memcmp(p, "post:", sizeof("post:") - 1) == 0)
+			 memcmp(p, "post:", sizeof("post:") - 1) == 0)
 			mode = S_POST;
 		else if (*s != '\0' || (*s == '\0' && !was_space)) {
 			if (mode == S_PRE) {
@@ -317,8 +319,7 @@ static int kmod_config_add_softdep(struct kmod_config *config,
 	DBG(config->ctx, "%u pre, %u post\n", n_pre, n_post);
 
 	dep = malloc(sizeof(struct kmod_softdep) + modnamelen +
-		     n_pre * sizeof(const char *) +
-		     n_post * sizeof(const char *) +
+		     n_pre * sizeof(const char *) + n_post * sizeof(const char *) +
 		     buflen);
 	if (dep == NULL) {
 		ERR(config->ctx, "out-of-memory modname=%s\n", modname);
@@ -338,7 +339,7 @@ static int kmod_config_add_softdep(struct kmod_config *config,
 	n_post = 0;
 	mode = S_NONE;
 	was_space = false;
-	for (p = s = line; ; s++) {
+	for (p = s = line;; s++) {
 		size_t plen;
 
 		if (*s != '\0') {
@@ -359,10 +360,10 @@ static int kmod_config_add_softdep(struct kmod_config *config,
 		plen = s - p;
 
 		if (plen == sizeof("pre:") - 1 &&
-				memcmp(p, "pre:", sizeof("pre:") - 1) == 0)
+		    memcmp(p, "pre:", sizeof("pre:") - 1) == 0)
 			mode = S_PRE;
 		else if (plen == sizeof("post:") - 1 &&
-				memcmp(p, "post:", sizeof("post:") - 1) == 0)
+			 memcmp(p, "post:", sizeof("post:") - 1) == 0)
 			mode = S_POST;
 		else if (*s != '\0' || (*s == '\0' && !was_space)) {
 			if (mode == S_PRE) {
@@ -394,9 +395,8 @@ static int kmod_config_add_softdep(struct kmod_config *config,
 	return 0;
 }
 
-static int kmod_config_add_weakdep(struct kmod_config *config,
-							const char *modname,
-							const char *line)
+static int kmod_config_add_weakdep(struct kmod_config *config, const char *modname,
+				   const char *line)
 {
 	struct kmod_list *list;
 	struct kmod_weakdep *dep;
@@ -410,7 +410,7 @@ static int kmod_config_add_weakdep(struct kmod_config *config,
 	DBG(config->ctx, "modname=%s\n", modname);
 
 	/* analyze and count */
-	for (p = s = line; ; s++) {
+	for (p = s = line;; s++) {
 		size_t plen;
 
 		if (*s != '\0') {
@@ -442,8 +442,7 @@ static int kmod_config_add_weakdep(struct kmod_config *config,
 	DBG(config->ctx, "%u weak\n", n_weak);
 
 	dep = malloc(sizeof(struct kmod_weakdep) + modnamelen +
-		     n_weak * sizeof(const char *) +
-		     buflen);
+		     n_weak * sizeof(const char *) + buflen);
 	if (dep == NULL) {
 		ERR(config->ctx, "out-of-memory modname=%s\n", modname);
 		return -ENOMEM;
@@ -458,7 +457,7 @@ static int kmod_config_add_weakdep(struct kmod_config *config,
 	itr = dep->name + modnamelen;
 	n_weak = 0;
 	was_space = false;
-	for (p = s = line; ; s++) {
+	for (p = s = line;; s++) {
 		size_t plen;
 
 		if (*s != '\0') {
@@ -500,7 +499,8 @@ static int kmod_config_add_weakdep(struct kmod_config *config,
 	return 0;
 }
 
-static char *softdep_to_char(struct kmod_softdep *dep) {
+static char *softdep_to_char(struct kmod_softdep *dep)
+{
 	const size_t sz_preprefix = sizeof("pre: ") - 1;
 	const size_t sz_postprefix = sizeof("post: ") - 1;
 	size_t sz = 1; /* at least '\0' */
@@ -514,8 +514,7 @@ static char *softdep_to_char(struct kmod_softdep *dep) {
 	 */
 	if (dep->n_pre > 0) {
 		start = dep->pre[0];
-		end = dep->pre[dep->n_pre - 1]
-					+ strlen(dep->pre[dep->n_pre - 1]);
+		end = dep->pre[dep->n_pre - 1] + strlen(dep->pre[dep->n_pre - 1]);
 		sz_pre = end - start;
 		sz += sz_pre + sz_preprefix;
 	} else
@@ -523,8 +522,7 @@ static char *softdep_to_char(struct kmod_softdep *dep) {
 
 	if (dep->n_post > 0) {
 		start = dep->post[0];
-		end = dep->post[dep->n_post - 1]
-					+ strlen(dep->post[dep->n_post - 1]);
+		end = dep->post[dep->n_post - 1] + strlen(dep->post[dep->n_post - 1]);
 		sz_post = end - start;
 		sz += sz_post + sz_postprefix;
 	} else
@@ -569,7 +567,8 @@ static char *softdep_to_char(struct kmod_softdep *dep) {
 	return s;
 }
 
-static char *weakdep_to_char(struct kmod_weakdep *dep) {
+static char *weakdep_to_char(struct kmod_weakdep *dep)
+{
 	size_t sz;
 	const char *start, *end;
 	char *s, *itr;
@@ -580,8 +579,7 @@ static char *weakdep_to_char(struct kmod_weakdep *dep) {
 	 */
 	if (dep->n_weak > 0) {
 		start = dep->weak[0];
-		end = dep->weak[dep->n_weak - 1]
-					+ strlen(dep->weak[dep->n_weak - 1]);
+		end = dep->weak[dep->n_weak - 1] + strlen(dep->weak[dep->n_weak - 1]);
 		sz = end - start;
 	} else
 		sz = 0;
@@ -607,22 +605,20 @@ static char *weakdep_to_char(struct kmod_weakdep *dep) {
 	return s;
 }
 
-static void kmod_config_free_softdep(struct kmod_config *config,
-							struct kmod_list *l)
+static void kmod_config_free_softdep(struct kmod_config *config, struct kmod_list *l)
 {
 	free(l->data);
 	config->softdeps = kmod_list_remove(l);
 }
 
-static void kmod_config_free_weakdep(struct kmod_config *config,
-							struct kmod_list *l)
+static void kmod_config_free_weakdep(struct kmod_config *config, struct kmod_list *l)
 {
 	free(l->data);
 	config->weakdeps = kmod_list_remove(l);
 }
 
-static void kcmdline_parse_result(struct kmod_config *config, char *modname,
-						char *param, char *value)
+static void kcmdline_parse_result(struct kmod_config *config, char *modname, char *param,
+				  char *value)
 {
 	if (modname == NULL || param == NULL)
 		return;
@@ -639,7 +635,8 @@ static void kcmdline_parse_result(struct kmod_config *config, char *modname,
 		}
 	} else {
 		if (underscores(modname) < 0) {
-			ERR(config->ctx, "Ignoring bad option on kernel command line while parsing module name: '%s'\n",
+			ERR(config->ctx,
+			    "Ignoring bad option on kernel command line while parsing module name: '%s'\n",
 			    modname);
 		} else {
 			kmod_config_add_options(config, modname, param);
@@ -651,7 +648,7 @@ static int kmod_config_parse_kcmdline(struct kmod_config *config)
 {
 	char buf[KCMD_LINE_SIZE];
 	int fd, err;
-	char *p, *p_quote_start, *modname,  *param = NULL, *value = NULL;
+	char *p, *p_quote_start, *modname, *param = NULL, *value = NULL;
 	bool is_quoted = false, iter = true;
 	enum state {
 		STATE_IGNORE,
@@ -661,7 +658,7 @@ static int kmod_config_parse_kcmdline(struct kmod_config *config)
 		STATE_COMPLETE,
 	} state;
 
-	fd = open("/proc/cmdline", O_RDONLY|O_CLOEXEC);
+	fd = open("/proc/cmdline", O_RDONLY | O_CLOEXEC);
 	if (fd < 0) {
 		err = -errno;
 		DBG(config->ctx, "could not open '/proc/cmdline' for reading: %m\n");
@@ -672,7 +669,7 @@ static int kmod_config_parse_kcmdline(struct kmod_config *config)
 	close(fd);
 	if (err < 0) {
 		ERR(config->ctx, "could not read from '/proc/cmdline': %s\n",
-							strerror(-err));
+		    strerror(-err));
 		return err;
 	}
 
@@ -762,7 +759,9 @@ static int kmod_config_parse_kcmdline(struct kmod_config *config)
 				 * vv        v      v
 				 * "parport\0dyndbg=file drivers/parport/ieee1284_ops.c +mpf" */
 				memmove(p_quote_start, modname, value - modname);
-				value--; modname--; param--;
+				value--;
+				modname--;
+				param--;
 				*value = '"';
 			}
 			kcmdline_parse_result(config, modname, param, value);
@@ -780,8 +779,7 @@ static int kmod_config_parse_kcmdline(struct kmod_config *config)
  * Take an fd and own it. It will be closed on return. filename is used only
  * for debug messages
  */
-static int kmod_config_parse(struct kmod_config *config, int fd,
-							const char *filename)
+static int kmod_config_parse(struct kmod_config *config, int fd, const char *filename)
 {
 	struct kmod_ctx *ctx = config->ctx;
 	char *line;
@@ -837,8 +835,8 @@ static int kmod_config_parse(struct kmod_config *config, int fd,
 			if (underscores(modname) < 0 || installcmd == NULL)
 				goto syntax_error;
 
-			kmod_config_add_command(config, modname, installcmd,
-					cmd, &config->install_commands);
+			kmod_config_add_command(config, modname, installcmd, cmd,
+						&config->install_commands);
 		} else if (streq(cmd, "remove")) {
 			char *modname = strtok_r(NULL, "\t ", &saveptr);
 			char *removecmd = strtok_r(NULL, "\0", &saveptr);
@@ -846,8 +844,8 @@ static int kmod_config_parse(struct kmod_config *config, int fd,
 			if (underscores(modname) < 0 || removecmd == NULL)
 				goto syntax_error;
 
-			kmod_config_add_command(config, modname, removecmd,
-					cmd, &config->remove_commands);
+			kmod_config_add_command(config, modname, removecmd, cmd,
+						&config->remove_commands);
 		} else if (streq(cmd, "softdep")) {
 			char *modname = strtok_r(NULL, "\t ", &saveptr);
 			char *softdeps = strtok_r(NULL, "\0", &saveptr);
@@ -864,14 +862,13 @@ static int kmod_config_parse(struct kmod_config *config, int fd,
 				goto syntax_error;
 
 			kmod_config_add_weakdep(config, modname, weakdeps);
-		} else if (streq(cmd, "include")
-				|| streq(cmd, "config")) {
+		} else if (streq(cmd, "include") || streq(cmd, "config")) {
 			ERR(ctx, "%s: command %s is deprecated and not parsed anymore\n",
-								filename, cmd);
+			    filename, cmd);
 		} else {
 syntax_error:
 			ERR(ctx, "%s line %u: ignoring bad line starting with '%s'\n",
-						filename, linenum, cmd);
+			    filename, linenum, cmd);
 		}
 
 done_next:
@@ -896,12 +893,12 @@ void kmod_config_free(struct kmod_config *config)
 
 	while (config->install_commands) {
 		kmod_config_free_command(config, config->install_commands,
-						&config->install_commands);
+					 &config->install_commands);
 	}
 
 	while (config->remove_commands) {
 		kmod_config_free_command(config, config->remove_commands,
-						&config->remove_commands);
+					 &config->remove_commands);
 	}
 
 	while (config->softdeps)
@@ -910,15 +907,14 @@ void kmod_config_free(struct kmod_config *config)
 	while (config->weakdeps)
 		kmod_config_free_weakdep(config, config->weakdeps);
 
-	for (; config->paths != NULL;
-				config->paths = kmod_list_remove(config->paths))
+	for (; config->paths != NULL; config->paths = kmod_list_remove(config->paths))
 		free(config->paths->data);
 
 	free(config);
 }
 
-static bool conf_files_filter_out(struct kmod_ctx *ctx, DIR *d,
-					const char *path, const char *fn)
+static bool conf_files_filter_out(struct kmod_ctx *ctx, DIR *d, const char *path,
+				  const char *fn)
 {
 	size_t len = strlen(fn);
 	struct stat st;
@@ -935,8 +931,10 @@ static bool conf_files_filter_out(struct kmod_ctx *ctx, DIR *d,
 	}
 
 	if (S_ISDIR(st.st_mode)) {
-		ERR(ctx, "Directories inside directories are not supported: "
-							"%s/%s\n", path, fn);
+		ERR(ctx,
+		    "Directories inside directories are not supported: "
+		    "%s/%s\n",
+		    path, fn);
 		return true;
 	}
 
@@ -949,9 +947,8 @@ struct conf_file {
 	char name[];
 };
 
-static int conf_files_insert_sorted(struct kmod_ctx *ctx,
-					struct kmod_list **list,
-					const char *path, const char *name)
+static int conf_files_insert_sorted(struct kmod_ctx *ctx, struct kmod_list **list,
+				    const char *path, const char *name)
 {
 	struct kmod_list *lpos, *tmp;
 	struct conf_file *cf;
@@ -972,8 +969,7 @@ static int conf_files_insert_sorted(struct kmod_ctx *ctx,
 	}
 
 	if (cmp == 0) {
-		DBG(ctx, "Ignoring duplicate config file: %s/%s\n", path,
-									name);
+		DBG(ctx, "Ignoring duplicate config file: %s/%s\n", path, name);
 		return -EEXIST;
 	}
 
@@ -1008,8 +1004,7 @@ static int conf_files_insert_sorted(struct kmod_ctx *ctx,
  * Insert configuration files in @list, ignoring duplicates
  */
 static int conf_files_list(struct kmod_ctx *ctx, struct kmod_list **list,
-						const char *path,
-						unsigned long long *path_stamp)
+			   const char *path, unsigned long long *path_stamp)
 {
 	DIR *d;
 	int err;
@@ -1047,7 +1042,7 @@ static int conf_files_list(struct kmod_ctx *ctx, struct kmod_list **list,
 }
 
 int kmod_config_new(struct kmod_ctx *ctx, struct kmod_config **p_config,
-					const char * const *config_paths)
+		    const char *const *config_paths)
 {
 	struct kmod_config *config;
 	struct kmod_list *list = NULL;
@@ -1098,15 +1093,15 @@ int kmod_config_new(struct kmod_ctx *ctx, struct kmod_config **p_config,
 
 		if (cf->is_single) {
 			fn = cf->path;
-		} else if (snprintf(buf, sizeof(buf), "%s/%s",
-				    cf->path, cf->name) >= (int)sizeof(buf)) {
-			ERR(ctx, "Error parsing %s/%s: path too long\n",
-			    cf->path, cf->name);
+		} else if (snprintf(buf, sizeof(buf), "%s/%s", cf->path, cf->name) >=
+			   (int)sizeof(buf)) {
+			ERR(ctx, "Error parsing %s/%s: path too long\n", cf->path,
+			    cf->name);
 			free(cf);
 			continue;
 		}
 
-		fd = open(fn, O_RDONLY|O_CLOEXEC);
+		fd = open(fn, O_RDONLY | O_CLOEXEC);
 		DBG(ctx, "parsing file '%s' fd=%d\n", fn, fd);
 
 		if (fd >= 0)
@@ -1165,8 +1160,8 @@ static const char *weakdep_get_plain_weakdep(const struct kmod_list *l)
 	return s;
 }
 
-static struct kmod_config_iter *kmod_config_iter_new(const struct kmod_ctx* ctx,
-							enum config_type type)
+static struct kmod_config_iter *kmod_config_iter_new(const struct kmod_ctx *ctx,
+						     enum config_type type)
 {
 	struct kmod_config_iter *iter = calloc(1, sizeof(*iter));
 	const struct kmod_config *config = kmod_get_config(ctx);
@@ -1300,7 +1295,7 @@ KMOD_EXPORT const char *kmod_config_iter_get_value(const struct kmod_config_iter
 		struct kmod_config_iter *i = (struct kmod_config_iter *)iter;
 
 		free(i->data);
-		s = i->data = (void *) iter->get_value(iter->curr);
+		s = i->data = (void *)iter->get_value(iter->curr);
 	} else
 		s = iter->get_value(iter->curr);
 

--- a/libkmod/libkmod-elf.c
+++ b/libkmod/libkmod-elf.c
@@ -56,17 +56,15 @@ struct kmod_elf {
 //#define ENABLE_ELFDBG 1
 
 #if defined(ENABLE_LOGGING) && defined(ENABLE_ELFDBG)
-#define ELFDBG(elf, ...)			\
-	_elf_dbg(elf, __FILE__, __LINE__, __func__, __VA_ARGS__);
+#define ELFDBG(elf, ...) _elf_dbg(elf, __FILE__, __LINE__, __func__, __VA_ARGS__);
 
-static inline void _elf_dbg(const struct kmod_elf *elf, const char *fname, unsigned line, const char *func, const char *fmt, ...)
+static inline void _elf_dbg(const struct kmod_elf *elf, const char *fname, unsigned line,
+			    const char *func, const char *fmt, ...)
 {
 	va_list args;
 
-	fprintf(stderr, "ELFDBG-%d%c: %s:%u %s() ",
-		(elf->class & KMOD_ELF_32) ? 32 : 64,
-		(elf->class & KMOD_ELF_MSB) ? 'M' : 'L',
-		fname, line, func);
+	fprintf(stderr, "ELFDBG-%d%c: %s:%u %s() ", (elf->class & KMOD_ELF_32) ? 32 : 64,
+		(elf->class & KMOD_ELF_MSB) ? 'M' : 'L', fname, line, func);
 	va_start(args, fmt);
 	vfprintf(stderr, fmt, args);
 	va_end(args);
@@ -74,7 +72,6 @@ static inline void _elf_dbg(const struct kmod_elf *elf, const char *fname, unsig
 #else
 #define ELFDBG(elf, ...)
 #endif
-
 
 static int elf_identify(const void *memory, uint64_t size)
 {
@@ -113,7 +110,8 @@ static int elf_identify(const void *memory, uint64_t size)
 	return class;
 }
 
-static inline uint64_t elf_get_uint(const struct kmod_elf *elf, uint64_t offset, uint16_t size)
+static inline uint64_t elf_get_uint(const struct kmod_elf *elf, uint64_t offset,
+				    uint16_t size)
 {
 	const uint8_t *p;
 	uint64_t ret = 0;
@@ -122,7 +120,9 @@ static inline uint64_t elf_get_uint(const struct kmod_elf *elf, uint64_t offset,
 	assert(size <= sizeof(uint64_t));
 	assert(offset + size <= elf->size);
 	if (offset + size > elf->size) {
-		ELFDBG(elf, "out of bounds: %"PRIu64" + %"PRIu16" = %"PRIu64"> %"PRIu64" (ELF size)\n",
+		ELFDBG(elf,
+		       "out of bounds: %" PRIu64 " + %" PRIu16 " = %" PRIu64 "> %" PRIu64
+		       " (ELF size)\n",
 		       offset, size, offset + size, elf->size);
 		return (uint64_t)-1;
 	}
@@ -136,24 +136,28 @@ static inline uint64_t elf_get_uint(const struct kmod_elf *elf, uint64_t offset,
 			ret = (ret << 8) | p[size - i];
 	}
 
-	ELFDBG(elf, "size=%"PRIu16" offset=%"PRIu64" value=%"PRIu64"\n",
-	       size, offset, ret);
+	ELFDBG(elf, "size=%" PRIu16 " offset=%" PRIu64 " value=%" PRIu64 "\n", size,
+	       offset, ret);
 
 	return ret;
 }
 
-static inline int elf_set_uint(struct kmod_elf *elf, uint64_t offset, uint64_t size, uint64_t value)
+static inline int elf_set_uint(struct kmod_elf *elf, uint64_t offset, uint64_t size,
+			       uint64_t value)
 {
 	uint8_t *p;
 	size_t i;
 
-	ELFDBG(elf, "size=%"PRIu16" offset=%"PRIu64" value=%"PRIu64" write memory=%p\n",
+	ELFDBG(elf,
+	       "size=%" PRIu16 " offset=%" PRIu64 " value=%" PRIu64 " write memory=%p\n",
 	       size, offset, value, elf->changed);
 
 	assert(size <= sizeof(uint64_t));
 	assert(offset + size <= elf->size);
 	if (offset + size > elf->size) {
-		ELFDBG(elf, "out of bounds: %"PRIu64" + %"PRIu16" = %"PRIu64"> %"PRIu64" (ELF size)\n",
+		ELFDBG(elf,
+		       "out of bounds: %" PRIu64 " + %" PRIu16 " = %" PRIu64 "> %" PRIu64
+		       " (ELF size)\n",
 		       offset, size, offset + size, elf->size);
 		return -1;
 	}
@@ -187,7 +191,7 @@ static inline const void *elf_get_mem(const struct kmod_elf *elf, uint64_t offse
 {
 	assert(offset < elf->size);
 	if (offset >= elf->size) {
-		ELFDBG(elf, "out-of-bounds: %"PRIu64" >= %"PRIu64" (ELF size)\n",
+		ELFDBG(elf, "out-of-bounds: %" PRIu64 " >= %" PRIu64 " (ELF size)\n",
 		       offset, elf->size);
 		return NULL;
 	}
@@ -199,21 +203,23 @@ static inline const void *elf_get_section_header(const struct kmod_elf *elf, uin
 	assert(idx != SHN_UNDEF);
 	assert(idx < elf->header.section.count);
 	if (idx == SHN_UNDEF || idx >= elf->header.section.count) {
-		ELFDBG(elf, "invalid section number: %"PRIu16", last=%"PRIu16"\n",
+		ELFDBG(elf, "invalid section number: %" PRIu16 ", last=%" PRIu16 "\n",
 		       idx, elf->header.section.count);
 		return NULL;
 	}
 	return elf_get_mem(elf, elf->header.section.offset +
-			   (uint64_t)(idx * elf->header.section.entry_size));
+					(uint64_t)(idx * elf->header.section.entry_size));
 }
 
-static inline int elf_get_section_info(const struct kmod_elf *elf, uint16_t idx, uint64_t *offset, uint64_t *size, uint32_t *nameoff)
+static inline int elf_get_section_info(const struct kmod_elf *elf, uint16_t idx,
+				       uint64_t *offset, uint64_t *size,
+				       uint32_t *nameoff)
 {
 	const uint8_t *p = elf_get_section_header(elf, idx);
 	uint64_t min_size, off = p - elf->memory;
 
 	if (p == NULL) {
-		ELFDBG(elf, "no section at %"PRIu16"\n", idx);
+		ELFDBG(elf, "no section at %" PRIu16 "\n", idx);
 		*offset = 0;
 		*size = 0;
 		*nameoff = 0;
@@ -236,14 +242,15 @@ static inline int elf_get_section_info(const struct kmod_elf *elf, uint16_t idx,
 	}
 #undef READV
 
-	if (addu64_overflow(*offset, *size, &min_size)
-	    || min_size > elf->size) {
-		ELFDBG(elf, "out-of-bounds: %"PRIu64" >= %"PRIu64" (ELF size)\n",
+	if (addu64_overflow(*offset, *size, &min_size) || min_size > elf->size) {
+		ELFDBG(elf, "out-of-bounds: %" PRIu64 " >= %" PRIu64 " (ELF size)\n",
 		       min_size, elf->size);
 		return -EINVAL;
 	}
 
-	ELFDBG(elf, "section=%"PRIu16" is: offset=%"PRIu64" size=%"PRIu64" nameoff=%"PRIu32"\n",
+	ELFDBG(elf,
+	       "section=%" PRIu16 " is: offset=%" PRIu64 " size=%" PRIu64
+	       " nameoff=%" PRIu32 "\n",
 	       idx, *offset, *size, *nameoff);
 
 	return 0;
@@ -288,14 +295,13 @@ struct kmod_elf *kmod_elf_new(const void *memory, off_t size)
 	elf->size = size;
 	elf->class = class;
 
-#define READV(field) \
-	elf_get_uint(elf, offsetof(typeof(*hdr), field), sizeof(hdr->field))
+#define READV(field) elf_get_uint(elf, offsetof(typeof(*hdr), field), sizeof(hdr->field))
 
-#define LOAD_HEADER						\
-	elf->header.section.offset = READV(e_shoff);		\
-	elf->header.section.count = READV(e_shnum);		\
-	elf->header.section.entry_size = READV(e_shentsize);	\
-	elf->header.strings.section = READV(e_shstrndx);	\
+#define LOAD_HEADER                                          \
+	elf->header.section.offset = READV(e_shoff);         \
+	elf->header.section.count = READV(e_shnum);          \
+	elf->header.section.entry_size = READV(e_shentsize); \
+	elf->header.strings.section = READV(e_shstrndx);     \
 	elf->header.machine = READV(e_machine)
 	if (elf->class & KMOD_ELF_32) {
 		const Elf32_Ehdr *hdr _unused_ = elf_get_mem(elf, 0);
@@ -309,28 +315,29 @@ struct kmod_elf *kmod_elf_new(const void *memory, off_t size)
 #undef LOAD_HEADER
 #undef READV
 
-	ELFDBG(elf, "section: offset=%"PRIu64" count=%"PRIu16" entry_size=%"PRIu16" strings index=%"PRIu16"\n",
-	       elf->header.section.offset,
-	       elf->header.section.count,
-	       elf->header.section.entry_size,
-	       elf->header.strings.section);
+	ELFDBG(elf,
+	       "section: offset=%" PRIu64 " count=%" PRIu16 " entry_size=%" PRIu16
+	       " strings index=%" PRIu16 "\n",
+	       elf->header.section.offset, elf->header.section.count,
+	       elf->header.section.entry_size, elf->header.strings.section);
 
 	if (elf->header.section.entry_size != shdr_size) {
-		ELFDBG(elf, "unexpected section entry size: %"PRIu16", expected %"PRIu16"\n",
+		ELFDBG(elf,
+		       "unexpected section entry size: %" PRIu16 ", expected %" PRIu16
+		       "\n",
 		       elf->header.section.entry_size, shdr_size);
 		goto invalid;
 	}
 	shdrs_size = shdr_size * elf->header.section.count;
-	if (addu64_overflow(shdrs_size, elf->header.section.offset, &min_size)
-	    || min_size > elf->size) {
+	if (addu64_overflow(shdrs_size, elf->header.section.offset, &min_size) ||
+	    min_size > elf->size) {
 		ELFDBG(elf, "file is too short to hold sections\n");
 		goto invalid;
 	}
 
 	if (elf_get_section_info(elf, elf->header.strings.section,
-					&elf->header.strings.offset,
-					&elf->header.strings.size,
-					&elf->header.strings.nameoff) < 0) {
+				 &elf->header.strings.offset, &elf->header.strings.size,
+				 &elf->header.strings.nameoff) < 0) {
 		ELFDBG(elf, "could not get strings section\n");
 		goto invalid;
 	} else {
@@ -386,7 +393,8 @@ static int elf_find_section(const struct kmod_elf *elf, const char *section)
 	return -ENODATA;
 }
 
-int kmod_elf_get_section(const struct kmod_elf *elf, const char *section, const void **buf, uint64_t *buf_size)
+int kmod_elf_get_section(const struct kmod_elf *elf, const char *section,
+			 const void **buf, uint64_t *buf_size)
 {
 	uint64_t nameslen;
 	const char *names = elf_get_strings_section(elf, &nameslen);
@@ -445,7 +453,7 @@ int kmod_elf_get_strings(const struct kmod_elf *elf, const char *section, char *
 	if (size <= 1)
 		return 0;
 
-	for (i = 0, count = 0; i < size; ) {
+	for (i = 0, count = 0; i < size;) {
 		if (strings[i] != '\0') {
 			i++;
 			continue;
@@ -472,7 +480,7 @@ int kmod_elf_get_strings(const struct kmod_elf *elf, const char *section, char *
 	a[count] = NULL;
 	a[0] = s;
 
-	for (i = 0, j = 1; j < count && i < size; ) {
+	for (i = 0, j = 1; j < count && i < size;) {
 		if (s[i] != '\0') {
 			i++;
 			continue;
@@ -499,8 +507,7 @@ int kmod_elf_get_modversions(const struct kmod_elf *elf, struct kmod_modversion 
 	int i, count, err;
 #define MODVERSION_SEC_SIZE (sizeof(struct kmod_modversion64))
 
-	assert_cc(sizeof(struct kmod_modversion64) ==
-					sizeof(struct kmod_modversion32));
+	assert_cc(sizeof(struct kmod_modversion64) == sizeof(struct kmod_modversion32));
 
 	if (elf->class & KMOD_ELF_32)
 		offcrc = sizeof(uint32_t);
@@ -637,8 +644,7 @@ int kmod_elf_strip_vermagic(struct kmod_elf *elf)
 		}
 
 		len = strlen(s);
-		ELFDBG(elf, "clear .modinfo vermagic \"%s\" (%zd bytes)\n",
-		       s, len);
+		ELFDBG(elf, "clear .modinfo vermagic \"%s\" (%zd bytes)\n", s, len);
 		memset(elf->changed + off, '\0', len);
 		return 0;
 	}
@@ -647,8 +653,8 @@ int kmod_elf_strip_vermagic(struct kmod_elf *elf)
 	return -ENODATA;
 }
 
-
-static int kmod_elf_get_symbols_symtab(const struct kmod_elf *elf, struct kmod_modversion **array)
+static int kmod_elf_get_symbols_symtab(const struct kmod_elf *elf,
+				       struct kmod_modversion **array)
 {
 	uint64_t i, last, size;
 	const void *buf;
@@ -738,7 +744,8 @@ static inline uint8_t kmod_symbol_bind_from_elf(uint8_t elf_value)
 	}
 }
 
-static uint64_t kmod_elf_resolve_crc(const struct kmod_elf *elf, uint64_t crc, uint16_t shndx)
+static uint64_t kmod_elf_resolve_crc(const struct kmod_elf *elf, uint64_t crc,
+				     uint16_t shndx)
 {
 	int err;
 	uint64_t off, size;
@@ -749,12 +756,13 @@ static uint64_t kmod_elf_resolve_crc(const struct kmod_elf *elf, uint64_t crc, u
 
 	err = elf_get_section_info(elf, shndx, &off, &size, &nameoff);
 	if (err < 0) {
-		ELFDBG("Could not find section index %"PRIu16" for crc", shndx);
+		ELFDBG("Could not find section index %" PRIu16 " for crc", shndx);
 		return (uint64_t)-1;
 	}
 
 	if (crc > (size - sizeof(uint32_t))) {
-		ELFDBG("CRC offset %"PRIu64" is too big, section %"PRIu16" size is %"PRIu64"\n",
+		ELFDBG("CRC offset %" PRIu64 " is too big, section %" PRIu16
+		       " size is %" PRIu64 "\n",
 		       crc, shndx, size);
 		return (uint64_t)-1;
 	}
@@ -793,7 +801,10 @@ int kmod_elf_get_symbols(const struct kmod_elf *elf, struct kmod_modversion **ar
 		symlen = sizeof(Elf64_Sym);
 
 	if (symtablen % symlen != 0) {
-		ELFDBG(elf, "unexpected .symtab of length %"PRIu64", not multiple of %"PRIu64" as expected.\n", symtablen, symlen);
+		ELFDBG(elf,
+		       "unexpected .symtab of length %" PRIu64
+		       ", not multiple of %" PRIu64 " as expected.\n",
+		       symtablen, symlen);
 		goto fallback;
 	}
 
@@ -806,9 +817,8 @@ int kmod_elf_get_symbols(const struct kmod_elf *elf, struct kmod_modversion **ar
 		const char *name;
 		uint32_t name_off;
 
-#define READV(field)							\
-		elf_get_uint(elf, sym_off + offsetof(typeof(*s), field),\
-			     sizeof(s->field))
+#define READV(field) \
+	elf_get_uint(elf, sym_off + offsetof(typeof(*s), field), sizeof(s->field))
 		if (elf->class & KMOD_ELF_32) {
 			Elf32_Sym *s;
 			name_off = READV(st_name);
@@ -818,7 +828,11 @@ int kmod_elf_get_symbols(const struct kmod_elf *elf, struct kmod_modversion **ar
 		}
 #undef READV
 		if (name_off >= strtablen) {
-			ELFDBG(elf, ".strtab is %"PRIu64" bytes, but .symtab entry %d wants to access offset %"PRIu32".\n", strtablen, i, name_off);
+			ELFDBG(elf,
+			       ".strtab is %" PRIu64
+			       " bytes, but .symtab entry %d wants to access offset %" PRIu32
+			       ".\n",
+			       strtablen, i, name_off);
 			goto fallback;
 		}
 
@@ -848,9 +862,8 @@ int kmod_elf_get_symbols(const struct kmod_elf *elf, struct kmod_modversion **ar
 		uint8_t info, bind;
 		uint16_t shndx;
 
-#define READV(field)							\
-		elf_get_uint(elf, sym_off + offsetof(typeof(*s), field),\
-			     sizeof(s->field))
+#define READV(field) \
+	elf_get_uint(elf, sym_off + offsetof(typeof(*s), field), sizeof(s->field))
 		if (elf->class & KMOD_ELF_32) {
 			Elf32_Sym *s;
 			name_off = READV(st_name);
@@ -891,7 +904,8 @@ fallback:
 	return kmod_elf_get_symbols_symtab(elf, array);
 }
 
-static int kmod_elf_crc_find(const struct kmod_elf *elf, const void *versions, uint64_t versionslen, const char *name, uint64_t *crc)
+static int kmod_elf_crc_find(const struct kmod_elf *elf, const void *versions,
+			     uint64_t versionslen, const char *name, uint64_t *crc)
 {
 	size_t verlen, crclen, off;
 	uint64_t i;
@@ -922,11 +936,12 @@ static int kmod_elf_crc_find(const struct kmod_elf *elf, const void *versions, u
 
 /* from module-init-tools:elfops_core.c */
 #ifndef STT_REGISTER
-#define STT_REGISTER    13              /* Global register reserved to app. */
+#define STT_REGISTER 13 /* Global register reserved to app. */
 #endif
 
 /* array will be allocated with strings in a single malloc, just free *array */
-int kmod_elf_get_dependency_symbols(const struct kmod_elf *elf, struct kmod_modversion **array)
+int kmod_elf_get_dependency_symbols(const struct kmod_elf *elf,
+				    struct kmod_modversion **array)
 {
 	uint64_t versionslen, strtablen, symtablen, str_off, sym_off, ver_off;
 	const void *versions, *strtab, *symtab;
@@ -955,7 +970,10 @@ int kmod_elf_get_dependency_symbols(const struct kmod_elf *elf, struct kmod_modv
 			crclen = sizeof(mv->crc);
 		}
 		if (versionslen % verlen != 0) {
-			ELFDBG(elf, "unexpected __versions of length %"PRIu64", not multiple of %zd as expected.\n", versionslen, verlen);
+			ELFDBG(elf,
+			       "unexpected __versions of length %" PRIu64
+			       ", not multiple of %zd as expected.\n",
+			       versionslen, verlen);
 			versions = NULL;
 			versionslen = 0;
 		}
@@ -979,7 +997,10 @@ int kmod_elf_get_dependency_symbols(const struct kmod_elf *elf, struct kmod_modv
 		symlen = sizeof(Elf64_Sym);
 
 	if (symtablen % symlen != 0) {
-		ELFDBG(elf, "unexpected .symtab of length %"PRIu64", not multiple of %"PRIu64" as expected.\n", symtablen, symlen);
+		ELFDBG(elf,
+		       "unexpected .symtab of length %" PRIu64
+		       ", not multiple of %" PRIu64 " as expected.\n",
+		       symtablen, symlen);
 		return -EINVAL;
 	}
 
@@ -993,8 +1014,8 @@ int kmod_elf_get_dependency_symbols(const struct kmod_elf *elf, struct kmod_modv
 			return -ENOMEM;
 	}
 
-	handle_register_symbols = (elf->header.machine == EM_SPARC ||
-				   elf->header.machine == EM_SPARCV9);
+	handle_register_symbols =
+		(elf->header.machine == EM_SPARC || elf->header.machine == EM_SPARCV9);
 
 	symcount = symtablen / symlen;
 	count = 0;
@@ -1016,9 +1037,8 @@ int kmod_elf_get_dependency_symbols(const struct kmod_elf *elf, struct kmod_modv
 		uint8_t info;
 		int idx;
 
-#define READV(field)							\
-		elf_get_uint(elf, sym_off + offsetof(typeof(*s), field),\
-			     sizeof(s->field))
+#define READV(field) \
+	elf_get_uint(elf, sym_off + offsetof(typeof(*s), field), sizeof(s->field))
 		if (elf->class & KMOD_ELF_32) {
 			Elf32_Sym *s;
 			name_off = READV(st_name);
@@ -1051,7 +1071,11 @@ int kmod_elf_get_dependency_symbols(const struct kmod_elf *elf, struct kmod_modv
 		}
 
 		if (name_off >= strtablen) {
-			ELFDBG(elf, ".strtab is %"PRIu64" bytes, but .symtab entry %d wants to access offset %"PRIu32".\n", strtablen, i, name_off);
+			ELFDBG(elf,
+			       ".strtab is %" PRIu64
+			       " bytes, but .symtab entry %d wants to access offset %" PRIu32
+			       ".\n",
+			       strtablen, i, name_off);
 			free(visited_versions);
 			free(symcrcs);
 			return -EINVAL;
@@ -1059,7 +1083,7 @@ int kmod_elf_get_dependency_symbols(const struct kmod_elf *elf, struct kmod_modv
 
 		name = elf_get_mem(elf, str_off + name_off);
 		if (name[0] == '\0') {
-			ELFDBG(elf, "empty symbol name at index %"PRIu64"\n", i);
+			ELFDBG(elf, "empty symbol name at index %" PRIu64 "\n", i);
 			continue;
 		}
 
@@ -1111,9 +1135,8 @@ int kmod_elf_get_dependency_symbols(const struct kmod_elf *elf, struct kmod_modv
 		uint16_t secidx;
 		uint8_t info, bind;
 
-#define READV(field)							\
-		elf_get_uint(elf, sym_off + offsetof(typeof(*s), field),\
-			     sizeof(s->field))
+#define READV(field) \
+	elf_get_uint(elf, sym_off + offsetof(typeof(*s), field), sizeof(s->field))
 		if (elf->class & KMOD_ELF_32) {
 			Elf32_Sym *s;
 			name_off = READV(st_name);
@@ -1147,7 +1170,7 @@ int kmod_elf_get_dependency_symbols(const struct kmod_elf *elf, struct kmod_modv
 
 		name = elf_get_mem(elf, str_off + name_off);
 		if (name[0] == '\0') {
-			ELFDBG(elf, "empty symbol name at index %"PRIu64"\n", i);
+			ELFDBG(elf, "empty symbol name at index %" PRIu64 "\n", i);
 			continue;
 		}
 

--- a/libkmod/libkmod-file-xz.c
+++ b/libkmod/libkmod-file-xz.c
@@ -50,8 +50,8 @@ static int xz_uncompress(lzma_stream *strm, struct kmod_file *file)
 	void *p = NULL;
 	size_t total = 0;
 
-	strm->avail_in  = 0;
-	strm->next_out  = out_buf;
+	strm->avail_in = 0;
+	strm->next_out = out_buf;
 	strm->avail_out = sizeof(out_buf);
 
 	while (true) {
@@ -61,7 +61,7 @@ static int xz_uncompress(lzma_stream *strm, struct kmod_file *file)
 				ret = -errno;
 				goto out;
 			}
-			strm->next_in  = in_buf;
+			strm->next_in = in_buf;
 			strm->avail_in = rdret;
 			if (rdret == 0)
 				action = LZMA_FINISH;
@@ -91,7 +91,7 @@ static int xz_uncompress(lzma_stream *strm, struct kmod_file *file)
 	file->memory = p;
 	file->size = total;
 	return 0;
- out:
+out:
 	free(p);
 	return ret;
 }

--- a/libkmod/libkmod-file-zlib.c
+++ b/libkmod/libkmod-file-zlib.c
@@ -78,4 +78,3 @@ error:
 	gzclose(gzf); /* closes the gzfd */
 	return err;
 }
-

--- a/libkmod/libkmod-file.c
+++ b/libkmod/libkmod-file.c
@@ -20,9 +20,9 @@
 #include "libkmod-internal.h"
 #include "libkmod-internal-file.h"
 
-static const char magic_zstd[] = {0x28, 0xB5, 0x2F, 0xFD};
-static const char magic_xz[] = {0xfd, '7', 'z', 'X', 'Z', 0};
-static const char magic_zlib[] = {0x1f, 0x8b};
+static const char magic_zstd[] = { 0x28, 0xB5, 0x2F, 0xFD };
+static const char magic_xz[] = { 0xfd, '7', 'z', 'X', 'Z', 0 };
+static const char magic_zlib[] = { 0x1f, 0x8b };
 
 static int load_reg(struct kmod_file *file)
 {
@@ -35,8 +35,7 @@ static int load_reg(struct kmod_file *file)
 	if ((uintmax_t)file->size > SIZE_MAX)
 		return -ENOMEM;
 
-	file->memory = mmap(NULL, file->size, PROT_READ, MAP_PRIVATE,
-			    file->fd, 0);
+	file->memory = mmap(NULL, file->size, PROT_READ, MAP_PRIVATE, file->fd, 0);
 	if (file->memory == MAP_FAILED) {
 		file->memory = NULL;
 		return -errno;
@@ -76,8 +75,7 @@ struct kmod_elf *kmod_file_get_elf(struct kmod_file *file)
 	return file->elf;
 }
 
-struct kmod_file *kmod_file_open(const struct kmod_ctx *ctx,
-						const char *filename)
+struct kmod_file *kmod_file_open(const struct kmod_ctx *ctx, const char *filename)
 {
 	struct kmod_file *file;
 	char buf[7];
@@ -91,7 +89,7 @@ struct kmod_file *kmod_file_open(const struct kmod_ctx *ctx,
 	if (file == NULL)
 		return NULL;
 
-	file->fd = open(filename, O_RDONLY|O_CLOEXEC);
+	file->fd = open(filename, O_RDONLY | O_CLOEXEC);
 	if (file->fd < 0) {
 		free(file);
 		return NULL;

--- a/libkmod/libkmod-index.c
+++ b/libkmod/libkmod-index.c
@@ -35,7 +35,7 @@
 #define INDEX_MAGIC 0xB007F457
 #define INDEX_VERSION_MAJOR 0x0002
 #define INDEX_VERSION_MINOR 0x0001
-#define INDEX_VERSION ((INDEX_VERSION_MAJOR<<16)|INDEX_VERSION_MINOR)
+#define INDEX_VERSION ((INDEX_VERSION_MAJOR << 16) | INDEX_VERSION_MINOR)
 
 /* The index file maps keys to values. Both keys and values are ASCII strings.
  * Each key can have multiple values. Values are sorted by an integer priority.
@@ -127,12 +127,12 @@
 
 /* Format of node offsets within index file */
 enum node_offset {
-	INDEX_NODE_FLAGS    = 0xF0000000, /* Flags in high nibble */
-	INDEX_NODE_PREFIX   = 0x80000000,
+	INDEX_NODE_FLAGS = 0xF0000000, /* Flags in high nibble */
+	INDEX_NODE_PREFIX = 0x80000000,
 	INDEX_NODE_VALUES = 0x40000000,
-	INDEX_NODE_CHILDS   = 0x20000000,
+	INDEX_NODE_CHILDS = 0x20000000,
 
-	INDEX_NODE_MASK     = 0x0FFFFFFF, /* Offset value */
+	INDEX_NODE_MASK = 0x0FFFFFFF, /* Offset value */
 };
 
 void index_values_free(struct index_value *values)
@@ -145,8 +145,8 @@ void index_values_free(struct index_value *values)
 	}
 }
 
-static int add_value(struct index_value **values,
-		     const char *value, unsigned len, unsigned int priority)
+static int add_value(struct index_value **values, const char *value, unsigned len,
+		     unsigned int priority)
 {
 	struct index_value *v;
 
@@ -210,9 +210,9 @@ static ssize_t buf_freadchars(struct strbuf *buf, FILE *in)
  */
 struct index_node_f {
 	FILE *file;
-	char *prefix;		/* path compression */
+	char *prefix; /* path compression */
 	struct index_value *values;
-	unsigned char first;	/* range of child nodes */
+	unsigned char first; /* range of child nodes */
 	unsigned char last;
 	uint32_t children[0];
 };
@@ -257,8 +257,8 @@ static struct index_node_f *index_read(FILE *in, uint32_t offset)
 		if (node == NULL)
 			goto err;
 
-		node->first = (unsigned char) first;
-		node->last = (unsigned char) last;
+		node->first = (unsigned char)first;
+		node->last = (unsigned char)last;
 
 		for (i = 0; i < child_count; i++)
 			if (read_u32(in, &node->children[i]) < 0)
@@ -284,8 +284,7 @@ static struct index_node_f *index_read(FILE *in, uint32_t offset)
 
 		strbuf_init(&buf);
 		while (value_count--) {
-			if (read_u32(in, &priority) < 0 ||
-			    buf_freadchars(&buf, in) < 0) {
+			if (read_u32(in, &priority) < 0 || buf_freadchars(&buf, in) < 0) {
 				strbuf_release(&buf);
 				goto err;
 			}
@@ -331,8 +330,7 @@ struct index_file *index_file_open(const char *filename)
 	if (read_u32(file, &magic) < 0 || magic != INDEX_MAGIC)
 		goto err;
 
-	if (read_u32(file, &version) < 0 ||
-	    version >> 16 != INDEX_VERSION_MAJOR)
+	if (read_u32(file, &version) < 0 || version >> 16 != INDEX_VERSION_MAJOR)
 		goto err;
 
 	new = malloc(sizeof(struct index_file));
@@ -361,19 +359,16 @@ static struct index_node_f *index_readroot(struct index_file *in)
 	return index_read(in->file, in->root_offset);
 }
 
-static struct index_node_f *index_readchild(const struct index_node_f *parent,
-					    int ch)
+static struct index_node_f *index_readchild(const struct index_node_f *parent, int ch)
 {
 	if (parent->first <= ch && ch <= parent->last) {
-		return index_read(parent->file,
-		                       parent->children[ch - parent->first]);
+		return index_read(parent->file, parent->children[ch - parent->first]);
 	}
 
 	return NULL;
 }
 
-static void index_dump_node(struct index_node_f *node, struct strbuf *buf,
-								int fd)
+static void index_dump_node(struct index_node_f *node, struct strbuf *buf, int fd)
 {
 	struct index_value *v;
 	size_t pushed;
@@ -425,11 +420,11 @@ static char *index_search__node(struct index_node_f *node, const char *key, int 
 	int ch;
 	int j;
 
-	while(node) {
+	while (node) {
 		for (j = 0; node->prefix[j]; j++) {
 			ch = node->prefix[j];
 
-			if (ch != key[i+j]) {
+			if (ch != key[i + j]) {
 				index_close(node);
 				return NULL;
 			}
@@ -438,9 +433,8 @@ static char *index_search__node(struct index_node_f *node, const char *key, int 
 		i += j;
 
 		if (key[i] == '\0') {
-			value = node->values != NULL
-				? strdup(node->values[0].value)
-				: NULL;
+			value = node->values != NULL ? strdup(node->values[0].value) :
+						       NULL;
 
 			index_close(node);
 			return value;
@@ -464,7 +458,7 @@ static char *index_search__node(struct index_node_f *node, const char *key, int 
  */
 char *index_search(struct index_file *in, const char *key)
 {
-// FIXME: return value by reference instead of strdup
+	// FIXME: return value by reference instead of strdup
 	struct index_node_f *root;
 	char *value;
 
@@ -473,8 +467,6 @@ char *index_search(struct index_file *in, const char *key)
 
 	return value;
 }
-
-
 
 /* Level 4: add all the values from a matching node */
 static void index_searchwild__allvalues(struct index_node_f *node,
@@ -492,10 +484,8 @@ static void index_searchwild__allvalues(struct index_node_f *node,
  * Level 3: traverse a sub-keyspace which starts with a wildcard,
  * looking for matches.
  */
-static void index_searchwild__all(struct index_node_f *node, int j,
-				  struct strbuf *buf,
-				  const char *subkey,
-				  struct index_value **out)
+static void index_searchwild__all(struct index_node_f *node, int j, struct strbuf *buf,
+				  const char *subkey, struct index_value **out)
 {
 	size_t pushed = 0;
 	int ch;
@@ -532,26 +522,23 @@ static void index_searchwild__all(struct index_node_f *node, int j,
 }
 
 /* Level 2: descend the tree (until we hit a wildcard) */
-static void index_searchwild__node(struct index_node_f *node,
-				   struct strbuf *buf,
-				   const char *key, int i,
-				   struct index_value **out)
+static void index_searchwild__node(struct index_node_f *node, struct strbuf *buf,
+				   const char *key, int i, struct index_value **out)
 {
 	struct index_node_f *child;
 	int j;
 	int ch;
 
-	while(node) {
+	while (node) {
 		for (j = 0; node->prefix[j]; j++) {
 			ch = node->prefix[j];
 
 			if (ch == '*' || ch == '?' || ch == '[') {
-				index_searchwild__all(node, j, buf,
-						      &key[i+j], out);
+				index_searchwild__all(node, j, buf, &key[i + j], out);
 				return;
 			}
 
-			if (ch != key[i+j]) {
+			if (ch != key[i + j]) {
 				index_close(node);
 				return;
 			}
@@ -654,7 +641,7 @@ static inline uint32_t read_u32_mm(void **p)
 	uint32_t v;
 
 	/* addr may be unalined to uint32_t */
-	v = get_unaligned((uint32_t *) addr);
+	v = get_unaligned((uint32_t *)addr);
 
 	*p = addr + sizeof(uint32_t);
 	return ntohl(v);
@@ -676,8 +663,8 @@ static inline char *read_chars_mm(void **p, unsigned *rlen)
 	return addr;
 }
 
-static struct index_mm_node *index_mm_read_node(struct index_mm *idx,
-							uint32_t offset) {
+static struct index_mm_node *index_mm_read_node(struct index_mm *idx, uint32_t offset)
+{
 	void *p = idx->mm;
 	struct index_mm_node *node;
 	const char *prefix;
@@ -712,17 +699,17 @@ static struct index_mm_node *index_mm_read_node(struct index_mm *idx,
 		child_count = 0;
 	}
 
-	children_padding = (sizeof(struct index_mm_node) +
-			    (sizeof(uint32_t) * child_count)) % sizeof(void *);
+	children_padding =
+		(sizeof(struct index_mm_node) + (sizeof(uint32_t) * child_count)) %
+		sizeof(void *);
 
 	if (offset & INDEX_NODE_VALUES)
 		value_count = read_u32_mm(&p);
 	else
 		value_count = 0;
 
-	node = malloc(sizeof(struct index_mm_node)
-		      + sizeof(uint32_t) * child_count + children_padding
-		      + sizeof(struct index_mm_value) * value_count);
+	node = malloc(sizeof(struct index_mm_node) + sizeof(uint32_t) * child_count +
+		      children_padding + sizeof(struct index_mm_value) * value_count);
 	if (node == NULL)
 		return NULL;
 
@@ -731,9 +718,11 @@ static struct index_mm_node *index_mm_read_node(struct index_mm *idx,
 	if (value_count == 0)
 		node->values.values = NULL;
 	else {
-		node->values.values = (struct index_mm_value *)
-			((char *)node + sizeof(struct index_mm_node) +
-			 sizeof(uint32_t) * child_count + children_padding);
+		node->values.values =
+			(struct index_mm_value *)((char *)node +
+						  sizeof(struct index_mm_node) +
+						  sizeof(uint32_t) * child_count +
+						  children_padding);
 	}
 	node->values.len = value_count;
 	node->first = first;
@@ -777,13 +766,13 @@ int index_mm_open(const struct kmod_ctx *ctx, const char *filename,
 		return -ENOMEM;
 	}
 
-	if ((fd = open(filename, O_RDONLY|O_CLOEXEC)) < 0) {
+	if ((fd = open(filename, O_RDONLY | O_CLOEXEC)) < 0) {
 		DBG(ctx, "open(%s, O_RDONLY|O_CLOEXEC): %m\n", filename);
 		err = -errno;
 		goto fail_open;
 	}
 
-	if (fstat(fd, &st) < 0 || st.st_size < (off_t) sizeof(hdr)) {
+	if (fstat(fd, &st) < 0 || st.st_size < (off_t)sizeof(hdr)) {
 		err = -EINVAL;
 		goto fail_nommap;
 	}
@@ -795,8 +784,8 @@ int index_mm_open(const struct kmod_ctx *ctx, const char *filename,
 
 	idx->mm = mmap(NULL, st.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
 	if (idx->mm == MAP_FAILED) {
-		ERR(ctx, "mmap(NULL, %"PRIu64", PROT_READ, MAP_PRIVATE, %d, 0): %m\n",
-							(uint64_t) st.st_size, fd);
+		ERR(ctx, "mmap(NULL, %" PRIu64 ", PROT_READ, MAP_PRIVATE, %d, 0): %m\n",
+		    (uint64_t)st.st_size, fd);
 		err = -errno;
 		goto fail_nommap;
 	}
@@ -807,15 +796,14 @@ int index_mm_open(const struct kmod_ctx *ctx, const char *filename,
 	hdr.root_offset = read_u32_mm(&p);
 
 	if (hdr.magic != INDEX_MAGIC) {
-		ERR(ctx, "magic check fail: %x instead of %x\n", hdr.magic,
-								INDEX_MAGIC);
+		ERR(ctx, "magic check fail: %x instead of %x\n", hdr.magic, INDEX_MAGIC);
 		err = -EINVAL;
 		goto fail;
 	}
 
 	if (hdr.version >> 16 != INDEX_VERSION_MAJOR) {
 		ERR(ctx, "major version check fail: %u instead of %u\n",
-					hdr.version >> 16, INDEX_VERSION_MAJOR);
+		    hdr.version >> 16, INDEX_VERSION_MAJOR);
 		err = -EINVAL;
 		goto fail;
 	}
@@ -850,19 +838,17 @@ static struct index_mm_node *index_mm_readroot(struct index_mm *idx)
 	return index_mm_read_node(idx, idx->root_offset);
 }
 
-static struct index_mm_node *index_mm_readchild(const struct index_mm_node *parent,
-									int ch)
+static struct index_mm_node *index_mm_readchild(const struct index_mm_node *parent, int ch)
 {
 	if (parent->first <= ch && ch <= parent->last) {
 		return index_mm_read_node(parent->idx,
-					parent->children[ch - parent->first]);
+					  parent->children[ch - parent->first]);
 	}
 
 	return NULL;
 }
 
-static void index_mm_dump_node(struct index_mm_node *node, struct strbuf *buf,
-								int fd)
+static void index_mm_dump_node(struct index_mm_node *node, struct strbuf *buf, int fd)
 {
 	struct index_mm_value *itr, *itr_end;
 	size_t pushed;
@@ -909,19 +895,18 @@ void index_mm_dump(struct index_mm *idx, int fd, const char *prefix)
 	strbuf_release(&buf);
 }
 
-static char *index_mm_search_node(struct index_mm_node *node, const char *key,
-									int i)
+static char *index_mm_search_node(struct index_mm_node *node, const char *key, int i)
 {
 	char *value;
 	struct index_mm_node *child;
 	int ch;
 	int j;
 
-	while(node) {
+	while (node) {
 		for (j = 0; node->prefix[j]; j++) {
 			ch = node->prefix[j];
 
-			if (ch != key[i+j]) {
+			if (ch != key[i + j]) {
 				index_mm_free_node(node);
 				return NULL;
 			}
@@ -930,9 +915,9 @@ static char *index_mm_search_node(struct index_mm_node *node, const char *key,
 		i += j;
 
 		if (key[i] == '\0') {
-			value = node->values.len > 0
-				? strdup(node->values.values[0].value)
-				: NULL;
+			value = node->values.len > 0 ?
+					strdup(node->values.values[0].value) :
+					NULL;
 
 			index_mm_free_node(node);
 			return value;
@@ -956,7 +941,7 @@ static char *index_mm_search_node(struct index_mm_node *node, const char *key,
  */
 char *index_mm_search(struct index_mm *idx, const char *key)
 {
-// FIXME: return value by reference instead of strdup
+	// FIXME: return value by reference instead of strdup
 	struct index_mm_node *root;
 	char *value;
 
@@ -968,7 +953,7 @@ char *index_mm_search(struct index_mm *idx, const char *key)
 
 /* Level 4: add all the values from a matching node */
 static void index_mm_searchwild_allvalues(struct index_mm_node *node,
-						struct index_value **out)
+					  struct index_value **out)
 {
 	struct index_mm_value *itr, *itr_end;
 
@@ -984,10 +969,8 @@ static void index_mm_searchwild_allvalues(struct index_mm_node *node,
  * Level 3: traverse a sub-keyspace which starts with a wildcard,
  * looking for matches.
  */
-static void index_mm_searchwild_all(struct index_mm_node *node, int j,
-					  struct strbuf *buf,
-					  const char *subkey,
-					  struct index_value **out)
+static void index_mm_searchwild_all(struct index_mm_node *node, int j, struct strbuf *buf,
+				    const char *subkey, struct index_value **out)
 {
 	size_t pushed = 0;
 	int ch;
@@ -1024,26 +1007,23 @@ static void index_mm_searchwild_all(struct index_mm_node *node, int j,
 }
 
 /* Level 2: descend the tree (until we hit a wildcard) */
-static void index_mm_searchwild_node(struct index_mm_node *node,
-					   struct strbuf *buf,
-					   const char *key, int i,
-					   struct index_value **out)
+static void index_mm_searchwild_node(struct index_mm_node *node, struct strbuf *buf,
+				     const char *key, int i, struct index_value **out)
 {
 	struct index_mm_node *child;
 	int j;
 	int ch;
 
-	while(node) {
+	while (node) {
 		for (j = 0; node->prefix[j]; j++) {
 			ch = node->prefix[j];
 
 			if (ch == '*' || ch == '?' || ch == '[') {
-				index_mm_searchwild_all(node, j, buf,
-						      &key[i+j], out);
+				index_mm_searchwild_all(node, j, buf, &key[i + j], out);
 				return;
 			}
 
-			if (ch != key[i+j]) {
+			if (ch != key[i + j]) {
 				index_mm_free_node(node);
 				return;
 			}

--- a/libkmod/libkmod-internal-file.h
+++ b/libkmod/libkmod-internal-file.h
@@ -23,17 +23,26 @@ struct kmod_file {
 #ifdef ENABLE_XZ
 int kmod_file_load_xz(struct kmod_file *file);
 #else
-static inline int kmod_file_load_xz(struct kmod_file *file) { return -ENOSYS; }
+static inline int kmod_file_load_xz(struct kmod_file *file)
+{
+	return -ENOSYS;
+}
 #endif
 
 #ifdef ENABLE_ZLIB
 int kmod_file_load_zlib(struct kmod_file *file);
 #else
-static inline int kmod_file_load_zlib(struct kmod_file *file) { return -ENOSYS; }
+static inline int kmod_file_load_zlib(struct kmod_file *file)
+{
+	return -ENOSYS;
+}
 #endif
 
 #ifdef ENABLE_ZSTD
 int kmod_file_load_zstd(struct kmod_file *file);
 #else
-static inline int kmod_file_load_zstd(struct kmod_file *file) { return -ENOSYS; }
+static inline int kmod_file_load_zstd(struct kmod_file *file)
+{
+	return -ENOSYS;
+}
 #endif

--- a/libkmod/libkmod-internal.h
+++ b/libkmod/libkmod-internal.h
@@ -10,32 +10,34 @@
 
 #include "libkmod.h"
 
-static _always_inline_ _printf_format_(2, 3) void
-	kmod_log_null(const struct kmod_ctx *ctx, const char *format, ...) {}
+static _always_inline_ _printf_format_(2, 3) void kmod_log_null(const struct kmod_ctx *ctx,
+								const char *format, ...)
+{
+}
 
-#define kmod_log_cond(ctx, prio, arg...) \
-	do { \
-		if (kmod_get_log_priority(ctx) >= prio) \
-		kmod_log(ctx, prio, __FILE__, __LINE__, __func__, ## arg);\
+#define kmod_log_cond(ctx, prio, arg...)                                          \
+	do {                                                                      \
+		if (kmod_get_log_priority(ctx) >= prio)                           \
+			kmod_log(ctx, prio, __FILE__, __LINE__, __func__, ##arg); \
 	} while (0)
 
 #ifdef ENABLE_LOGGING
-#  ifdef ENABLE_DEBUG
-#    define DBG(ctx, arg...) kmod_log_cond(ctx, LOG_DEBUG, ## arg)
-#  else
-#    define DBG(ctx, arg...) kmod_log_null(ctx, ## arg)
-#  endif
-#  define NOTICE(ctx, arg...) kmod_log_cond(ctx, LOG_NOTICE, ## arg)
-#  define INFO(ctx, arg...) kmod_log_cond(ctx, LOG_INFO, ## arg)
-#  define ERR(ctx, arg...) kmod_log_cond(ctx, LOG_ERR, ## arg)
+#ifdef ENABLE_DEBUG
+#define DBG(ctx, arg...) kmod_log_cond(ctx, LOG_DEBUG, ##arg)
 #else
-#  define DBG(ctx, arg...) kmod_log_null(ctx, ## arg)
-#  define NOTICE(ctx, arg...) kmod_log_null(ctx, ## arg)
-#  define INFO(ctx, arg...) kmod_log_null(ctx, ## arg)
-#  define ERR(ctx, arg...) kmod_log_null(ctx, ## arg)
+#define DBG(ctx, arg...) kmod_log_null(ctx, ##arg)
+#endif
+#define NOTICE(ctx, arg...) kmod_log_cond(ctx, LOG_NOTICE, ##arg)
+#define INFO(ctx, arg...) kmod_log_cond(ctx, LOG_INFO, ##arg)
+#define ERR(ctx, arg...) kmod_log_cond(ctx, LOG_ERR, ##arg)
+#else
+#define DBG(ctx, arg...) kmod_log_null(ctx, ##arg)
+#define NOTICE(ctx, arg...) kmod_log_null(ctx, ##arg)
+#define INFO(ctx, arg...) kmod_log_null(ctx, ##arg)
+#define ERR(ctx, arg...) kmod_log_null(ctx, ##arg)
 #endif
 
-#define KMOD_EXPORT __attribute__ ((visibility("default")))
+#define KMOD_EXPORT __attribute__((visibility("default")))
 
 #define KCMD_LINE_SIZE 4096
 
@@ -45,8 +47,9 @@ static _always_inline_ _printf_format_(2, 3) void
 #endif
 
 _printf_format_(6, 7) _nonnull_(1, 3, 5) void kmod_log(const struct kmod_ctx *ctx,
-		int priority, const char *file, int line, const char *fn,
-		const char *format, ...);
+						       int priority, const char *file,
+						       int line, const char *fn,
+						       const char *format, ...);
 
 struct list_node {
 	struct list_node *next, *prev;

--- a/libkmod/libkmod-list.c
+++ b/libkmod/libkmod-list.c
@@ -16,8 +16,7 @@ static inline struct list_node *list_node_init(struct list_node *node)
 	return node;
 }
 
-static inline void list_node_append(struct list_node *list,
-							struct list_node *node)
+static inline void list_node_append(struct list_node *list, struct list_node *node)
 {
 	if (list == NULL) {
 		list_node_init(node);
@@ -41,8 +40,7 @@ static inline struct list_node *list_node_remove(struct list_node *node)
 	return node->next;
 }
 
-static inline void list_node_insert_after(struct list_node *list,
-							struct list_node *node)
+static inline void list_node_insert_after(struct list_node *list, struct list_node *node)
 {
 	if (list == NULL) {
 		list_node_init(node);
@@ -55,8 +53,7 @@ static inline void list_node_insert_after(struct list_node *list,
 	list->next = node;
 }
 
-static inline void list_node_insert_before(struct list_node *list,
-							struct list_node *node)
+static inline void list_node_insert_before(struct list_node *list, struct list_node *node)
 {
 	if (list == NULL) {
 		list_node_init(node);
@@ -69,8 +66,7 @@ static inline void list_node_insert_before(struct list_node *list,
 	list->prev = node;
 }
 
-static inline void list_node_append_list(struct list_node *list1,
-							struct list_node *list2)
+static inline void list_node_append_list(struct list_node *list1, struct list_node *list2)
 {
 	struct list_node *list1_last;
 
@@ -103,8 +99,7 @@ struct kmod_list *kmod_list_append(struct kmod_list *list, const void *data)
 	return list ? list : new;
 }
 
-struct kmod_list *kmod_list_insert_after(struct kmod_list *list,
-							const void *data)
+struct kmod_list *kmod_list_insert_after(struct kmod_list *list, const void *data)
 {
 	struct kmod_list *new;
 
@@ -121,8 +116,7 @@ struct kmod_list *kmod_list_insert_after(struct kmod_list *list,
 	return list;
 }
 
-struct kmod_list *kmod_list_insert_before(struct kmod_list *list,
-							const void *data)
+struct kmod_list *kmod_list_insert_before(struct kmod_list *list, const void *data)
 {
 	struct kmod_list *new;
 
@@ -139,8 +133,7 @@ struct kmod_list *kmod_list_insert_before(struct kmod_list *list,
 	return new;
 }
 
-struct kmod_list *kmod_list_append_list(struct kmod_list *list1,
-						struct kmod_list *list2)
+struct kmod_list *kmod_list_append_list(struct kmod_list *list1, struct kmod_list *list2)
 {
 	if (list1 == NULL)
 		return list2;
@@ -183,8 +176,7 @@ struct kmod_list *kmod_list_remove(struct kmod_list *list)
 	return container_of(node, struct kmod_list, node);
 }
 
-struct kmod_list *kmod_list_remove_data(struct kmod_list *list,
-							const void *data)
+struct kmod_list *kmod_list_remove_data(struct kmod_list *list, const void *data)
 {
 	struct kmod_list *itr;
 	struct list_node *node;
@@ -210,8 +202,7 @@ struct kmod_list *kmod_list_remove_data(struct kmod_list *list,
  * n must be greater to or equal the number of elements (we don't check the
  * condition)
  */
-struct kmod_list *kmod_list_remove_n_latest(struct kmod_list *list,
-							unsigned int n)
+struct kmod_list *kmod_list_remove_n_latest(struct kmod_list *list, unsigned int n)
 {
 	struct kmod_list *l = list;
 	unsigned int i;
@@ -225,7 +216,7 @@ struct kmod_list *kmod_list_remove_n_latest(struct kmod_list *list,
 }
 
 KMOD_EXPORT struct kmod_list *kmod_list_prev(const struct kmod_list *list,
-						const struct kmod_list *curr)
+					     const struct kmod_list *curr)
 {
 	if (list == NULL || curr == NULL)
 		return NULL;
@@ -237,7 +228,7 @@ KMOD_EXPORT struct kmod_list *kmod_list_prev(const struct kmod_list *list,
 }
 
 KMOD_EXPORT struct kmod_list *kmod_list_next(const struct kmod_list *list,
-						const struct kmod_list *curr)
+					     const struct kmod_list *curr)
 {
 	if (list == NULL || curr == NULL)
 		return NULL;

--- a/libkmod/libkmod-module.c
+++ b/libkmod/libkmod-module.c
@@ -28,9 +28,9 @@
 #include "libkmod-internal.h"
 
 enum kmod_module_builtin {
-    KMOD_MODULE_BUILTIN_UNKNOWN,
-    KMOD_MODULE_BUILTIN_NO,
-    KMOD_MODULE_BUILTIN_YES,
+	KMOD_MODULE_BUILTIN_UNKNOWN,
+	KMOD_MODULE_BUILTIN_NO,
+	KMOD_MODULE_BUILTIN_YES,
 };
 
 struct kmod_module {
@@ -40,8 +40,8 @@ struct kmod_module {
 	char *path;
 	struct kmod_list *dep;
 	char *options;
-	const char *install_commands;	/* owned by kmod_config */
-	const char *remove_commands;	/* owned by kmod_config */
+	const char *install_commands; /* owned by kmod_config */
+	const char *remove_commands; /* owned by kmod_config */
 	char *alias; /* only set if this module was created from an alias */
 	struct kmod_file *file;
 	int n_dep;
@@ -80,8 +80,7 @@ struct kmod_module {
 	bool required : 1;
 };
 
-static inline const char *path_join(const char *path, size_t prefixlen,
-							char buf[PATH_MAX])
+static inline const char *path_join(const char *path, size_t prefixlen, char buf[PATH_MAX])
 {
 	size_t pathlen;
 
@@ -100,8 +99,7 @@ static inline bool module_is_inkernel(struct kmod_module *mod)
 {
 	int state = kmod_module_get_initstate(mod);
 
-	if (state == KMOD_MODULE_LIVE ||
-			state == KMOD_MODULE_BUILTIN)
+	if (state == KMOD_MODULE_LIVE || state == KMOD_MODULE_BUILTIN)
 		return true;
 
 	return false;
@@ -148,21 +146,19 @@ int kmod_module_parse_depline(struct kmod_module *mod, char *line)
 
 	p++;
 	for (p = strtok_r(p, " \t", &saveptr); p != NULL;
-					p = strtok_r(NULL, " \t", &saveptr)) {
+	     p = strtok_r(NULL, " \t", &saveptr)) {
 		struct kmod_module *depmod = NULL;
 		const char *path;
 
 		path = path_join(p, dirnamelen, buf);
 		if (path == NULL) {
-			ERR(ctx, "could not join path '%s' and '%s'.\n",
-			    dirname, p);
+			ERR(ctx, "could not join path '%s' and '%s'.\n", dirname, p);
 			goto fail;
 		}
 
 		err = kmod_module_new_from_path(ctx, path, &depmod);
 		if (err < 0) {
-			ERR(ctx, "ctx=%p path=%s error=%s\n",
-						ctx, path, strerror(-err));
+			ERR(ctx, "ctx=%p path=%s error=%s\n", ctx, path, strerror(-err));
 			goto fail;
 		}
 
@@ -191,8 +187,7 @@ void kmod_module_set_visited(struct kmod_module *mod, bool visited)
 
 void kmod_module_set_builtin(struct kmod_module *mod, bool builtin)
 {
-	mod->builtin =
-		builtin ? KMOD_MODULE_BUILTIN_YES : KMOD_MODULE_BUILTIN_NO;
+	mod->builtin = builtin ? KMOD_MODULE_BUILTIN_YES : KMOD_MODULE_BUILTIN_NO;
 }
 
 void kmod_module_set_required(struct kmod_module *mod, bool required)
@@ -203,8 +198,8 @@ void kmod_module_set_required(struct kmod_module *mod, bool required)
 bool kmod_module_is_builtin(struct kmod_module *mod)
 {
 	if (mod->builtin == KMOD_MODULE_BUILTIN_UNKNOWN) {
-		kmod_module_set_builtin(mod,
-					kmod_lookup_alias_is_builtin(mod->ctx, mod->name));
+		kmod_module_set_builtin(mod, kmod_lookup_alias_is_builtin(mod->ctx,
+									  mod->name));
 	}
 
 	return mod->builtin == KMOD_MODULE_BUILTIN_YES;
@@ -232,10 +227,9 @@ bool kmod_module_is_builtin(struct kmod_module *mod)
  *
  * @key is "name\alias" or "name" (in which case alias == NULL)
  */
-static int kmod_module_new(struct kmod_ctx *ctx, const char *key,
-				const char *name, size_t namelen,
-				const char *alias, size_t aliaslen,
-				struct kmod_module **mod)
+static int kmod_module_new(struct kmod_ctx *ctx, const char *key, const char *name,
+			   size_t namelen, const char *alias, size_t aliaslen,
+			   struct kmod_module **mod)
 {
 	struct kmod_module *m;
 	size_t keylen;
@@ -277,9 +271,8 @@ static int kmod_module_new(struct kmod_ctx *ctx, const char *key,
 	return 0;
 }
 
-KMOD_EXPORT int kmod_module_new_from_name(struct kmod_ctx *ctx,
-						const char *name,
-						struct kmod_module **mod)
+KMOD_EXPORT int kmod_module_new_from_name(struct kmod_ctx *ctx, const char *name,
+					  struct kmod_module **mod)
 {
 	size_t namelen;
 	char name_norm[PATH_MAX];
@@ -292,8 +285,8 @@ KMOD_EXPORT int kmod_module_new_from_name(struct kmod_ctx *ctx,
 	return kmod_module_new(ctx, name_norm, name_norm, namelen, NULL, 0, mod);
 }
 
-int kmod_module_new_from_alias(struct kmod_ctx *ctx, const char *alias,
-				const char *name, struct kmod_module **mod)
+int kmod_module_new_from_alias(struct kmod_ctx *ctx, const char *alias, const char *name,
+			       struct kmod_module **mod)
 {
 	int err;
 	char key[PATH_MAX];
@@ -314,9 +307,8 @@ int kmod_module_new_from_alias(struct kmod_ctx *ctx, const char *alias,
 	return 0;
 }
 
-KMOD_EXPORT int kmod_module_new_from_path(struct kmod_ctx *ctx,
-						const char *path,
-						struct kmod_module **mod)
+KMOD_EXPORT int kmod_module_new_from_path(struct kmod_ctx *ctx, const char *path,
+					  struct kmod_module **mod)
 {
 	struct kmod_module *m;
 	int err;
@@ -355,8 +347,9 @@ KMOD_EXPORT int kmod_module_new_from_path(struct kmod_ctx *ctx,
 		else if (streq(m->path, abspath))
 			free(abspath);
 		else {
-			ERR(ctx, "kmod_module '%s' already exists with different path: new-path='%s' old-path='%s'\n",
-							name, abspath, m->path);
+			ERR(ctx,
+			    "kmod_module '%s' already exists with different path: new-path='%s' old-path='%s'\n",
+			    name, abspath, m->path);
 			free(abspath);
 			return -EEXIST;
 		}
@@ -411,7 +404,8 @@ KMOD_EXPORT struct kmod_module *kmod_module_ref(struct kmod_module *mod)
 	return mod;
 }
 
-typedef _nonnull_all_ int (*lookup_func)(struct kmod_ctx *ctx, const char *name, struct kmod_list **list);
+typedef _nonnull_all_ int (*lookup_func)(struct kmod_ctx *ctx, const char *name,
+					 struct kmod_list **list);
 
 static int __kmod_module_new_from_lookup(struct kmod_ctx *ctx, const lookup_func lookup[],
 					 size_t lookup_count, const char *s,
@@ -432,9 +426,8 @@ static int __kmod_module_new_from_lookup(struct kmod_ctx *ctx, const lookup_func
 	return 0;
 }
 
-KMOD_EXPORT int kmod_module_new_from_lookup(struct kmod_ctx *ctx,
-						const char *given_alias,
-						struct kmod_list **list)
+KMOD_EXPORT int kmod_module_new_from_lookup(struct kmod_ctx *ctx, const char *given_alias,
+					    struct kmod_list **list)
 {
 	static const lookup_func lookup[] = {
 		kmod_lookup_alias_from_config,
@@ -463,8 +456,7 @@ KMOD_EXPORT int kmod_module_new_from_lookup(struct kmod_ctx *ctx,
 
 	DBG(ctx, "input alias=%s, normalized=%s\n", given_alias, alias);
 
-	err = __kmod_module_new_from_lookup(ctx, lookup, ARRAY_SIZE(lookup),
-					    alias, list);
+	err = __kmod_module_new_from_lookup(ctx, lookup, ARRAY_SIZE(lookup), alias, list);
 
 	DBG(ctx, "lookup=%s found=%d\n", alias, err >= 0 && *list);
 
@@ -496,8 +488,8 @@ KMOD_EXPORT int kmod_module_new_from_name_lookup(struct kmod_ctx *ctx,
 
 	DBG(ctx, "input modname=%s, normalized=%s\n", modname, name_norm);
 
-	err = __kmod_module_new_from_lookup(ctx, lookup, ARRAY_SIZE(lookup),
-					    name_norm, &list);
+	err = __kmod_module_new_from_lookup(ctx, lookup, ARRAY_SIZE(lookup), name_norm,
+					    &list);
 
 	DBG(ctx, "lookup=%s found=%d\n", name_norm, err >= 0 && list);
 
@@ -518,8 +510,8 @@ KMOD_EXPORT int kmod_module_unref_list(struct kmod_list *list)
 }
 
 KMOD_EXPORT int kmod_module_get_filtered_blacklist(const struct kmod_ctx *ctx,
-						const struct kmod_list *input,
-						struct kmod_list **output)
+						   const struct kmod_list *input,
+						   struct kmod_list **output)
 {
 	return kmod_module_apply_filter(ctx, KMOD_FILTER_BLACKLIST, input, output);
 }
@@ -605,17 +597,15 @@ KMOD_EXPORT const char *kmod_module_get_path(const struct kmod_module *mod)
 	if (line == NULL)
 		return NULL;
 
-	kmod_module_parse_depline((struct kmod_module *) mod, line);
+	kmod_module_parse_depline((struct kmod_module *)mod, line);
 	free(line);
 
 	return mod->path;
 }
 
-
 extern long delete_module(const char *name, unsigned int flags);
 
-KMOD_EXPORT int kmod_module_remove_module(struct kmod_module *mod,
-							unsigned int flags)
+KMOD_EXPORT int kmod_module_remove_module(struct kmod_module *mod, unsigned int flags)
 {
 	unsigned int libkmod_flags = flags & 0xff;
 
@@ -640,8 +630,7 @@ KMOD_EXPORT int kmod_module_remove_module(struct kmod_module *mod,
 
 extern long init_module(const void *mem, unsigned long len, const char *args);
 
-static int do_finit_module(struct kmod_module *mod, unsigned int flags,
-			   const char *args)
+static int do_finit_module(struct kmod_module *mod, unsigned int flags, const char *args)
 {
 	enum kmod_file_compression_type compression, kernel_compression;
 	unsigned int kernel_flags = 0;
@@ -674,8 +663,7 @@ static int do_finit_module(struct kmod_module *mod, unsigned int flags,
 	return err;
 }
 
-static int do_init_module(struct kmod_module *mod, unsigned int flags,
-			  const char *args)
+static int do_init_module(struct kmod_module *mod, unsigned int flags, const char *args)
 {
 	struct kmod_elf *elf;
 	const void *mem;
@@ -692,13 +680,15 @@ static int do_init_module(struct kmod_module *mod, unsigned int flags,
 		if (flags & KMOD_INSERT_FORCE_MODVERSION) {
 			err = kmod_elf_strip_section(elf, "__versions");
 			if (err < 0)
-				INFO(mod->ctx, "Failed to strip modversion: %s\n", strerror(-err));
+				INFO(mod->ctx, "Failed to strip modversion: %s\n",
+				     strerror(-err));
 		}
 
 		if (flags & KMOD_INSERT_FORCE_VERMAGIC) {
 			err = kmod_elf_strip_vermagic(elf);
 			if (err < 0)
-				INFO(mod->ctx, "Failed to strip vermagic: %s\n", strerror(-err));
+				INFO(mod->ctx, "Failed to strip vermagic: %s\n",
+				     strerror(-err));
 		}
 
 		mem = kmod_elf_get_memory(elf);
@@ -718,9 +708,8 @@ static int do_init_module(struct kmod_module *mod, unsigned int flags,
 	return err;
 }
 
-KMOD_EXPORT int kmod_module_insert_module(struct kmod_module *mod,
-							unsigned int flags,
-							const char *options)
+KMOD_EXPORT int kmod_module_insert_module(struct kmod_module *mod, unsigned int flags,
+					  const char *options)
 {
 	int err;
 	const char *path;
@@ -748,8 +737,7 @@ KMOD_EXPORT int kmod_module_insert_module(struct kmod_module *mod,
 		err = do_init_module(mod, flags, args);
 
 	if (err < 0)
-		INFO(mod->ctx, "Failed to insert module '%s': %s\n",
-		     path, strerror(-err));
+		INFO(mod->ctx, "Failed to insert module '%s': %s\n", path, strerror(-err));
 
 	return err;
 }
@@ -772,9 +760,9 @@ static bool module_is_blacklisted(const struct kmod_module *mod)
 }
 
 KMOD_EXPORT int kmod_module_apply_filter(const struct kmod_ctx *ctx,
-						enum kmod_filter filter_type,
-						const struct kmod_list *input,
-						struct kmod_list **output)
+					 enum kmod_filter filter_type,
+					 const struct kmod_list *input,
+					 struct kmod_list **output)
 {
 	const struct kmod_list *li;
 
@@ -789,12 +777,10 @@ KMOD_EXPORT int kmod_module_apply_filter(const struct kmod_ctx *ctx,
 		struct kmod_module *mod = li->data;
 		struct kmod_list *node;
 
-		if ((filter_type & KMOD_FILTER_BLACKLIST) &&
-				module_is_blacklisted(mod))
+		if ((filter_type & KMOD_FILTER_BLACKLIST) && module_is_blacklisted(mod))
 			continue;
 
-		if ((filter_type & KMOD_FILTER_BUILTIN)
-		    && kmod_module_is_builtin(mod))
+		if ((filter_type & KMOD_FILTER_BUILTIN) && kmod_module_is_builtin(mod))
 			continue;
 
 		node = kmod_list_append(*output, mod);
@@ -813,8 +799,7 @@ fail:
 	return -ENOMEM;
 }
 
-static int command_do(struct kmod_module *mod, const char *type,
-							const char *cmd)
+static int command_do(struct kmod_module *mod, const char *type, const char *cmd)
 {
 	const char *modname = kmod_module_get_name(mod);
 	int err;
@@ -826,8 +811,8 @@ static int command_do(struct kmod_module *mod, const char *type,
 	unsetenv("MODPROBE_MODULE");
 
 	if (err == -1) {
-		ERR(mod->ctx, "Could not run %s command '%s' for module %s: %m\n",
-		    type, cmd, modname);
+		ERR(mod->ctx, "Could not run %s command '%s' for module %s: %m\n", type,
+		    cmd, modname);
 		return -EINVAL;
 	}
 
@@ -845,9 +830,8 @@ struct probe_insert_cb {
 	void *data;
 };
 
-static int module_do_install_commands(struct kmod_module *mod,
-					const char *options,
-					struct probe_insert_cb *cb)
+static int module_do_install_commands(struct kmod_module *mod, const char *options,
+				      struct probe_insert_cb *cb)
 {
 	const char *command = kmod_module_get_install_commands(mod);
 	char *p;
@@ -921,22 +905,18 @@ static char *module_options_concat(const char *opt, const char *xopt)
 	return r;
 }
 
-static int __kmod_module_get_probe_list(struct kmod_module *mod,
-						bool required,
-						bool ignorecmd,
-						struct kmod_list **list);
+static int __kmod_module_get_probe_list(struct kmod_module *mod, bool required,
+					bool ignorecmd, struct kmod_list **list);
 
 /* re-entrant */
-static int __kmod_module_fill_softdep(struct kmod_module *mod,
-						struct kmod_list **list)
+static int __kmod_module_fill_softdep(struct kmod_module *mod, struct kmod_list **list)
 {
 	struct kmod_list *pre = NULL, *post = NULL, *l;
 	int err;
 
 	err = kmod_module_get_softdeps(mod, &pre, &post);
 	if (err < 0) {
-		ERR(mod->ctx, "could not get softdep: %s\n",
-							strerror(-err));
+		ERR(mod->ctx, "could not get softdep: %s\n", strerror(-err));
 		goto fail;
 	}
 
@@ -971,17 +951,14 @@ fail:
 }
 
 /* re-entrant */
-static int __kmod_module_get_probe_list(struct kmod_module *mod,
-						bool required,
-						bool ignorecmd,
-						struct kmod_list **list)
+static int __kmod_module_get_probe_list(struct kmod_module *mod, bool required,
+					bool ignorecmd, struct kmod_list **list)
 {
 	struct kmod_list *dep, *l;
 	int err = 0;
 
 	if (mod->visited) {
-		DBG(mod->ctx, "Ignore module '%s': already visited\n",
-								mod->name);
+		DBG(mod->ctx, "Ignore module '%s': already visited\n", mod->name);
 		return 0;
 	}
 	mod->visited = true;
@@ -1024,9 +1001,8 @@ finish:
 	return err;
 }
 
-static int kmod_module_get_probe_list(struct kmod_module *mod,
-						bool ignorecmd,
-						struct kmod_list **list)
+static int kmod_module_get_probe_list(struct kmod_module *mod, bool ignorecmd,
+				      struct kmod_list **list)
 {
 	int err;
 
@@ -1048,14 +1024,11 @@ static int kmod_module_get_probe_list(struct kmod_module *mod,
 	return err;
 }
 
-KMOD_EXPORT int kmod_module_probe_insert_module(struct kmod_module *mod,
-			unsigned int flags, const char *extra_options,
-			int (*run_install)(struct kmod_module *m,
-						const char *cmd, void *data),
-			const void *data,
-			void (*print_action)(struct kmod_module *m,
-						bool install,
-						const char *options))
+KMOD_EXPORT int kmod_module_probe_insert_module(
+	struct kmod_module *mod, unsigned int flags, const char *extra_options,
+	int (*run_install)(struct kmod_module *m, const char *cmd, void *data),
+	const void *data,
+	void (*print_action)(struct kmod_module *m, bool install, const char *options))
 {
 	struct kmod_list *list = NULL, *l;
 	struct probe_insert_cb cb;
@@ -1064,8 +1037,7 @@ KMOD_EXPORT int kmod_module_probe_insert_module(struct kmod_module *mod,
 	if (mod == NULL)
 		return -ENOENT;
 
-	if (!(flags & KMOD_PROBE_IGNORE_LOADED)
-					&& module_is_inkernel(mod)) {
+	if (!(flags & KMOD_PROBE_IGNORE_LOADED) && module_is_inkernel(mod)) {
 		if (flags & KMOD_PROBE_FAIL_ON_LOADED)
 			return -EEXIST;
 		else
@@ -1083,16 +1055,16 @@ KMOD_EXPORT int kmod_module_probe_insert_module(struct kmod_module *mod,
 			return KMOD_PROBE_APPLY_BLACKLIST;
 	}
 
-	err = kmod_module_get_probe_list(mod,
-				!!(flags & KMOD_PROBE_IGNORE_COMMAND), &list);
+	err = kmod_module_get_probe_list(mod, !!(flags & KMOD_PROBE_IGNORE_COMMAND),
+					 &list);
 	if (err < 0)
 		return err;
 
 	if (flags & KMOD_PROBE_APPLY_BLACKLIST_ALL) {
 		struct kmod_list *filtered = NULL;
 
-		err = kmod_module_apply_filter(mod->ctx,
-				KMOD_FILTER_BLACKLIST, list, &filtered);
+		err = kmod_module_apply_filter(mod->ctx, KMOD_FILTER_BLACKLIST, list,
+					       &filtered);
 		if (err < 0)
 			return err;
 
@@ -1104,7 +1076,7 @@ KMOD_EXPORT int kmod_module_probe_insert_module(struct kmod_module *mod,
 	}
 
 	cb.run_install = run_install;
-	cb.data = (void *) data;
+	cb.data = (void *)data;
 
 	kmod_list_foreach(l, list) {
 		struct kmod_module *m = l->data;
@@ -1112,31 +1084,27 @@ KMOD_EXPORT int kmod_module_probe_insert_module(struct kmod_module *mod,
 		const char *cmd = kmod_module_get_install_commands(m);
 		char *options;
 
-		if (!(flags & KMOD_PROBE_IGNORE_LOADED)
-						&& module_is_inkernel(m)) {
-			DBG(mod->ctx, "Ignoring module '%s': already loaded\n",
-								m->name);
+		if (!(flags & KMOD_PROBE_IGNORE_LOADED) && module_is_inkernel(m)) {
+			DBG(mod->ctx, "Ignoring module '%s': already loaded\n", m->name);
 			err = -EEXIST;
 			goto finish_module;
 		}
 
-		options = module_options_concat(moptions,
-					m == mod ? extra_options : NULL);
+		options =
+			module_options_concat(moptions, m == mod ? extra_options : NULL);
 
 		if (cmd != NULL && !m->ignorecmd) {
 			if (print_action != NULL)
 				print_action(m, true, options ?: "");
 
 			if (!(flags & KMOD_PROBE_DRY_RUN))
-				err = module_do_install_commands(m, options,
-									&cb);
+				err = module_do_install_commands(m, options, &cb);
 		} else {
 			if (print_action != NULL)
 				print_action(m, false, options ?: "");
 
 			if (!(flags & KMOD_PROBE_DRY_RUN))
-				err = kmod_module_insert_module(m, flags,
-								options);
+				err = kmod_module_insert_module(m, flags, options);
 		}
 
 		free(options);
@@ -1152,8 +1120,7 @@ finish_module:
 		 * been loaded between the check and the moment we try to
 		 * insert it.
 		 */
-		if (err == -EEXIST && m == mod &&
-				(flags & KMOD_PROBE_FAIL_ON_LOADED))
+		if (err == -EEXIST && m == mod && (flags & KMOD_PROBE_FAIL_ON_LOADED))
 			break;
 
 		/*
@@ -1191,12 +1158,14 @@ KMOD_EXPORT const char *kmod_module_get_options(const struct kmod_module *mod)
 			size_t len;
 			void *tmp;
 
-			DBG(mod->ctx, "modname=%s mod->name=%s mod->alias=%s\n", modname, mod->name, mod->alias);
-			if (!(streq(modname, mod->name) || (mod->alias != NULL &&
-						streq(modname, mod->alias))))
+			DBG(mod->ctx, "modname=%s mod->name=%s mod->alias=%s\n", modname,
+			    mod->name, mod->alias);
+			if (!(streq(modname, mod->name) ||
+			      (mod->alias != NULL && streq(modname, mod->alias))))
 				continue;
 
-			DBG(mod->ctx, "passed = modname=%s mod->name=%s mod->alias=%s\n", modname, mod->name, mod->alias);
+			DBG(mod->ctx, "passed = modname=%s mod->name=%s mod->alias=%s\n",
+			    modname, mod->name, mod->alias);
 			str = kmod_option_get_options(l);
 			len = strlen(str);
 			if (len < 1)
@@ -1271,7 +1240,8 @@ void kmod_module_set_install_commands(struct kmod_module *mod, const char *cmd)
 	mod->install_commands = cmd;
 }
 
-static struct kmod_list *lookup_dep(struct kmod_ctx *ctx, const char * const * array, unsigned int count)
+static struct kmod_list *lookup_dep(struct kmod_ctx *ctx, const char *const *array,
+				    unsigned int count)
 {
 	struct kmod_list *ret = NULL;
 	unsigned i;
@@ -1283,7 +1253,8 @@ static struct kmod_list *lookup_dep(struct kmod_ctx *ctx, const char * const * a
 
 		err = kmod_module_new_from_lookup(ctx, depname, &lst);
 		if (err < 0) {
-			ERR(ctx, "failed to lookup dependency '%s', continuing anyway.\n", depname);
+			ERR(ctx, "failed to lookup dependency '%s', continuing anyway.\n",
+			    depname);
 			continue;
 		} else if (lst != NULL)
 			ret = kmod_list_append_list(ret, lst);
@@ -1292,8 +1263,7 @@ static struct kmod_list *lookup_dep(struct kmod_ctx *ctx, const char * const * a
 }
 
 KMOD_EXPORT int kmod_module_get_softdeps(const struct kmod_module *mod,
-						struct kmod_list **pre,
-						struct kmod_list **post)
+					 struct kmod_list **pre, struct kmod_list **post)
 {
 	const struct kmod_list *l;
 	const struct kmod_config *config;
@@ -1308,7 +1278,7 @@ KMOD_EXPORT int kmod_module_get_softdeps(const struct kmod_module *mod,
 
 	kmod_list_foreach(l, config->softdeps) {
 		const char *modname = kmod_softdep_get_name(l);
-		const char * const *array;
+		const char *const *array;
 		unsigned count;
 
 		if (fnmatch(modname, mod->name, 0) != 0)
@@ -1330,7 +1300,7 @@ KMOD_EXPORT int kmod_module_get_softdeps(const struct kmod_module *mod,
 }
 
 KMOD_EXPORT int kmod_module_get_weakdeps(const struct kmod_module *mod,
-						struct kmod_list **weak)
+					 struct kmod_list **weak)
 {
 	const struct kmod_list *l;
 	const struct kmod_config *config;
@@ -1344,7 +1314,7 @@ KMOD_EXPORT int kmod_module_get_weakdeps(const struct kmod_module *mod,
 
 	kmod_list_foreach(l, config->weakdeps) {
 		const char *modname = kmod_weakdep_get_name(l);
-		const char * const *array;
+		const char *const *array;
 		unsigned count;
 
 		if (fnmatch(modname, mod->name, 0) != 0)
@@ -1403,8 +1373,7 @@ void kmod_module_set_remove_commands(struct kmod_module *mod, const char *cmd)
 	mod->remove_commands = cmd;
 }
 
-KMOD_EXPORT int kmod_module_new_from_loaded(struct kmod_ctx *ctx,
-						struct kmod_list **list)
+KMOD_EXPORT int kmod_module_new_from_loaded(struct kmod_ctx *ctx, struct kmod_list **list)
 {
 	struct kmod_list *l = NULL;
 	FILE *fp;
@@ -1429,8 +1398,8 @@ KMOD_EXPORT int kmod_module_new_from_loaded(struct kmod_ctx *ctx,
 
 		err = kmod_module_new_from_name(ctx, name, &m);
 		if (err < 0) {
-			ERR(ctx, "could not get module from name '%s': %s\n",
-				name, strerror(-err));
+			ERR(ctx, "could not get module from name '%s': %s\n", name,
+			    strerror(-err));
 			goto eat_line;
 		}
 
@@ -1480,18 +1449,16 @@ KMOD_EXPORT int kmod_module_get_initstate(const struct kmod_module *mod)
 	if (kmod_module_is_builtin((struct kmod_module *)mod))
 		return KMOD_MODULE_BUILTIN;
 
-	pathlen = snprintf(path, sizeof(path),
-				"/sys/module/%s/initstate", mod->name);
+	pathlen = snprintf(path, sizeof(path), "/sys/module/%s/initstate", mod->name);
 	if (pathlen >= (int)sizeof(path)) {
 		/* Too long path was truncated */
 		return -ENAMETOOLONG;
 	}
-	fd = open(path, O_RDONLY|O_CLOEXEC);
+	fd = open(path, O_RDONLY | O_CLOEXEC);
 	if (fd < 0) {
 		err = -errno;
 
-		DBG(mod->ctx, "could not open '%s': %s\n",
-			path, strerror(-err));
+		DBG(mod->ctx, "could not open '%s': %s\n", path, strerror(-err));
 
 		if (pathlen > (int)sizeof("/initstate") - 1) {
 			struct stat st;
@@ -1500,16 +1467,14 @@ KMOD_EXPORT int kmod_module_get_initstate(const struct kmod_module *mod)
 				return KMOD_MODULE_COMING;
 		}
 
-		DBG(mod->ctx, "could not open '%s': %s\n",
-			path, strerror(-err));
+		DBG(mod->ctx, "could not open '%s': %s\n", path, strerror(-err));
 		return err;
 	}
 
 	err = read_str_safe(fd, buf, sizeof(buf));
 	close(fd);
 	if (err < 0) {
-		ERR(mod->ctx, "could not read from '%s': %s\n",
-			path, strerror(-err));
+		ERR(mod->ctx, "could not read from '%s': %s\n", path, strerror(-err));
 		return err;
 	}
 
@@ -1540,12 +1505,12 @@ KMOD_EXPORT long kmod_module_get_size(const struct kmod_module *mod)
 	 * loaded.
 	 */
 	snprintf(line, sizeof(line), "/sys/module/%s", mod->name);
-	dfd = open(line, O_RDONLY|O_CLOEXEC);
+	dfd = open(line, O_RDONLY | O_CLOEXEC);
 	if (dfd < 0)
 		return -errno;
 
 	/* available as of linux 3.3.x */
-	cfd = openat(dfd, "coresize", O_RDONLY|O_CLOEXEC);
+	cfd = openat(dfd, "coresize", O_RDONLY | O_CLOEXEC);
 	if (cfd >= 0) {
 		if (read_str_long(cfd, &size, 10) < 0)
 			ERR(mod->ctx, "failed to read coresize from %s\n", line);
@@ -1557,8 +1522,7 @@ KMOD_EXPORT long kmod_module_get_size(const struct kmod_module *mod)
 	fp = fopen("/proc/modules", "re");
 	if (fp == NULL) {
 		int err = -errno;
-		ERR(mod->ctx,
-		    "could not open /proc/modules: %s\n", strerror(errno));
+		ERR(mod->ctx, "could not open /proc/modules: %s\n", strerror(errno));
 		close(dfd);
 		return err;
 	}
@@ -1574,15 +1538,13 @@ KMOD_EXPORT long kmod_module_get_size(const struct kmod_module *mod)
 
 		tok = strtok_r(NULL, " \t", &saveptr);
 		if (tok == NULL) {
-			ERR(mod->ctx,
-			"invalid line format at /proc/modules:%d\n", lineno);
+			ERR(mod->ctx, "invalid line format at /proc/modules:%d\n", lineno);
 			break;
 		}
 
 		value = strtol(tok, &endptr, 10);
 		if (endptr == tok || *endptr != '\0') {
-			ERR(mod->ctx,
-			"invalid line format at /proc/modules:%d\n", lineno);
+			ERR(mod->ctx, "invalid line format at /proc/modules:%d\n", lineno);
 			break;
 		}
 
@@ -1609,19 +1571,18 @@ KMOD_EXPORT int kmod_module_get_refcnt(const struct kmod_module *mod)
 		return -ENOENT;
 
 	snprintf(path, sizeof(path), "/sys/module/%s/refcnt", mod->name);
-	fd = open(path, O_RDONLY|O_CLOEXEC);
+	fd = open(path, O_RDONLY | O_CLOEXEC);
 	if (fd < 0) {
 		err = -errno;
-		DBG(mod->ctx, "could not open '%s': %s\n",
-			path, strerror(errno));
+		DBG(mod->ctx, "could not open '%s': %s\n", path, strerror(errno));
 		return err;
 	}
 
 	err = read_str_long(fd, &refcnt, 10);
 	close(fd);
 	if (err < 0) {
-		ERR(mod->ctx, "could not read integer from '%s': '%s'\n",
-			path, strerror(-err));
+		ERR(mod->ctx, "could not read integer from '%s': '%s'\n", path,
+		    strerror(-err));
 		return err;
 	}
 
@@ -1642,8 +1603,7 @@ KMOD_EXPORT struct kmod_list *kmod_module_get_holders(const struct kmod_module *
 
 	d = opendir(dname);
 	if (d == NULL) {
-		ERR(mod->ctx, "could not open '%s': %s\n",
-						dname, strerror(errno));
+		ERR(mod->ctx, "could not open '%s': %s\n", dname, strerror(errno));
 		return NULL;
 	}
 
@@ -1658,11 +1618,10 @@ KMOD_EXPORT struct kmod_list *kmod_module_get_holders(const struct kmod_module *
 				continue;
 		}
 
-		err = kmod_module_new_from_name(mod->ctx, dent->d_name,
-						&holder);
+		err = kmod_module_new_from_name(mod->ctx, dent->d_name, &holder);
 		if (err < 0) {
 			ERR(mod->ctx, "could not create module for '%s': %s\n",
-				dent->d_name, strerror(-err));
+			    dent->d_name, strerror(-err));
 			goto fail;
 		}
 
@@ -1710,8 +1669,7 @@ KMOD_EXPORT struct kmod_list *kmod_module_get_sections(const struct kmod_module 
 
 	d = opendir(dname);
 	if (d == NULL) {
-		ERR(mod->ctx, "could not open '%s': %s\n",
-			dname, strerror(errno));
+		ERR(mod->ctx, "could not open '%s': %s\n", dname, strerror(errno));
 		return NULL;
 	}
 
@@ -1730,18 +1688,17 @@ KMOD_EXPORT struct kmod_list *kmod_module_get_sections(const struct kmod_module 
 				continue;
 		}
 
-		fd = openat(dfd, dent->d_name, O_RDONLY|O_CLOEXEC);
+		fd = openat(dfd, dent->d_name, O_RDONLY | O_CLOEXEC);
 		if (fd < 0) {
-			ERR(mod->ctx, "could not open '%s/%s': %m\n",
-							dname, dent->d_name);
+			ERR(mod->ctx, "could not open '%s/%s': %m\n", dname, dent->d_name);
 			goto fail;
 		}
 
 		err = read_str_ulong(fd, &address, 16);
 		close(fd);
 		if (err < 0) {
-			ERR(mod->ctx, "could not read long from '%s/%s': %m\n",
-							dname, dent->d_name);
+			ERR(mod->ctx, "could not read long from '%s/%s': %m\n", dname,
+			    dent->d_name);
 			goto fail;
 		}
 
@@ -1815,8 +1772,7 @@ static struct kmod_elf *kmod_module_get_elf(const struct kmod_module *mod)
 			return NULL;
 		}
 
-		((struct kmod_module *)mod)->file = kmod_file_open(mod->ctx,
-									path);
+		((struct kmod_module *)mod)->file = kmod_file_open(mod->ctx, path);
 		if (mod->file == NULL)
 			return NULL;
 	}
@@ -1829,7 +1785,8 @@ struct kmod_module_info {
 	char value[];
 };
 
-static struct kmod_module_info *kmod_module_info_new(const char *key, size_t keylen, const char *value, size_t valuelen)
+static struct kmod_module_info *kmod_module_info_new(const char *key, size_t keylen,
+						     const char *value, size_t valuelen)
 {
 	struct kmod_module_info *info;
 
@@ -1837,8 +1794,7 @@ static struct kmod_module_info *kmod_module_info_new(const char *key, size_t key
 	if (info == NULL)
 		return NULL;
 
-	info->key = (char *)info + sizeof(struct kmod_module_info)
-		    + valuelen + 1;
+	info->key = (char *)info + sizeof(struct kmod_module_info) + valuelen + 1;
 	memcpy(info->key, key, keylen);
 	info->key[keylen] = '\0';
 	memcpy(info->value, value, valuelen);
@@ -1851,7 +1807,9 @@ static void kmod_module_info_free(struct kmod_module_info *info)
 	free(info);
 }
 
-static struct kmod_list *kmod_module_info_append(struct kmod_list **list, const char *key, size_t keylen, const char *value, size_t valuelen)
+static struct kmod_list *kmod_module_info_append(struct kmod_list **list, const char *key,
+						 size_t keylen, const char *value,
+						 size_t valuelen)
 {
 	struct kmod_module_info *info;
 	struct kmod_list *n;
@@ -1895,10 +1853,8 @@ static char *kmod_module_hex_to_str(const char *hex, size_t len)
 }
 
 static struct kmod_list *kmod_module_info_append_hex(struct kmod_list **list,
-						     const char *key,
-						     size_t keylen,
-						     const char *value,
-						     size_t valuelen)
+						     const char *key, size_t keylen,
+						     const char *value, size_t valuelen)
 {
 	char *hex;
 	struct kmod_list *n;
@@ -1924,7 +1880,8 @@ list_error:
 	return NULL;
 }
 
-KMOD_EXPORT int kmod_module_get_info(const struct kmod_module *mod, struct kmod_list **list)
+KMOD_EXPORT int kmod_module_get_info(const struct kmod_module *mod,
+				     struct kmod_list **list)
 {
 	struct kmod_elf *elf;
 	char **strings;
@@ -1938,9 +1895,8 @@ KMOD_EXPORT int kmod_module_get_info(const struct kmod_module *mod, struct kmod_
 
 	/* remove const: this can only change internal state */
 	if (kmod_module_is_builtin((struct kmod_module *)mod)) {
-		count = kmod_builtin_get_modinfo(mod->ctx,
-						kmod_module_get_name(mod),
-						&strings);
+		count = kmod_builtin_get_modinfo(mod->ctx, kmod_module_get_name(mod),
+						 &strings);
 		if (count < 0)
 			return count;
 	} else {
@@ -1979,28 +1935,26 @@ KMOD_EXPORT int kmod_module_get_info(const struct kmod_module *mod, struct kmod_
 		struct kmod_list *n;
 
 		n = kmod_module_info_append(list, "sig_id", strlen("sig_id"),
-				sig_info.id_type, strlen(sig_info.id_type));
+					    sig_info.id_type, strlen(sig_info.id_type));
 		if (n == NULL)
 			goto list_error;
 		count++;
 
 		n = kmod_module_info_append(list, "signer", strlen("signer"),
-				sig_info.signer, sig_info.signer_len);
+					    sig_info.signer, sig_info.signer_len);
 		if (n == NULL)
 			goto list_error;
 		count++;
-
 
 		n = kmod_module_info_append_hex(list, "sig_key", strlen("sig_key"),
-						sig_info.key_id,
-						sig_info.key_id_len);
+						sig_info.key_id, sig_info.key_id_len);
 		if (n == NULL)
 			goto list_error;
 		count++;
 
-		n = kmod_module_info_append(list,
-				"sig_hashalgo", strlen("sig_hashalgo"),
-				sig_info.hash_algo, strlen(sig_info.hash_algo));
+		n = kmod_module_info_append(list, "sig_hashalgo", strlen("sig_hashalgo"),
+					    sig_info.hash_algo,
+					    strlen(sig_info.hash_algo));
 		if (n == NULL)
 			goto list_error;
 		count++;
@@ -2009,15 +1963,12 @@ KMOD_EXPORT int kmod_module_get_info(const struct kmod_module *mod, struct kmod_
 		 * Omit sig_info.algo for now, as these
 		 * are currently constant.
 		 */
-		n = kmod_module_info_append_hex(list, "signature",
-						strlen("signature"),
-						sig_info.sig,
-						sig_info.sig_len);
+		n = kmod_module_info_append_hex(list, "signature", strlen("signature"),
+						sig_info.sig, sig_info.sig_len);
 
 		if (n == NULL)
 			goto list_error;
 		count++;
-
 	}
 	ret = count;
 
@@ -2068,7 +2019,8 @@ struct kmod_module_version {
 	char symbol[];
 };
 
-static struct kmod_module_version *kmod_module_versions_new(uint64_t crc, const char *symbol)
+static struct kmod_module_version *kmod_module_versions_new(uint64_t crc,
+							    const char *symbol)
 {
 	struct kmod_module_version *mv;
 	size_t symbollen = strlen(symbol) + 1;
@@ -2087,7 +2039,8 @@ static void kmod_module_version_free(struct kmod_module_version *version)
 	free(version);
 }
 
-KMOD_EXPORT int kmod_module_get_versions(const struct kmod_module *mod, struct kmod_list **list)
+KMOD_EXPORT int kmod_module_get_versions(const struct kmod_module *mod,
+					 struct kmod_list **list)
 {
 	struct kmod_elf *elf;
 	struct kmod_modversion *versions;
@@ -2190,7 +2143,8 @@ static void kmod_module_symbol_free(struct kmod_module_symbol *symbol)
 	free(symbol);
 }
 
-KMOD_EXPORT int kmod_module_get_symbols(const struct kmod_module *mod, struct kmod_list **list)
+KMOD_EXPORT int kmod_module_get_symbols(const struct kmod_module *mod,
+					struct kmod_list **list)
 {
 	struct kmod_elf *elf;
 	struct kmod_modversion *symbols;
@@ -2292,12 +2246,14 @@ static struct kmod_module_dependency_symbol *kmod_module_dependency_symbols_new(
 	return mv;
 }
 
-static void kmod_module_dependency_symbol_free(struct kmod_module_dependency_symbol *dependency_symbol)
+static void kmod_module_dependency_symbol_free(
+	struct kmod_module_dependency_symbol *dependency_symbol)
 {
 	free(dependency_symbol);
 }
 
-KMOD_EXPORT int kmod_module_get_dependency_symbols(const struct kmod_module *mod, struct kmod_list **list)
+KMOD_EXPORT int kmod_module_get_dependency_symbols(const struct kmod_module *mod,
+						   struct kmod_list **list)
 {
 	struct kmod_elf *elf;
 	struct kmod_modversion *symbols;
@@ -2320,8 +2276,7 @@ KMOD_EXPORT int kmod_module_get_dependency_symbols(const struct kmod_module *mod
 		struct kmod_module_dependency_symbol *mv;
 		struct kmod_list *n;
 
-		mv = kmod_module_dependency_symbols_new(symbols[i].crc,
-							symbols[i].bind,
+		mv = kmod_module_dependency_symbols_new(symbols[i].crc, symbols[i].bind,
 							symbols[i].symbol);
 		if (mv == NULL) {
 			ret = -errno;

--- a/libkmod/libkmod-signature.c
+++ b/libkmod/libkmod-signature.c
@@ -29,8 +29,8 @@ enum pkey_algo {
 };
 
 static const char *const pkey_algo[PKEY_ALGO__LAST] = {
-	[PKEY_ALGO_DSA]		= "DSA",
-	[PKEY_ALGO_RSA]		= "RSA",
+	[PKEY_ALGO_DSA] = "DSA",
+	[PKEY_ALGO_RSA] = "RSA",
 };
 
 enum pkey_hash_algo {
@@ -61,29 +61,29 @@ const char *const pkey_hash_algo[PKEY_HASH__LAST] = {
 };
 
 enum pkey_id_type {
-	PKEY_ID_PGP,		/* OpenPGP generated key ID */
-	PKEY_ID_X509,		/* X.509 arbitrary subjectKeyIdentifier */
-	PKEY_ID_PKCS7,		/* Signature in PKCS#7 message */
+	PKEY_ID_PGP, /* OpenPGP generated key ID */
+	PKEY_ID_X509, /* X.509 arbitrary subjectKeyIdentifier */
+	PKEY_ID_PKCS7, /* Signature in PKCS#7 message */
 	PKEY_ID_TYPE__LAST,
 };
 
 const char *const pkey_id_type[PKEY_ID_TYPE__LAST] = {
-	[PKEY_ID_PGP]		= "PGP",
-	[PKEY_ID_X509]		= "X509",
-	[PKEY_ID_PKCS7]		= "PKCS#7",
+	[PKEY_ID_PGP] = "PGP",
+	[PKEY_ID_X509] = "X509",
+	[PKEY_ID_PKCS7] = "PKCS#7",
 };
 
 /*
  * Module signature information block.
  */
 struct module_signature {
-	uint8_t algo;        /* Public-key crypto algorithm [enum pkey_algo] */
-	uint8_t hash;        /* Digest algorithm [enum pkey_hash_algo] */
-	uint8_t id_type;     /* Key identifier type [enum pkey_id_type] */
-	uint8_t signer_len;  /* Length of signer's name */
-	uint8_t key_id_len;  /* Length of key identifier */
+	uint8_t algo; /* Public-key crypto algorithm [enum pkey_algo] */
+	uint8_t hash; /* Digest algorithm [enum pkey_hash_algo] */
+	uint8_t id_type; /* Key identifier type [enum pkey_id_type] */
+	uint8_t signer_len; /* Length of signer's name */
+	uint8_t key_id_len; /* Length of key identifier */
 	uint8_t __pad[3];
-	uint32_t sig_len;    /* Length of signature data (big endian) */
+	uint32_t sig_len; /* Length of signature data (big endian) */
 };
 
 static bool fill_default(const char *mem, off_t size,
@@ -156,13 +156,12 @@ static const char *x509_name_to_str(X509_NAME *name)
 	return str;
 }
 
-static bool fill_pkcs7(const char *mem, off_t size,
-		       const struct module_signature *modsig, size_t sig_len,
-		       struct kmod_signature_info *sig_info)
+static bool fill_pkcs7(const char *mem, off_t size, const struct module_signature *modsig,
+		       size_t sig_len, struct kmod_signature_info *sig_info)
 {
 	const char *pkcs7_raw;
 	PKCS7 *pkcs7;
-	STACK_OF(PKCS7_SIGNER_INFO) *sis;
+	STACK_OF(PKCS7_SIGNER_INFO) * sis;
 	PKCS7_SIGNER_INFO *si;
 	PKCS7_ISSUER_AND_SERIAL *is;
 	X509_NAME *issuer;
@@ -279,9 +278,8 @@ err:
 
 #else /* ENABLE OPENSSL */
 
-static bool fill_pkcs7(const char *mem, off_t size,
-		       const struct module_signature *modsig, size_t sig_len,
-		       struct kmod_signature_info *sig_info)
+static bool fill_pkcs7(const char *mem, off_t size, const struct module_signature *modsig,
+		       size_t sig_len, struct kmod_signature_info *sig_info)
 {
 	sig_info->hash_algo = "unknown";
 	sig_info->id_type = pkey_id_type[modsig->id_type];
@@ -303,7 +301,8 @@ static bool fill_pkcs7(const char *mem, off_t size,
  * [ SIG_MAGIC               ]
  */
 
-bool kmod_module_signature_info(const struct kmod_file *file, struct kmod_signature_info *sig_info)
+bool kmod_module_signature_info(const struct kmod_file *file,
+				struct kmod_signature_info *sig_info)
 {
 	const char *mem;
 	off_t size;
@@ -322,9 +321,8 @@ bool kmod_module_signature_info(const struct kmod_file *file, struct kmod_signat
 		return false;
 	size -= sizeof(struct module_signature);
 	memcpy(&modsig, mem + size, sizeof(struct module_signature));
-	if (modsig.algo >= PKEY_ALGO__LAST ||
-			modsig.hash >= PKEY_HASH__LAST ||
-			modsig.id_type >= PKEY_ID_TYPE__LAST)
+	if (modsig.algo >= PKEY_ALGO__LAST || modsig.hash >= PKEY_HASH__LAST ||
+	    modsig.id_type >= PKEY_ID_TYPE__LAST)
 		return false;
 	sig_len = be32toh(modsig.sig_len);
 	if (sig_len == 0 ||

--- a/libkmod/libkmod.c
+++ b/libkmod/libkmod.c
@@ -55,9 +55,8 @@ static const char *const default_config_paths[] = {
 struct kmod_ctx {
 	int refcount;
 	int log_priority;
-	void (*log_fn)(void *data,
-			int priority, const char *file, int line,
-			const char *fn, const char *format, va_list args);
+	void (*log_fn)(void *data, int priority, const char *file, int line,
+		       const char *fn, const char *format, va_list args);
 	void *log_data;
 	const void *userdata;
 	char *dirname;
@@ -68,9 +67,8 @@ struct kmod_ctx {
 	unsigned long long indexes_stamp[_KMOD_INDEX_MODULES_SIZE];
 };
 
-void kmod_log(const struct kmod_ctx *ctx,
-		int priority, const char *file, int line, const char *fn,
-		const char *format, ...)
+void kmod_log(const struct kmod_ctx *ctx, int priority, const char *file, int line,
+	      const char *fn, const char *format, ...)
 {
 	va_list args;
 
@@ -82,10 +80,9 @@ void kmod_log(const struct kmod_ctx *ctx,
 	va_end(args);
 }
 
-_printf_format_(6, 0)
-static void log_filep(void *data,
-			int priority, const char *file, int line,
-			const char *fn, const char *format, va_list args)
+_printf_format_(6, 0) static void log_filep(void *data, int priority, const char *file,
+					    int line, const char *fn, const char *format,
+					    va_list args)
 {
 	FILE *fp = data;
 #ifdef ENABLE_DEBUG
@@ -192,7 +189,7 @@ static enum kmod_file_compression_type get_kernel_compression(struct kmod_ctx *c
 	int fd;
 	int err;
 
-	fd = open(path, O_RDONLY|O_CLOEXEC);
+	fd = open(path, O_RDONLY | O_CLOEXEC);
 	if (fd < 0) {
 		/* Not having the file is not an error: kernel may be too old */
 		DBG(ctx, "could not open '%s' for reading: %m\n", path);
@@ -202,8 +199,7 @@ static enum kmod_file_compression_type get_kernel_compression(struct kmod_ctx *c
 	err = read_str_safe(fd, buf, sizeof(buf));
 	close(fd);
 	if (err < 0) {
-		ERR(ctx, "could not read from '%s': %s\n",
-		    path, strerror(-err));
+		ERR(ctx, "could not read from '%s': %s\n", path, strerror(-err));
 		return KMOD_FILE_COMPRESSION_NONE;
 	}
 
@@ -219,8 +215,7 @@ static enum kmod_file_compression_type get_kernel_compression(struct kmod_ctx *c
 	return KMOD_FILE_COMPRESSION_NONE;
 }
 
-KMOD_EXPORT struct kmod_ctx *kmod_new(const char *dirname,
-					const char * const *config_paths)
+KMOD_EXPORT struct kmod_ctx *kmod_new(const char *dirname, const char *const *config_paths)
 {
 	const char *env;
 	struct kmod_ctx *ctx;
@@ -303,11 +298,10 @@ KMOD_EXPORT struct kmod_ctx *kmod_unref(struct kmod_ctx *ctx)
 }
 
 KMOD_EXPORT void kmod_set_log_fn(struct kmod_ctx *ctx,
-					void (*log_fn)(void *data,
-						int priority, const char *file,
-						int line, const char *fn,
+				 void (*log_fn)(void *data, int priority,
+						const char *file, int line, const char *fn,
 						const char *format, va_list args),
-					const void *data)
+				 const void *data)
 {
 	if (ctx == NULL)
 		return;
@@ -330,8 +324,7 @@ KMOD_EXPORT void kmod_set_log_priority(struct kmod_ctx *ctx, int priority)
 	ctx->log_priority = priority;
 }
 
-struct kmod_module *kmod_pool_get_module(struct kmod_ctx *ctx,
-							const char *key)
+struct kmod_module *kmod_pool_get_module(struct kmod_ctx *ctx, const char *key)
 {
 	struct kmod_module *mod;
 
@@ -342,16 +335,14 @@ struct kmod_module *kmod_pool_get_module(struct kmod_ctx *ctx,
 	return mod;
 }
 
-void kmod_pool_add_module(struct kmod_ctx *ctx, struct kmod_module *mod,
-							const char *key)
+void kmod_pool_add_module(struct kmod_ctx *ctx, struct kmod_module *mod, const char *key)
 {
 	DBG(ctx, "add %p key='%s'\n", mod, key);
 
 	hash_add(ctx->modules_by_name, key, mod);
 }
 
-void kmod_pool_del_module(struct kmod_ctx *ctx, struct kmod_module *mod,
-							const char *key)
+void kmod_pool_del_module(struct kmod_ctx *ctx, struct kmod_module *mod, const char *key)
 {
 	DBG(ctx, "del %p key='%s'\n", mod, key);
 
@@ -359,9 +350,8 @@ void kmod_pool_del_module(struct kmod_ctx *ctx, struct kmod_module *mod,
 }
 
 static int kmod_lookup_alias_from_alias_bin(struct kmod_ctx *ctx,
-						enum kmod_index index_number,
-						const char *name,
-						struct kmod_list **list)
+					    enum kmod_index index_number,
+					    const char *name, struct kmod_list **list)
 {
 	int err, nmatch = 0;
 	struct index_file *idx;
@@ -369,14 +359,13 @@ static int kmod_lookup_alias_from_alias_bin(struct kmod_ctx *ctx,
 
 	if (ctx->indexes[index_number] != NULL) {
 		DBG(ctx, "use mmapped index '%s' for name=%s\n",
-			index_files[index_number].fn, name);
-		realnames = index_mm_searchwild(ctx->indexes[index_number],
-									name);
+		    index_files[index_number].fn, name);
+		realnames = index_mm_searchwild(ctx->indexes[index_number], name);
 	} else {
 		char fn[PATH_MAX];
 
 		snprintf(fn, sizeof(fn), "%s/%s.bin", ctx->dirname,
-					index_files[index_number].fn);
+			 index_files[index_number].fn);
 
 		DBG(ctx, "file=%s name=%s\n", fn, name);
 
@@ -409,24 +398,22 @@ fail:
 	*list = kmod_list_remove_n_latest(*list, nmatch);
 	index_values_free(realnames);
 	return err;
-
 }
 
 int kmod_lookup_alias_from_symbols_file(struct kmod_ctx *ctx, const char *name,
-						struct kmod_list **list)
+					struct kmod_list **list)
 {
 	if (!strstartswith(name, "symbol:"))
 		return 0;
 
-	return kmod_lookup_alias_from_alias_bin(ctx, KMOD_INDEX_MODULES_SYMBOL,
-								name, list);
+	return kmod_lookup_alias_from_alias_bin(ctx, KMOD_INDEX_MODULES_SYMBOL, name,
+						list);
 }
 
 int kmod_lookup_alias_from_aliases_file(struct kmod_ctx *ctx, const char *name,
-						struct kmod_list **list)
+					struct kmod_list **list)
 {
-	return kmod_lookup_alias_from_alias_bin(ctx, KMOD_INDEX_MODULES_ALIAS,
-								name, list);
+	return kmod_lookup_alias_from_alias_bin(ctx, KMOD_INDEX_MODULES_ALIAS, name, list);
 }
 
 static char *lookup_builtin_file(struct kmod_ctx *ctx, const char *name)
@@ -435,16 +422,14 @@ static char *lookup_builtin_file(struct kmod_ctx *ctx, const char *name)
 
 	if (ctx->indexes[KMOD_INDEX_MODULES_BUILTIN]) {
 		DBG(ctx, "use mmapped index '%s' modname=%s\n",
-				index_files[KMOD_INDEX_MODULES_BUILTIN].fn,
-				name);
-		line = index_mm_search(ctx->indexes[KMOD_INDEX_MODULES_BUILTIN],
-									name);
+		    index_files[KMOD_INDEX_MODULES_BUILTIN].fn, name);
+		line = index_mm_search(ctx->indexes[KMOD_INDEX_MODULES_BUILTIN], name);
 	} else {
 		struct index_file *idx;
 		char fn[PATH_MAX];
 
 		snprintf(fn, sizeof(fn), "%s/%s.bin", ctx->dirname,
-				index_files[KMOD_INDEX_MODULES_BUILTIN].fn);
+			 index_files[KMOD_INDEX_MODULES_BUILTIN].fn);
 		DBG(ctx, "file=%s modname=%s\n", fn, name);
 
 		idx = index_file_open(fn);
@@ -460,17 +445,15 @@ static char *lookup_builtin_file(struct kmod_ctx *ctx, const char *name)
 	return line;
 }
 
-int kmod_lookup_alias_from_kernel_builtin_file(struct kmod_ctx *ctx,
-						const char *name,
-						struct kmod_list **list)
+int kmod_lookup_alias_from_kernel_builtin_file(struct kmod_ctx *ctx, const char *name,
+					       struct kmod_list **list)
 {
 	struct kmod_list *l;
 	int ret;
 
 	assert(*list == NULL);
 
-	ret = kmod_lookup_alias_from_alias_bin(ctx,
-					       KMOD_INDEX_MODULES_BUILTIN_ALIAS,
+	ret = kmod_lookup_alias_from_alias_bin(ctx, KMOD_INDEX_MODULES_BUILTIN_ALIAS,
 					       name, list);
 
 	kmod_list_foreach(l, *list) {
@@ -482,7 +465,7 @@ int kmod_lookup_alias_from_kernel_builtin_file(struct kmod_ctx *ctx,
 }
 
 int kmod_lookup_alias_from_builtin_file(struct kmod_ctx *ctx, const char *name,
-						struct kmod_list **list)
+					struct kmod_list **list)
 {
 	char *line;
 	int err = 0;
@@ -495,8 +478,8 @@ int kmod_lookup_alias_from_builtin_file(struct kmod_ctx *ctx, const char *name,
 
 		err = kmod_module_new_from_name(ctx, name, &mod);
 		if (err < 0) {
-			ERR(ctx, "Could not create module from name %s: %s\n",
-							name, strerror(-err));
+			ERR(ctx, "Could not create module from name %s: %s\n", name,
+			    strerror(-err));
 			goto finish;
 		}
 
@@ -530,13 +513,12 @@ char *kmod_search_moddep(struct kmod_ctx *ctx, const char *name)
 
 	if (ctx->indexes[KMOD_INDEX_MODULES_DEP]) {
 		DBG(ctx, "use mmapped index '%s' modname=%s\n",
-				index_files[KMOD_INDEX_MODULES_DEP].fn, name);
-		return index_mm_search(ctx->indexes[KMOD_INDEX_MODULES_DEP],
-									name);
+		    index_files[KMOD_INDEX_MODULES_DEP].fn, name);
+		return index_mm_search(ctx->indexes[KMOD_INDEX_MODULES_DEP], name);
 	}
 
 	snprintf(fn, sizeof(fn), "%s/%s.bin", ctx->dirname,
-					index_files[KMOD_INDEX_MODULES_DEP].fn);
+		 index_files[KMOD_INDEX_MODULES_DEP].fn);
 
 	DBG(ctx, "file=%s modname=%s\n", fn, name);
 
@@ -553,7 +535,7 @@ char *kmod_search_moddep(struct kmod_ctx *ctx, const char *name)
 }
 
 int kmod_lookup_alias_from_moddep_file(struct kmod_ctx *ctx, const char *name,
-						struct kmod_list **list)
+				       struct kmod_list **list)
 {
 	char *line;
 	int n = 0;
@@ -571,8 +553,8 @@ int kmod_lookup_alias_from_moddep_file(struct kmod_ctx *ctx, const char *name,
 
 		n = kmod_module_new_from_name(ctx, name, &mod);
 		if (n < 0) {
-			ERR(ctx, "Could not create module from name %s: %s\n",
-			    name, strerror(-n));
+			ERR(ctx, "Could not create module from name %s: %s\n", name,
+			    strerror(-n));
 			goto finish;
 		}
 
@@ -587,7 +569,7 @@ finish:
 }
 
 int kmod_lookup_alias_from_config(struct kmod_ctx *ctx, const char *name,
-						struct kmod_list **list)
+				  struct kmod_list **list)
 {
 	struct kmod_config *config = ctx->config;
 	struct kmod_list *l;
@@ -600,10 +582,10 @@ int kmod_lookup_alias_from_config(struct kmod_ctx *ctx, const char *name,
 		if (fnmatch(aliasname, name, 0) == 0) {
 			struct kmod_module *mod;
 
-			err = kmod_module_new_from_alias(ctx, aliasname,
-								modname, &mod);
+			err = kmod_module_new_from_alias(ctx, aliasname, modname, &mod);
 			if (err < 0) {
-				ERR(ctx, "Could not create module for alias=%s modname=%s: %s\n",
+				ERR(ctx,
+				    "Could not create module for alias=%s modname=%s: %s\n",
 				    name, modname, strerror(-err));
 				goto fail;
 			}
@@ -621,7 +603,7 @@ fail:
 }
 
 int kmod_lookup_alias_from_commands(struct kmod_ctx *ctx, const char *name,
-						struct kmod_list **list)
+				    struct kmod_list **list)
 {
 	struct kmod_config *config = ctx->config;
 	struct kmod_list *l, *node;
@@ -753,8 +735,7 @@ KMOD_EXPORT int kmod_validate_resources(struct kmod_ctx *ctx)
 		if (ctx->indexes[i] == NULL)
 			continue;
 
-		snprintf(path, sizeof(path), "%s/%s.bin", ctx->dirname,
-						index_files[i].fn);
+		snprintf(path, sizeof(path), "%s/%s.bin", ctx->dirname, index_files[i].fn);
 
 		if (is_cache_invalid(path, ctx->indexes_stamp[i]))
 			return KMOD_RESOURCES_MUST_RELOAD;
@@ -775,15 +756,12 @@ KMOD_EXPORT int kmod_load_resources(struct kmod_ctx *ctx)
 		char path[PATH_MAX];
 
 		if (ctx->indexes[i] != NULL) {
-			INFO(ctx, "Index %s already loaded\n",
-							index_files[i].fn);
+			INFO(ctx, "Index %s already loaded\n", index_files[i].fn);
 			continue;
 		}
 
-		snprintf(path, sizeof(path), "%s/%s.bin", ctx->dirname,
-							index_files[i].fn);
-		ret = index_mm_open(ctx, path, &ctx->indexes_stamp[i],
-				    &ctx->indexes[i]);
+		snprintf(path, sizeof(path), "%s/%s.bin", ctx->dirname, index_files[i].fn);
+		ret = index_mm_open(ctx, path, &ctx->indexes_stamp[i], &ctx->indexes[i]);
 
 		/*
 		 * modules.builtin.alias are considered optional since it's
@@ -819,8 +797,7 @@ KMOD_EXPORT void kmod_unload_resources(struct kmod_ctx *ctx)
 	}
 }
 
-KMOD_EXPORT int kmod_dump_index(struct kmod_ctx *ctx, enum kmod_index type,
-									int fd)
+KMOD_EXPORT int kmod_dump_index(struct kmod_ctx *ctx, enum kmod_index type, int fd)
 {
 	if (ctx == NULL)
 		return -ENOSYS;
@@ -830,14 +807,12 @@ KMOD_EXPORT int kmod_dump_index(struct kmod_ctx *ctx, enum kmod_index type,
 
 	if (ctx->indexes[type] != NULL) {
 		DBG(ctx, "use mmapped index '%s'\n", index_files[type].fn);
-		index_mm_dump(ctx->indexes[type], fd,
-						index_files[type].prefix);
+		index_mm_dump(ctx->indexes[type], fd, index_files[type].prefix);
 	} else {
 		char fn[PATH_MAX];
 		struct index_file *idx;
 
-		snprintf(fn, sizeof(fn), "%s/%s.bin", ctx->dirname,
-						index_files[type].fn);
+		snprintf(fn, sizeof(fn), "%s/%s.bin", ctx->dirname, index_files[type].fn);
 
 		DBG(ctx, "file=%s\n", fn);
 

--- a/libkmod/libkmod.h
+++ b/libkmod/libkmod.h
@@ -55,7 +55,7 @@ struct kmod_ctx;
  *
  * Since: 1
  */
-struct kmod_ctx *kmod_new(const char *dirname, const char * const *config_paths);
+struct kmod_ctx *kmod_new(const char *dirname, const char *const *config_paths);
 
 /**
  * kmod_ref:
@@ -81,7 +81,6 @@ struct kmod_ctx *kmod_ref(struct kmod_ctx *ctx);
  * Since: 1
  */
 struct kmod_ctx *kmod_unref(struct kmod_ctx *ctx);
-
 
 /**
  * kmod_load_resources:
@@ -187,7 +186,6 @@ enum kmod_index {
  */
 int kmod_dump_index(struct kmod_ctx *ctx, enum kmod_index type, int fd);
 
-
 /**
  * kmod_set_log_priority:
  * @ctx: kmod library context
@@ -225,11 +223,10 @@ int kmod_get_log_priority(const struct kmod_ctx *ctx);
  * Since: 1
  */
 void kmod_set_log_fn(struct kmod_ctx *ctx,
-			void (*log_fn)(void *log_data,
-					int priority, const char *file, int line,
-					const char *fn, const char *format,
-					va_list args),
-			const void *data);
+		     void (*log_fn)(void *log_data, int priority, const char *file,
+				    int line, const char *fn, const char *format,
+				    va_list args),
+		     const void *data);
 
 /**
  * kmod_set_userdata:
@@ -266,8 +263,6 @@ void *kmod_get_userdata(const struct kmod_ctx *ctx);
  */
 const char *kmod_get_dirname(const struct kmod_ctx *ctx);
 
-
-
 /**
  * SECTION:libkmod-list
  * @short_description: general purpose list
@@ -290,9 +285,7 @@ struct kmod_list;
  * Iterate over the list @list.
  */
 #define kmod_list_foreach(curr, list) \
-	for (curr = list; \
-		curr != NULL; \
-		curr = kmod_list_next(list, curr))
+	for (curr = list; curr != NULL; curr = kmod_list_next(list, curr))
 
 /**
  * kmod_list_foreach_reverse:
@@ -302,9 +295,7 @@ struct kmod_list;
  * Iterate in reverse over the list @list.
  */
 #define kmod_list_foreach_reverse(curr, list) \
-	for (curr = kmod_list_last(list); \
-		curr != NULL; \
-		curr = kmod_list_prev(list, curr))
+	for (curr = kmod_list_last(list); curr != NULL; curr = kmod_list_prev(list, curr))
 
 /**
  * kmod_list_last:
@@ -339,7 +330,7 @@ struct kmod_list *kmod_list_last(const struct kmod_list *list);
  * Since: 1
  */
 struct kmod_list *kmod_list_next(const struct kmod_list *list,
-						const struct kmod_list *curr);
+				 const struct kmod_list *curr);
 
 /**
  * kmod_list_prev:
@@ -357,9 +348,7 @@ struct kmod_list *kmod_list_next(const struct kmod_list *list,
  * Since: 1
  */
 struct kmod_list *kmod_list_prev(const struct kmod_list *list,
-						const struct kmod_list *curr);
-
-
+				 const struct kmod_list *curr);
 
 /**
  * SECTION:libkmod-config
@@ -542,7 +531,6 @@ bool kmod_config_iter_next(struct kmod_config_iter *iter);
  */
 void kmod_config_iter_free_iter(struct kmod_config_iter *iter);
 
-
 /**
  * SECTION:libkmod-module
  * @short_description: operate on kernel modules
@@ -588,7 +576,7 @@ struct kmod_module;
  * Since: 1
  */
 int kmod_module_new_from_lookup(struct kmod_ctx *ctx, const char *given_alias,
-						struct kmod_list **list);
+				struct kmod_list **list);
 
 /**
  * kmod_module_new_from_name_lookup:
@@ -616,8 +604,7 @@ int kmod_module_new_from_lookup(struct kmod_ctx *ctx, const char *given_alias,
  *
  * Since: 30
  */
-int kmod_module_new_from_name_lookup(struct kmod_ctx *ctx,
-				     const char *modname,
+int kmod_module_new_from_name_lookup(struct kmod_ctx *ctx, const char *modname,
 				     struct kmod_module **mod);
 
 /**
@@ -645,7 +632,7 @@ int kmod_module_new_from_name_lookup(struct kmod_ctx *ctx,
  * Since: 1
  */
 int kmod_module_new_from_name(struct kmod_ctx *ctx, const char *name,
-						struct kmod_module **mod);
+			      struct kmod_module **mod);
 
 /**
  * kmod_module_new_from_path:
@@ -671,8 +658,7 @@ int kmod_module_new_from_name(struct kmod_ctx *ctx, const char *name,
  * Since: 1
  */
 int kmod_module_new_from_path(struct kmod_ctx *ctx, const char *path,
-						struct kmod_module **mod);
-
+			      struct kmod_module **mod);
 
 /**
  * kmod_module_ref:
@@ -713,7 +699,6 @@ struct kmod_module *kmod_module_unref(struct kmod_module *mod);
  */
 int kmod_module_unref_list(struct kmod_list *list);
 
-
 /**
  * kmod_insert:
  * @KMOD_INSERT_FORCE_VERMAGIC: ignore kernel version magic
@@ -742,7 +727,7 @@ enum kmod_insert {
  * Since: 1
  */
 int kmod_module_insert_module(struct kmod_module *mod, unsigned int flags,
-							const char *options);
+			      const char *options);
 
 /**
  * kmod_probe:
@@ -768,17 +753,17 @@ int kmod_module_insert_module(struct kmod_module *mod, unsigned int flags,
  * Bitmask which defines the behaviour of kmod_module_probe_insert_module().
  */
 enum kmod_probe {
-	KMOD_PROBE_FORCE_VERMAGIC =		0x00001,
-	KMOD_PROBE_FORCE_MODVERSION =		0x00002,
-	KMOD_PROBE_IGNORE_COMMAND =		0x00004,
-	KMOD_PROBE_IGNORE_LOADED =		0x00008,
-	KMOD_PROBE_DRY_RUN =			0x00010,
-	KMOD_PROBE_FAIL_ON_LOADED =		0x00020,
+	KMOD_PROBE_FORCE_VERMAGIC = 0x00001,
+	KMOD_PROBE_FORCE_MODVERSION = 0x00002,
+	KMOD_PROBE_IGNORE_COMMAND = 0x00004,
+	KMOD_PROBE_IGNORE_LOADED = 0x00008,
+	KMOD_PROBE_DRY_RUN = 0x00010,
+	KMOD_PROBE_FAIL_ON_LOADED = 0x00020,
 
 	/* codes below can be used in return value, too */
-	KMOD_PROBE_APPLY_BLACKLIST_ALL =	0x10000,
-	KMOD_PROBE_APPLY_BLACKLIST =		0x20000,
-	KMOD_PROBE_APPLY_BLACKLIST_ALIAS_ONLY =	0x40000,
+	KMOD_PROBE_APPLY_BLACKLIST_ALL = 0x10000,
+	KMOD_PROBE_APPLY_BLACKLIST = 0x20000,
+	KMOD_PROBE_APPLY_BLACKLIST_ALIAS_ONLY = 0x40000,
 };
 
 /**
@@ -807,13 +792,11 @@ enum kmod_probe {
  *
  * Since: 3
  */
-int kmod_module_probe_insert_module(struct kmod_module *mod,
-			unsigned int flags, const char *extra_options,
-			int (*run_install)(struct kmod_module *m,
-						const char *cmdline, void *data),
-			const void *data,
-			void (*print_action)(struct kmod_module *m, bool install,
-						const char *options));
+int kmod_module_probe_insert_module(
+	struct kmod_module *mod, unsigned int flags, const char *extra_options,
+	int (*run_install)(struct kmod_module *m, const char *cmdline, void *data),
+	const void *data,
+	void (*print_action)(struct kmod_module *m, bool install, const char *options));
 
 /**
  * kmod_remove:
@@ -844,7 +827,6 @@ enum kmod_remove {
  * Since: 1
  */
 int kmod_module_remove_module(struct kmod_module *mod, unsigned int flags);
-
 
 /**
  * kmod_module_get_module:
@@ -896,8 +878,8 @@ struct kmod_list *kmod_module_get_dependencies(const struct kmod_module *mod);
  *
  * Since: 2
  */
-int kmod_module_get_softdeps(const struct kmod_module *mod,
-				struct kmod_list **pre, struct kmod_list **post);
+int kmod_module_get_softdeps(const struct kmod_module *mod, struct kmod_list **pre,
+			     struct kmod_list **post);
 
 /**
  * kmod_module_get_weakdeps:
@@ -917,8 +899,7 @@ int kmod_module_get_softdeps(const struct kmod_module *mod,
  *
  * Since: 33
  */
-int kmod_module_get_weakdeps(const struct kmod_module *mod,
-				struct kmod_list **weak);
+int kmod_module_get_weakdeps(const struct kmod_module *mod, struct kmod_list **weak);
 
 /**
  * kmod_filter:
@@ -947,10 +928,8 @@ enum kmod_filter {
  *
  * Since: 6
  */
-int kmod_module_apply_filter(const struct kmod_ctx *ctx,
-					enum kmod_filter filter_type,
-					const struct kmod_list *input,
-					struct kmod_list **output);
+int kmod_module_apply_filter(const struct kmod_ctx *ctx, enum kmod_filter filter_type,
+			     const struct kmod_list *input, struct kmod_list **output);
 
 /**
  * kmod_module_get_filtered_blacklist:
@@ -969,8 +948,9 @@ int kmod_module_apply_filter(const struct kmod_ctx *ctx,
  * Since: 1
  */
 int kmod_module_get_filtered_blacklist(const struct kmod_ctx *ctx,
-					const struct kmod_list *input,
-					struct kmod_list **output) __attribute__ ((deprecated));
+				       const struct kmod_list *input,
+				       struct kmod_list **output)
+	__attribute__((deprecated));
 
 /**
  * kmod_module_get_install_commands:
@@ -1052,7 +1032,6 @@ const char *kmod_module_get_options(const struct kmod_module *mod);
  */
 const char *kmod_module_get_path(const struct kmod_module *mod);
 
-
 /**
  * kmod_module_get_dependency_symbols:
  * @mod: kmod module
@@ -1071,7 +1050,8 @@ const char *kmod_module_get_path(const struct kmod_module *mod);
  *
  * Since: 3
  */
-int kmod_module_get_dependency_symbols(const struct kmod_module *mod, struct kmod_list **list);
+int kmod_module_get_dependency_symbols(const struct kmod_module *mod,
+				       struct kmod_list **list);
 
 /**
  * kmod_symbol_bind:
@@ -1139,7 +1119,6 @@ const char *kmod_module_dependency_symbol_get_symbol(const struct kmod_list *ent
  */
 void kmod_module_dependency_symbols_free_list(struct kmod_list *list);
 
-
 /**
  * kmod_module_get_sections:
  * @mod: kmod module
@@ -1193,7 +1172,6 @@ const char *kmod_module_section_get_name(const struct kmod_list *entry);
  * Since: 1
  */
 void kmod_module_section_free_list(struct kmod_list *list);
-
 
 /**
  * kmod_module_get_symbols:
@@ -1249,7 +1227,6 @@ const char *kmod_module_symbol_get_symbol(const struct kmod_list *entry);
  */
 void kmod_module_symbols_free_list(struct kmod_list *list);
 
-
 /**
  * kmod_module_get_versions:
  * @mod: kmod module
@@ -1303,7 +1280,6 @@ const char *kmod_module_version_get_symbol(const struct kmod_list *entry);
  * Since: 2
  */
 void kmod_module_versions_free_list(struct kmod_list *list);
-
 
 /**
  * kmod_module_get_info:
@@ -1364,8 +1340,6 @@ const char *kmod_module_info_get_value(const struct kmod_list *entry);
  */
 void kmod_module_info_free_list(struct kmod_list *list);
 
-
-
 /**
  * SECTION:libkmod-loaded
  * @short_description: currently loaded modules
@@ -1396,8 +1370,7 @@ void kmod_module_info_free_list(struct kmod_list *list);
  *
  * Since: 1
  */
-int kmod_module_new_from_loaded(struct kmod_ctx *ctx,
-						struct kmod_list **list);
+int kmod_module_new_from_loaded(struct kmod_ctx *ctx, struct kmod_list **list);
 
 /**
  * kmod_module_initstate:

--- a/shared/array.c
+++ b/shared/array.c
@@ -13,7 +13,6 @@
 
 /* basic pointer array growing in steps */
 
-
 static int array_realloc(struct array *array, size_t new_total)
 {
 	void *tmp;
@@ -74,20 +73,21 @@ int array_append_unique(struct array *array, const void *element)
 	return array_append(array, element);
 }
 
-void array_pop(struct array *array) {
+void array_pop(struct array *array)
+{
 	if (array->count == 0)
 		return;
 	array->count--;
 	array_trim(array);
 }
 
-void array_free_array(struct array *array) {
+void array_free_array(struct array *array)
+{
 	free(array->array);
 	array->array = NULL;
 	array->count = 0;
 	array->total = 0;
 }
-
 
 void array_sort(struct array *array, int (*cmp)(const void *a, const void *b))
 {

--- a/shared/hash.c
+++ b/shared/hash.c
@@ -30,14 +30,12 @@ struct hash {
 	struct hash_bucket buckets[];
 };
 
-struct hash *hash_new(unsigned int n_buckets,
-					void (*free_value)(void *value))
+struct hash *hash_new(unsigned int n_buckets, void (*free_value)(void *value))
 {
 	struct hash *hash;
 
 	n_buckets = ALIGN_POWER2(n_buckets);
-	hash = calloc(1, sizeof(struct hash) +
-		      n_buckets * sizeof(struct hash_bucket));
+	hash = calloc(1, sizeof(struct hash) + n_buckets * sizeof(struct hash_bucket));
 	if (hash == NULL)
 		return NULL;
 	hash->n_buckets = n_buckets;
@@ -84,7 +82,7 @@ static inline unsigned int hash_superfast(const char *key, unsigned int len)
 
 	/* Main loop */
 	for (; len > 0; len--) {
-		hash += get_unaligned((uint16_t *) key);
+		hash += get_unaligned((uint16_t *)key);
 		tmp = (get_unaligned((uint16_t *)(key + 2)) << 11) ^ hash;
 		hash = (hash << 16) ^ tmp;
 		key += 4;
@@ -94,14 +92,14 @@ static inline unsigned int hash_superfast(const char *key, unsigned int len)
 	/* Handle end cases */
 	switch (rem) {
 	case 3:
-		hash += get_unaligned((uint16_t *) key);
+		hash += get_unaligned((uint16_t *)key);
 		hash ^= hash << 16;
 		hash ^= key[2] << 18;
 		hash += hash >> 11;
 		break;
 
 	case 2:
-		hash += get_unaligned((uint16_t *) key);
+		hash += get_unaligned((uint16_t *)key);
 		hash ^= hash << 11;
 		hash += hash >> 17;
 		break;
@@ -232,8 +230,8 @@ void *hash_find(const struct hash *hash, const char *key)
 	if (!bucket->entries)
 		return NULL;
 
-	entry = bsearch(&se, bucket->entries, bucket->used,
-			sizeof(struct hash_entry), hash_entry_cmp);
+	entry = bsearch(&se, bucket->entries, bucket->used, sizeof(struct hash_entry),
+			hash_entry_cmp);
 
 	return entry ? (void *)entry->value : NULL;
 }
@@ -251,8 +249,8 @@ int hash_del(struct hash *hash, const char *key)
 		.value = NULL,
 	};
 
-	entry = bsearch(&se, bucket->entries, bucket->used,
-		sizeof(struct hash_entry), hash_entry_cmp);
+	entry = bsearch(&se, bucket->entries, bucket->used, sizeof(struct hash_entry),
+			hash_entry_cmp);
 	if (entry == NULL)
 		return -ENOENT;
 
@@ -260,8 +258,7 @@ int hash_del(struct hash *hash, const char *key)
 		hash->free_value((void *)entry->value);
 
 	entry_end = bucket->entries + bucket->used;
-	memmove(entry, entry + 1,
-		(entry_end - entry) * sizeof(struct hash_entry));
+	memmove(entry, entry + 1, (entry_end - entry) * sizeof(struct hash_entry));
 
 	bucket->used--;
 	hash->count--;
@@ -269,8 +266,7 @@ int hash_del(struct hash *hash, const char *key)
 	steps_used = bucket->used / hash->step;
 	steps_total = bucket->total / hash->step;
 	if (steps_used + 1 < steps_total) {
-		size_t size = (steps_used + 1) *
-			hash->step * sizeof(struct hash_entry);
+		size_t size = (steps_used + 1) * hash->step * sizeof(struct hash_entry);
 		struct hash_entry *tmp = realloc(bucket->entries, size);
 		if (tmp) {
 			bucket->entries = tmp;
@@ -293,8 +289,7 @@ void hash_iter_init(const struct hash *hash, struct hash_iter *iter)
 	iter->entry = -1;
 }
 
-bool hash_iter_next(struct hash_iter *iter, const char **key,
-							const void **value)
+bool hash_iter_next(struct hash_iter *iter, const char **key, const void **value)
 {
 	const struct hash_bucket *b = iter->hash->buckets + iter->bucket;
 	const struct hash_entry *e;
@@ -305,7 +300,7 @@ bool hash_iter_next(struct hash_iter *iter, const char **key,
 		iter->entry = 0;
 
 		for (iter->bucket++; iter->bucket < iter->hash->n_buckets;
-							iter->bucket++) {
+		     iter->bucket++) {
 			b = iter->hash->buckets + iter->bucket;
 
 			if (b->used > 0)

--- a/shared/hash.h
+++ b/shared/hash.h
@@ -18,5 +18,4 @@ int hash_del(struct hash *hash, const char *key);
 void *hash_find(const struct hash *hash, const char *key);
 unsigned int hash_get_count(const struct hash *hash);
 void hash_iter_init(const struct hash *hash, struct hash_iter *iter);
-bool hash_iter_next(struct hash_iter *iter, const char **key,
-							const void **value);
+bool hash_iter_next(struct hash_iter *iter, const char **key, const void **value);

--- a/shared/macro.h
+++ b/shared/macro.h
@@ -7,27 +7,26 @@
 #include <stddef.h>
 
 #if defined(HAVE_STATIC_ASSERT)
-#define assert_cc(expr) \
-	_Static_assert((expr), #expr)
+#define assert_cc(expr) _Static_assert((expr), #expr)
 #else
-#define assert_cc(expr) \
-       do { (void) sizeof(char [1 - 2*!(expr)]); } while(0)
+#define assert_cc(expr)                              \
+	do {                                         \
+		(void)sizeof(char[1 - 2 * !(expr)]); \
+	} while (0)
 #endif
 
-#define check_types_match(expr1, expr2)		\
-	((typeof(expr1) *)0 != (typeof(expr2) *)0)
+#define check_types_match(expr1, expr2) ((typeof(expr1) *)0 != (typeof(expr2) *)0)
 
-#define container_of(member_ptr, containing_type, member)		\
-	((containing_type *)						\
-	 ((char *)(member_ptr) - offsetof(containing_type, member))	\
-	 - check_types_match(*(member_ptr), ((containing_type *)0)->member))
-
+#define container_of(member_ptr, containing_type, member)                                \
+	((containing_type *)((char *)(member_ptr) - offsetof(containing_type, member)) - \
+	 check_types_match(*(member_ptr), ((containing_type *)0)->member))
 
 /* Two gcc extensions.
  * &a[0] degrades to a pointer: a different type from an array */
-#define _array_size_chk(arr) ({ \
-	assert_cc(!__builtin_types_compatible_p(typeof(arr), typeof(&(arr)[0]))); \
-	0; \
+#define _array_size_chk(arr)                                                              \
+	({                                                                                \
+		assert_cc(!__builtin_types_compatible_p(typeof(arr), typeof(&(arr)[0]))); \
+		0;                                                                        \
 	})
 
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]) + _array_size_chk(arr))
@@ -35,18 +34,18 @@
 #define XSTRINGIFY(x) #x
 #define STRINGIFY(x) XSTRINGIFY(x)
 
-#define XCONCATENATE(x, y) x ## y
+#define XCONCATENATE(x, y) x##y
 #define CONCATENATE(x, y) XCONCATENATE(x, y)
 #define UNIQ(x) CONCATENATE(x, __COUNTER__)
 
 /* Attributes */
 
 #define _must_check_ __attribute__((warn_unused_result))
-#define _printf_format_(a,b) __attribute__((format (printf, a, b)))
+#define _printf_format_(a, b) __attribute__((format(printf, a, b)))
 #define _unused_ __attribute__((unused))
 #define _always_inline_ __inline__ __attribute__((always_inline))
 #define _cleanup_(x) __attribute__((cleanup(x)))
-#define _nonnull_(...) __attribute__((nonnull (__VA_ARGS__)))
+#define _nonnull_(...) __attribute__((nonnull(__VA_ARGS__)))
 #define _nonnull_all_ __attribute__((nonnull))
 
 /* Define C11 noreturn without <stdnoreturn.h> and even on older gcc

--- a/shared/missing.h
+++ b/shared/missing.h
@@ -16,8 +16,8 @@
 #define MODULE_INIT_COMPRESSED_FILE 4
 
 #ifndef __NR_finit_module
-# warning __NR_finit_module missing - kmod might not work correctly
-# define __NR_finit_module -1
+#warning __NR_finit_module missing - kmod might not work correctly
+#define __NR_finit_module -1
 #endif
 
 #ifndef HAVE_FINIT_MODULE

--- a/shared/scratchbuf.h
+++ b/shared/scratchbuf.h
@@ -24,8 +24,9 @@ static inline char *scratchbuf_str(struct scratchbuf *buf)
 	return buf->bytes;
 }
 
-#define SCRATCHBUF_INITIALIZER(buf_) {			\
-	.bytes = buf_,					\
-	.size = sizeof(buf_) + _array_size_chk(buf_),	\
-	.need_free = false,				\
-}
+#define SCRATCHBUF_INITIALIZER(buf_)                          \
+	{                                                     \
+		.bytes = buf_,                                \
+		.size = sizeof(buf_) + _array_size_chk(buf_), \
+		.need_free = false,                           \
+	}

--- a/shared/strbuf.c
+++ b/shared/strbuf.c
@@ -111,4 +111,3 @@ void strbuf_clear(struct strbuf *buf)
 {
 	buf->used = 0;
 }
-

--- a/shared/util.c
+++ b/shared/util.c
@@ -18,24 +18,24 @@
 #include <shared/missing.h>
 #include <shared/util.h>
 
-#define USEC_PER_SEC  1000000ULL
+#define USEC_PER_SEC 1000000ULL
 #define NSEC_PER_USEC 1000ULL
 
 static const struct kmod_ext {
 	const char *ext;
 	size_t len;
 } kmod_exts[] = {
-	{KMOD_EXTENSION_UNCOMPRESSED, sizeof(KMOD_EXTENSION_UNCOMPRESSED) - 1},
+	{ KMOD_EXTENSION_UNCOMPRESSED, sizeof(KMOD_EXTENSION_UNCOMPRESSED) - 1 },
 #ifdef ENABLE_ZLIB
-	{".ko.gz", sizeof(".ko.gz") - 1},
+	{ ".ko.gz", sizeof(".ko.gz") - 1 },
 #endif
 #ifdef ENABLE_XZ
-	{".ko.xz", sizeof(".ko.xz") - 1},
+	{ ".ko.xz", sizeof(".ko.xz") - 1 },
 #endif
 #ifdef ENABLE_ZSTD
-	{".ko.zst", sizeof(".ko.zst") - 1},
+	{ ".ko.zst", sizeof(".ko.zst") - 1 },
 #endif
-	{ },
+	{},
 };
 
 /* string handling functions and memory allocations                         */
@@ -292,10 +292,10 @@ char *freadline_wrapped(FILE *fp, unsigned int *linenum)
 	if (buf == NULL)
 		return NULL;
 
-	for(;;) {
+	for (;;) {
 		int ch = getc_unlocked(fp);
 
-		switch(ch) {
+		switch (ch) {
 		case EOF:
 			if (i == 0)
 				return NULL;
@@ -453,14 +453,14 @@ int mkdir_parents(const char *path, mode_t mode)
 
 static unsigned long long ts_usec(const struct timespec *ts)
 {
-	return (unsigned long long) ts->tv_sec * USEC_PER_SEC +
-	       (unsigned long long) ts->tv_nsec / NSEC_PER_USEC;
+	return (unsigned long long)ts->tv_sec * USEC_PER_SEC +
+	       (unsigned long long)ts->tv_nsec / NSEC_PER_USEC;
 }
 
 static unsigned long long ts_msec(const struct timespec *ts)
 {
-	return (unsigned long long) ts->tv_sec * MSEC_PER_SEC +
-	       (unsigned long long) ts->tv_nsec / NSEC_PER_MSEC;
+	return (unsigned long long)ts->tv_sec * MSEC_PER_SEC +
+	       (unsigned long long)ts->tv_nsec / NSEC_PER_MSEC;
 }
 
 static struct timespec msec_ts(unsigned long long msec)
@@ -487,8 +487,7 @@ int sleep_until_msec(unsigned long long msec)
 /*
  * Exponential retry backoff with tail
  */
-unsigned long long get_backoff_delta_msec(unsigned long long t0,
-					  unsigned long long tend,
+unsigned long long get_backoff_delta_msec(unsigned long long t0, unsigned long long tend,
 					  unsigned long long *delta)
 {
 	unsigned long long t;
@@ -534,6 +533,6 @@ unsigned long long stat_mstamp(const struct stat *st)
 #ifdef HAVE_STRUCT_STAT_ST_MTIM
 	return ts_usec(&st->st_mtim);
 #else
-	return (unsigned long long) st->st_mtime;
+	return (unsigned long long)st->st_mtime;
 #endif
 }

--- a/shared/util.h
+++ b/shared/util.h
@@ -24,10 +24,13 @@ _nonnull_all_ void *memdup(const void *p, size_t n);
 /* ************************************************************************ */
 #define KMOD_EXTENSION_UNCOMPRESSED ".ko"
 
-_must_check_ _nonnull_(1, 2) int alias_normalize(const char *alias, char buf[static PATH_MAX], size_t *len);
+_must_check_ _nonnull_(1, 2) int alias_normalize(const char *alias,
+						 char buf[static PATH_MAX], size_t *len);
 _must_check_ int underscores(char *s);
-_nonnull_(1, 2) char *modname_normalize(const char *modname, char buf[static PATH_MAX], size_t *len);
-_nonnull_(2) char *path_to_modname(const char *path, char buf[static PATH_MAX], size_t *len);
+_nonnull_(1, 2) char *modname_normalize(const char *modname, char buf[static PATH_MAX],
+					size_t *len);
+_nonnull_(2) char *path_to_modname(const char *path, char buf[static PATH_MAX],
+				   size_t *len);
 _nonnull_all_ bool path_ends_with_kmod_ext(const char *path, size_t len);
 
 /* read-like and fread-like functions                                       */
@@ -47,36 +50,34 @@ unsigned long long stat_mstamp(const struct stat *st);
 
 /* time-related functions
  * ************************************************************************ */
-#define USEC_PER_SEC	1000000ULL
-#define USEC_PER_MSEC	1000ULL
-#define MSEC_PER_SEC	1000ULL
-#define NSEC_PER_MSEC	1000000ULL
+#define USEC_PER_SEC 1000000ULL
+#define USEC_PER_MSEC 1000ULL
+#define MSEC_PER_SEC 1000ULL
+#define NSEC_PER_MSEC 1000000ULL
 
 unsigned long long now_usec(void);
 unsigned long long now_msec(void);
 int sleep_until_msec(unsigned long long msec);
-unsigned long long get_backoff_delta_msec(unsigned long long t0,
-					  unsigned long long tend,
+unsigned long long get_backoff_delta_msec(unsigned long long t0, unsigned long long tend,
 					  unsigned long long *delta);
-
 
 /* endianness and alignments                                                */
 /* ************************************************************************ */
-#define get_unaligned(ptr)			\
-({						\
-	struct __attribute__((packed)) {	\
-		typeof(*(ptr)) __v;		\
-	} *__p = (typeof(__p)) (ptr);		\
-	__p->__v;				\
-})
+#define get_unaligned(ptr)                       \
+	({                                       \
+		struct __attribute__((packed)) { \
+			typeof(*(ptr)) __v;      \
+		} *__p = (typeof(__p))(ptr);     \
+		__p->__v;                        \
+	})
 
-#define put_unaligned(val, ptr)			\
-do {						\
-	struct __attribute__((packed)) {	\
-		typeof(*(ptr)) __v;		\
-	} *__p = (typeof(__p)) (ptr);		\
-	__p->__v = (val);			\
-} while(0)
+#define put_unaligned(val, ptr)                  \
+	do {                                     \
+		struct __attribute__((packed)) { \
+			typeof(*(ptr)) __v;      \
+		} *__p = (typeof(__p))(ptr);     \
+		__p->__v = (val);                \
+	} while (0)
 
 static _always_inline_ unsigned int ALIGN_POWER2(unsigned int u)
 {
@@ -85,8 +86,9 @@ static _always_inline_ unsigned int ALIGN_POWER2(unsigned int u)
 
 /* misc                                                                     */
 /* ************************************************************************ */
-static inline void freep(void *p) {
-        free(*(void**) p);
+static inline void freep(void *p)
+{
+	free(*(void **)p);
 }
 #define _cleanup_free_ _cleanup_(freep)
 

--- a/testsuite/delete_module.c
+++ b/testsuite/delete_module.c
@@ -63,7 +63,7 @@ static void parse_retcodes(struct mod **_modules, const char *s)
 		if (end == p || *end != ':')
 			break;
 
-		ret = (int) l;
+		ret = (int)l;
 		p = end + 1;
 
 		l = strtol(p, &end, 0);
@@ -72,7 +72,7 @@ static void parse_retcodes(struct mod **_modules, const char *s)
 		else if (*end != '\0')
 			break;
 
-		errcode = (int) l;
+		errcode = (int)l;
 
 		mod = malloc(sizeof(*mod) + modnamelen + 1);
 		if (mod == NULL)
@@ -111,15 +111,14 @@ static void init_retcodes(void)
 	s = getenv(S_TC_DELETE_MODULE_RETCODES);
 	if (s == NULL) {
 		ERR("TRAP delete_module(): missing export %s?\n",
-						S_TC_DELETE_MODULE_RETCODES);
+		    S_TC_DELETE_MODULE_RETCODES);
 	}
 
 	parse_retcodes(&modules, s);
 
 	for (mod = modules; mod != NULL; mod = mod->next) {
 		LOG("Added module to test delete_module:\n");
-		LOG("\tname=%s ret=%d errcode=%d\n",
-		    mod->name, mod->ret, mod->errcode);
+		LOG("\tname=%s ret=%d errcode=%d\n", mod->name, mod->ret, mod->errcode);
 	}
 }
 

--- a/testsuite/init_module.c
+++ b/testsuite/init_module.c
@@ -78,7 +78,7 @@ static void parse_retcodes(struct mod **_modules, const char *s)
 		l = strtol(p, &end, 0);
 		if (end == p || *end != ':')
 			break;
-		ret = (int) l;
+		ret = (int)l;
 		p = end + 1;
 
 		l = strtol(p, &end, 0);
@@ -87,7 +87,7 @@ static void parse_retcodes(struct mod **_modules, const char *s)
 		else if (*end != '\0')
 			break;
 
-		errcode = (int) l;
+		errcode = (int)l;
 
 		mod = malloc(sizeof(*mod) + modnamelen + 1);
 		if (mod == NULL)
@@ -104,35 +104,35 @@ static void parse_retcodes(struct mod **_modules, const char *s)
 
 static int write_one_line_file(const char *fn, const char *line, int len)
 {
-        FILE *f;
-        int r;
+	FILE *f;
+	int r;
 
-        assert(fn);
-        assert(line);
+	assert(fn);
+	assert(line);
 
-        f = fopen(fn, "we");
-        if (!f)
-                return -errno;
+	f = fopen(fn, "we");
+	if (!f)
+		return -errno;
 
-        errno = 0;
-        if (fputs(line, f) < 0) {
-                r = -errno;
-                goto finish;
-        }
+	errno = 0;
+	if (fputs(line, f) < 0) {
+		r = -errno;
+		goto finish;
+	}
 
-        fflush(f);
+	fflush(f);
 
-        if (ferror(f)) {
-                if (errno != 0)
-                        r = -errno;
-                else
-                        r = -EIO;
-        } else
-                r = 0;
+	if (ferror(f)) {
+		if (errno != 0)
+			r = -errno;
+		else
+			r = -EIO;
+	} else
+		r = 0;
 
 finish:
-        fclose(f);
-        return r;
+	fclose(f);
+	return r;
 }
 
 static int create_sysfs_files(const char *modname)
@@ -174,7 +174,7 @@ static void init_retcodes(void)
 	s = getenv(S_TC_INIT_MODULE_RETCODES);
 	if (s == NULL) {
 		fprintf(stderr, "TRAP init_module(): missing export %s?\n",
-						S_TC_INIT_MODULE_RETCODES);
+			S_TC_INIT_MODULE_RETCODES);
 	}
 
 	ctx = kmod_new(NULL, NULL);
@@ -193,8 +193,7 @@ static inline bool module_is_inkernel(const char *modname)
 
 	state = kmod_module_get_initstate(mod);
 
-	if (state == KMOD_MODULE_LIVE ||
-			state == KMOD_MODULE_BUILTIN)
+	if (state == KMOD_MODULE_LIVE || state == KMOD_MODULE_BUILTIN)
 		ret = true;
 	else
 		ret = false;
@@ -238,8 +237,7 @@ long init_module(void *mem, unsigned long len, const char *args)
 	if (elf == NULL)
 		return 0;
 
-	err = kmod_elf_get_section(elf, ".gnu.linkonce.this_module", &buf,
-								&bufsize);
+	err = kmod_elf_get_section(elf, ".gnu.linkonce.this_module", &buf, &bufsize);
 	kmod_elf_unref(elf);
 
 	/* We couldn't parse the ELF file. Just exit as if it was successful */
@@ -287,7 +285,6 @@ static int check_kernel_version(int major, int minor)
 		return true;
 	return false;
 }
-
 
 TS_EXPORT int finit_module(const int fd, const char *args, const int flags);
 
@@ -355,7 +352,8 @@ TS_EXPORT long int syscall(long int __sysno, ...)
 #endif
 			nextlib_syscall = dlsym(nextlib, "syscall");
 			if (nextlib_syscall == NULL) {
-				fprintf(stderr, "FIXME FIXME FIXME: could not load syscall symbol: %s\n",
+				fprintf(stderr,
+					"FIXME FIXME FIXME: could not load syscall symbol: %s\n",
 					dlerror());
 				abort();
 			}
@@ -370,7 +368,8 @@ TS_EXPORT long int syscall(long int __sysno, ...)
 	 * this may fail if a library or process is trying to call syscall()
 	 * directly, for example to implement gettid().
 	 */
-	fprintf(stderr, "FIXME FIXME FIXME: could not wrap call to syscall(%ld), this should not happen\n",
+	fprintf(stderr,
+		"FIXME FIXME FIXME: could not wrap call to syscall(%ld), this should not happen\n",
 		__sysno);
 
 	abort();

--- a/testsuite/stripped-module.h
+++ b/testsuite/stripped-module.h
@@ -1,7 +1,6 @@
 #pragma once
 
-enum module_state
-{
+enum module_state {
 	MODULE_STATE_LIVE,
 	MODULE_STATE_COMING,
 	MODULE_STATE_GOING,
@@ -13,8 +12,7 @@ struct list_head {
 
 #define MODULE_NAME_LEN (64 - sizeof(unsigned long))
 
-struct module
-{
+struct module {
 	enum module_state state;
 
 	/* Member of list of modules */
@@ -25,5 +23,5 @@ struct module
 };
 
 /*                                padding */
-#define MODULE_NAME_OFFSET_64 4 + 4           + 2 * 8
+#define MODULE_NAME_OFFSET_64 4 + 4 + 2 * 8
 #define MODULE_NAME_OFFSET_32 4 + 2 * 4

--- a/testsuite/test-array.c
+++ b/testsuite/test-array.c
@@ -27,9 +27,7 @@ static int test_array_append1(const struct test *t)
 
 	return 0;
 }
-DEFINE_TEST(test_array_append1,
-		.description = "test simple array append");
-
+DEFINE_TEST(test_array_append1, .description = "test simple array append");
 
 static int test_array_append2(const struct test *t)
 {
@@ -50,8 +48,7 @@ static int test_array_append2(const struct test *t)
 
 	return 0;
 }
-DEFINE_TEST(test_array_append2,
-		.description = "test array append over step");
+DEFINE_TEST(test_array_append2, .description = "test array append over step");
 
 static int test_array_append_unique(const struct test *t)
 {
@@ -75,10 +72,10 @@ static int test_array_append_unique(const struct test *t)
 
 	return 0;
 }
-DEFINE_TEST(test_array_append_unique,
-		.description = "test array append unique");
+DEFINE_TEST(test_array_append_unique, .description = "test array append unique");
 
-static int strptrcmp(const void *pa, const void *pb) {
+static int strptrcmp(const void *pa, const void *pb)
+{
 	const char *a = *(const char **)pa;
 	const char *b = *(const char **)pb;
 
@@ -111,8 +108,7 @@ static int test_array_sort(const struct test *t)
 
 	return 0;
 }
-DEFINE_TEST(test_array_sort,
-		.description = "test array sort");
+DEFINE_TEST(test_array_sort, .description = "test array sort");
 
 static int test_array_remove_at(const struct test *t)
 {
@@ -155,8 +151,7 @@ static int test_array_remove_at(const struct test *t)
 
 	return 0;
 }
-DEFINE_TEST(test_array_remove_at,
-		.description = "test array remove at");
+DEFINE_TEST(test_array_remove_at, .description = "test array remove at");
 
 static int test_array_pop(const struct test *t)
 {
@@ -169,7 +164,6 @@ static int test_array_pop(const struct test *t)
 	array_append(&array, c1);
 	array_append(&array, c2);
 	array_append(&array, c3);
-
 
 	array_pop(&array);
 
@@ -191,7 +185,6 @@ static int test_array_pop(const struct test *t)
 	return 0;
 }
 
-DEFINE_TEST(test_array_pop,
-		.description = "test array pop");
+DEFINE_TEST(test_array_pop, .description = "test array pop");
 
 TESTSUITE_MAIN();

--- a/testsuite/test-blacklist.c
+++ b/testsuite/test-blacklist.c
@@ -38,15 +38,14 @@ static int blacklist_1(const struct test *t)
 	if (ctx == NULL)
 		exit(EXIT_FAILURE);
 
-	for(name = names; *name; name++) {
+	for (name = names; *name; name++) {
 		err = kmod_module_new_from_name(ctx, *name, &mod);
 		if (err < 0)
 			goto fail_lookup;
 		list = kmod_list_append(list, mod);
 	}
 
-	err = kmod_module_apply_filter(ctx, KMOD_FILTER_BLACKLIST, list,
-								&filtered);
+	err = kmod_module_apply_filter(ctx, KMOD_FILTER_BLACKLIST, list, &filtered);
 	if (err < 0) {
 		ERR("Could not filter: %s\n", strerror(-err));
 		goto fail;

--- a/testsuite/test-depmod.c
+++ b/testsuite/test-depmod.c
@@ -43,8 +43,10 @@ DEFINE_TEST(depmod_modules_order_for_compressed,
 	});
 
 #define MODULES_OUTDIR_ROOTFS TESTSUITE_ROOTFS "test-depmod/modules-outdir"
-#define MODULES_OUTDIR_LIB_MODULES_OUTPUT MODULES_OUTDIR_ROOTFS "/outdir" MODULE_DIRECTORY "/" MODULES_UNAME
-#define MODULES_OUTDIR_LIB_MODULES_INPUT MODULES_OUTDIR_ROOTFS MODULE_DIRECTORY "/" MODULES_UNAME
+#define MODULES_OUTDIR_LIB_MODULES_OUTPUT \
+	MODULES_OUTDIR_ROOTFS "/outdir" MODULE_DIRECTORY "/" MODULES_UNAME
+#define MODULES_OUTDIR_LIB_MODULES_INPUT \
+	MODULES_OUTDIR_ROOTFS MODULE_DIRECTORY "/" MODULES_UNAME
 static noreturn int depmod_modules_outdir(const struct test *t)
 {
 	const char *progname = TOOLS_DIR "/depmod";
@@ -77,7 +79,8 @@ DEFINE_TEST(depmod_modules_outdir,
 	});
 
 #define SEARCH_ORDER_SIMPLE_ROOTFS TESTSUITE_ROOTFS "test-depmod/search-order-simple"
-#define SEARCH_ORDER_SIMPLE_LIB_MODULES SEARCH_ORDER_SIMPLE_ROOTFS MODULE_DIRECTORY "/" MODULES_UNAME
+#define SEARCH_ORDER_SIMPLE_LIB_MODULES \
+	SEARCH_ORDER_SIMPLE_ROOTFS MODULE_DIRECTORY "/" MODULES_UNAME
 static noreturn int depmod_search_order_simple(const struct test *t)
 {
 	const char *progname = TOOLS_DIR "/depmod";
@@ -103,10 +106,10 @@ DEFINE_TEST(depmod_search_order_simple,
 		},
 	});
 
-
 #define ANOTHER_MODDIR "/foobar"
 #define MODULES_ANOTHER_MODDIR_ROOTFS TESTSUITE_ROOTFS "test-depmod/another-moddir"
-#define MODULES_ANOTHER_MODDIR_LIB_MODULES MODULES_ANOTHER_MODDIR_ROOTFS ANOTHER_MODDIR "/" MODULES_UNAME
+#define MODULES_ANOTHER_MODDIR_LIB_MODULES \
+	MODULES_ANOTHER_MODDIR_ROOTFS ANOTHER_MODDIR "/" MODULES_UNAME
 static noreturn int depmod_another_moddir(const struct test *t)
 {
 	const char *progname = TOOLS_DIR "/depmod";
@@ -134,8 +137,10 @@ DEFINE_TEST(depmod_another_moddir,
 		},
 	});
 
-#define SEARCH_ORDER_SAME_PREFIX_ROOTFS TESTSUITE_ROOTFS "test-depmod/search-order-same-prefix"
-#define SEARCH_ORDER_SAME_PREFIX_LIB_MODULES SEARCH_ORDER_SAME_PREFIX_ROOTFS MODULE_DIRECTORY "/" MODULES_UNAME
+#define SEARCH_ORDER_SAME_PREFIX_ROOTFS \
+	TESTSUITE_ROOTFS "test-depmod/search-order-same-prefix"
+#define SEARCH_ORDER_SAME_PREFIX_LIB_MODULES \
+	SEARCH_ORDER_SAME_PREFIX_ROOTFS MODULE_DIRECTORY "/" MODULES_UNAME
 static noreturn int depmod_search_order_same_prefix(const struct test *t)
 {
 	const char *progname = TOOLS_DIR "/depmod";
@@ -184,8 +189,10 @@ DEFINE_TEST(depmod_detect_loop,
 		.err = DETECT_LOOP_ROOTFS "/correct.txt",
 	});
 
-#define SEARCH_ORDER_EXTERNAL_FIRST_ROOTFS TESTSUITE_ROOTFS "test-depmod/search-order-external-first"
-#define SEARCH_ORDER_EXTERNAL_FIRST_LIB_MODULES SEARCH_ORDER_EXTERNAL_FIRST_ROOTFS MODULE_DIRECTORY "/" MODULES_UNAME
+#define SEARCH_ORDER_EXTERNAL_FIRST_ROOTFS \
+	TESTSUITE_ROOTFS "test-depmod/search-order-external-first"
+#define SEARCH_ORDER_EXTERNAL_FIRST_LIB_MODULES \
+	SEARCH_ORDER_EXTERNAL_FIRST_ROOTFS MODULE_DIRECTORY "/" MODULES_UNAME
 static noreturn int depmod_search_order_external_first(const struct test *t)
 {
 	const char *progname = TOOLS_DIR "/depmod";
@@ -211,8 +218,10 @@ DEFINE_TEST(depmod_search_order_external_first,
 		},
 	});
 
-#define SEARCH_ORDER_EXTERNAL_LAST_ROOTFS TESTSUITE_ROOTFS "test-depmod/search-order-external-last"
-#define SEARCH_ORDER_EXTERNAL_LAST_LIB_MODULES SEARCH_ORDER_EXTERNAL_LAST_ROOTFS MODULE_DIRECTORY "/" MODULES_UNAME
+#define SEARCH_ORDER_EXTERNAL_LAST_ROOTFS \
+	TESTSUITE_ROOTFS "test-depmod/search-order-external-last"
+#define SEARCH_ORDER_EXTERNAL_LAST_LIB_MODULES \
+	SEARCH_ORDER_EXTERNAL_LAST_ROOTFS MODULE_DIRECTORY "/" MODULES_UNAME
 static noreturn int depmod_search_order_external_last(const struct test *t)
 {
 	const char *progname = TOOLS_DIR "/depmod";
@@ -239,7 +248,8 @@ DEFINE_TEST(depmod_search_order_external_last,
 	});
 
 #define SEARCH_ORDER_OVERRIDE_ROOTFS TESTSUITE_ROOTFS "test-depmod/search-order-override"
-#define SEARCH_ORDER_OVERRIDE_LIB_MODULES SEARCH_ORDER_OVERRIDE_ROOTFS MODULE_DIRECTORY "/" MODULES_UNAME
+#define SEARCH_ORDER_OVERRIDE_LIB_MODULES \
+	SEARCH_ORDER_OVERRIDE_ROOTFS MODULE_DIRECTORY "/" MODULES_UNAME
 static noreturn int depmod_search_order_override(const struct test *t)
 {
 	const char *progname = TOOLS_DIR "/depmod";

--- a/testsuite/test-hash.c
+++ b/testsuite/test-hash.c
@@ -29,9 +29,7 @@ static int test_hash_new(const struct test *t)
 	hash_free(h);
 	return 0;
 }
-DEFINE_TEST(test_hash_new,
-		.description = "test hash_new");
-
+DEFINE_TEST(test_hash_new, .description = "test hash_new");
 
 static int test_hash_get_count(const struct test *t)
 {
@@ -48,9 +46,7 @@ static int test_hash_get_count(const struct test *t)
 	hash_free(h);
 	return 0;
 }
-DEFINE_TEST(test_hash_get_count,
-		.description = "test hash_add / hash_get_count");
-
+DEFINE_TEST(test_hash_get_count, .description = "test hash_add / hash_get_count");
 
 static int test_hash_replace(const struct test *t)
 {
@@ -78,9 +74,7 @@ static int test_hash_replace(const struct test *t)
 	hash_free(h);
 	return 0;
 }
-DEFINE_TEST(test_hash_replace,
-		.description = "test hash_add replacing existing value");
-
+DEFINE_TEST(test_hash_replace, .description = "test hash_add replacing existing value");
 
 static int test_hash_replace_failing(const struct test *t)
 {
@@ -110,8 +104,7 @@ static int test_hash_replace_failing(const struct test *t)
 	return 0;
 }
 DEFINE_TEST(test_hash_replace_failing,
-		.description = "test hash_add_unique failing to replace existing value");
-
+	    .description = "test hash_add_unique failing to replace existing value");
 
 static int test_hash_iter(const struct test *t)
 {
@@ -129,8 +122,7 @@ static int test_hash_iter(const struct test *t)
 	hash_add(h, k3, v3);
 	hash_add(h2, k3, v3);
 
-	for (hash_iter_init(h, &iter);
-	     hash_iter_next(&iter, &k, (const void **) &v);) {
+	for (hash_iter_init(h, &iter); hash_iter_next(&iter, &k, (const void **)&v);) {
 		v2 = hash_find(h2, k);
 		assert_return(v2 != NULL, EXIT_FAILURE);
 		hash_del(h2, k);
@@ -143,9 +135,7 @@ static int test_hash_iter(const struct test *t)
 	hash_free(h2);
 	return 0;
 }
-DEFINE_TEST(test_hash_iter,
-		.description = "test hash_iter");
-
+DEFINE_TEST(test_hash_iter, .description = "test hash_iter");
 
 static int test_hash_iter_after_del(const struct test *t)
 {
@@ -165,8 +155,7 @@ static int test_hash_iter_after_del(const struct test *t)
 
 	hash_del(h, k1);
 
-	for (hash_iter_init(h, &iter);
-	     hash_iter_next(&iter, &k, (const void **) &v);) {
+	for (hash_iter_init(h, &iter); hash_iter_next(&iter, &k, (const void **)&v);) {
 		v2 = hash_find(h2, k);
 		assert_return(v2 != NULL, EXIT_FAILURE);
 		hash_del(h2, k);
@@ -180,8 +169,7 @@ static int test_hash_iter_after_del(const struct test *t)
 	return 0;
 }
 DEFINE_TEST(test_hash_iter_after_del,
-		.description = "test hash_iter, after deleting element");
-
+	    .description = "test hash_iter, after deleting element");
 
 static int test_hash_free(const struct test *t)
 {
@@ -206,8 +194,7 @@ static int test_hash_free(const struct test *t)
 	return 0;
 }
 DEFINE_TEST(test_hash_free,
-		.description = "test hash_free calling free function for all values");
-
+	    .description = "test hash_free calling free function for all values");
 
 static int test_hash_add_unique(const struct test *t)
 {
@@ -232,8 +219,7 @@ static int test_hash_add_unique(const struct test *t)
 	return 0;
 }
 DEFINE_TEST(test_hash_add_unique,
-		.description = "test hash_add_unique with different key orders")
-
+	    .description = "test hash_add_unique with different key orders")
 
 static int test_hash_massive_add_del(const struct test *t)
 {
@@ -265,6 +251,6 @@ static int test_hash_massive_add_del(const struct test *t)
 	return 0;
 }
 DEFINE_TEST(test_hash_massive_add_del,
-		.description = "test multiple adds followed by multiple dels")
+	    .description = "test multiple adds followed by multiple dels")
 
 TESTSUITE_MAIN();

--- a/testsuite/test-init.c
+++ b/testsuite/test-init.c
@@ -68,8 +68,7 @@ static noreturn int test_initlib(const struct test *t)
 
 	exit(EXIT_SUCCESS);
 }
-DEFINE_TEST(test_initlib,
-		.description = "test if libkmod's init function work");
+DEFINE_TEST(test_initlib, .description = "test if libkmod's init function work");
 
 static noreturn int test_insert(const struct test *t)
 {

--- a/testsuite/test-initstate.c
+++ b/testsuite/test-initstate.c
@@ -19,7 +19,6 @@
 
 #include "testsuite.h"
 
-
 static noreturn int test_initstate_from_lookup(const struct test *t)
 {
 	struct kmod_ctx *ctx;
@@ -107,8 +106,5 @@ DEFINE_TEST(test_initstate_from_name,
 		[TC_UNAME_R] = "4.4.4",
 	},
 	.need_spawn = true);
-
-
-
 
 TESTSUITE_MAIN();

--- a/testsuite/test-list.c
+++ b/testsuite/test-list.c
@@ -45,9 +45,7 @@ static int test_list_last(const struct test *t)
 
 	return 0;
 }
-DEFINE_TEST(test_list_last,
-	    .description = "test for the last element of a list");
-
+DEFINE_TEST(test_list_last, .description = "test for the last element of a list");
 
 static int test_list_prev(const struct test *t)
 {
@@ -76,9 +74,7 @@ static int test_list_prev(const struct test *t)
 
 	return 0;
 }
-DEFINE_TEST(test_list_prev,
-	    .description = "test list prev");
-
+DEFINE_TEST(test_list_prev, .description = "test list prev");
 
 static int test_list_remove_n_latest(const struct test *t)
 {
@@ -95,7 +91,7 @@ static int test_list_remove_n_latest(const struct test *t)
 	assert_return(len(list) == N - M, EXIT_FAILURE);
 
 	i = 0;
-	kmod_list_foreach (l, list) {
+	kmod_list_foreach(l, list) {
 		assert_return(l->data == v[i], EXIT_FAILURE);
 		i++;
 	}
@@ -106,7 +102,6 @@ static int test_list_remove_n_latest(const struct test *t)
 }
 DEFINE_TEST(test_list_remove_n_latest,
 	    .description = "test list function to remove n latest elements");
-
 
 static int test_list_remove_data(const struct test *t)
 {
@@ -122,7 +117,7 @@ static int test_list_remove_data(const struct test *t)
 	list = kmod_list_remove_data(list, removed);
 	assert_return(len(list) == N - 1, EXIT_FAILURE);
 
-	kmod_list_foreach (l, list)
+	kmod_list_foreach(l, list)
 		assert_return(l->data != removed, EXIT_FAILURE);
 
 	kmod_list_remove_all(list);
@@ -131,7 +126,6 @@ static int test_list_remove_data(const struct test *t)
 }
 DEFINE_TEST(test_list_remove_data,
 	    .description = "test list function to remove element by data");
-
 
 static int test_list_append_list(const struct test *t)
 {
@@ -158,7 +152,7 @@ static int test_list_append_list(const struct test *t)
 	assert_return(len(c) == N, EXIT_FAILURE);
 
 	i = 0;
-	kmod_list_foreach (l, c) {
+	kmod_list_foreach(l, c) {
 		assert_return(l->data == v[i], EXIT_FAILURE);
 		i++;
 	}
@@ -169,7 +163,6 @@ static int test_list_append_list(const struct test *t)
 }
 DEFINE_TEST(test_list_append_list,
 	    .description = "test list function to append another list");
-
 
 static int test_list_insert_before(const struct test *t)
 {
@@ -205,7 +198,6 @@ static int test_list_insert_before(const struct test *t)
 }
 DEFINE_TEST(test_list_insert_before,
 	    .description = "test list function to insert before element");
-
 
 static int test_list_insert_after(const struct test *t)
 {

--- a/testsuite/test-modinfo.c
+++ b/testsuite/test-modinfo.c
@@ -15,18 +15,16 @@
 
 static const char *progname = TOOLS_DIR "/modinfo";
 
-#define DEFINE_MODINFO_TEST(_field, _flavor, ...) \
-static noreturn int test_modinfo_##_field(const struct test *t) \
-{ \
-	const char *const args[] = { \
-		progname, "-F", #_field ,\
-		__VA_ARGS__ , \
-		NULL, \
-	}; \
-	test_spawn_prog(progname, args); \
-	exit(EXIT_FAILURE); \
-} \
-DEFINE_TEST(test_modinfo_##_field, \
+#define DEFINE_MODINFO_TEST(_field, _flavor, ...)                       \
+	static noreturn int test_modinfo_##_field(const struct test *t) \
+	{                                                               \
+		const char *const args[] = {                            \
+			progname, "-F", #_field, __VA_ARGS__, NULL,     \
+		};                                                      \
+		test_spawn_prog(progname, args);                        \
+		exit(EXIT_FAILURE);                                     \
+	}                                                               \
+	DEFINE_TEST(test_modinfo_##_field, \
 	.description = "check " #_field " output of modinfo for different architectures", \
 	.config = { \
 		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-modinfo/", \
@@ -37,20 +35,15 @@ DEFINE_TEST(test_modinfo_##_field, \
 
 /* TODO: add cross-compiled modules to the test */
 #define DEFINE_MODINFO_GENERIC_TEST(_field) \
-	DEFINE_MODINFO_TEST(_field, , \
-			    "/mod-simple.ko")
+	DEFINE_MODINFO_TEST(_field, , "/mod-simple.ko")
 
 #ifdef ENABLE_OPENSSL
-#define DEFINE_MODINFO_SIGN_TEST(_field) \
-	DEFINE_MODINFO_TEST(_field, -openssl, \
-			    "/mod-simple-sha1.ko", \
-			    "/mod-simple-sha256.ko",	\
-			    "/mod-simple-pkcs7.ko")
+#define DEFINE_MODINFO_SIGN_TEST(_field)                             \
+	DEFINE_MODINFO_TEST(_field, -openssl, "/mod-simple-sha1.ko", \
+			    "/mod-simple-sha256.ko", "/mod-simple-pkcs7.ko")
 #else
-#define DEFINE_MODINFO_SIGN_TEST(_field) \
-	DEFINE_MODINFO_TEST(_field, , \
-			    "/mod-simple-sha1.ko", \
-			    "/mod-simple-sha256.ko",	\
+#define DEFINE_MODINFO_SIGN_TEST(_field)                                              \
+	DEFINE_MODINFO_TEST(_field, , "/mod-simple-sha1.ko", "/mod-simple-sha256.ko", \
 			    "/mod-simple-pkcs7.ko")
 #endif
 

--- a/testsuite/test-modprobe.c
+++ b/testsuite/test-modprobe.c
@@ -18,7 +18,8 @@ static noreturn int modprobe_show_depends(const struct test *t)
 	const char *progname = TOOLS_DIR "/modprobe";
 	const char *const args[] = {
 		progname,
-		"--show-depends", "mod-loop-a",
+		"--show-depends",
+		"mod-loop-a",
 		NULL,
 	};
 
@@ -40,7 +41,8 @@ static noreturn int modprobe_show_depends2(const struct test *t)
 	const char *progname = TOOLS_DIR "/modprobe";
 	const char *const args[] = {
 		progname,
-		"--show-depends", "mod-simple",
+		"--show-depends",
+		"mod-simple",
 		NULL,
 	};
 
@@ -109,7 +111,6 @@ DEFINE_TEST(modprobe_show_exports,
 		.regex = true,
 	});
 
-
 static noreturn int modprobe_builtin(const struct test *t)
 {
 	const char *progname = TOOLS_DIR "/modprobe";
@@ -122,19 +123,19 @@ static noreturn int modprobe_builtin(const struct test *t)
 	test_spawn_prog(progname, args);
 	exit(EXIT_FAILURE);
 }
-DEFINE_TEST(modprobe_builtin,
-	.description = "check if modprobe return 0 for builtin",
-	.config = {
-		[TC_UNAME_R] = "4.4.4",
-		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-modprobe/builtin",
-	});
+DEFINE_TEST(modprobe_builtin, .description = "check if modprobe return 0 for builtin",
+	    .config = {
+		    [TC_UNAME_R] = "4.4.4",
+		    [TC_ROOTFS] = TESTSUITE_ROOTFS "test-modprobe/builtin",
+	    });
 
 static noreturn int modprobe_builtin_lookup_only(const struct test *t)
 {
 	const char *progname = TOOLS_DIR "/modprobe";
 	const char *const args[] = {
 		progname,
-		"-R", "unix",
+		"-R",
+		"unix",
 		NULL,
 	};
 
@@ -227,7 +228,8 @@ static noreturn int modprobe_param_kcmdline_show_deps(const struct test *t)
 	const char *progname = TOOLS_DIR "/modprobe";
 	const char *const args[] = {
 		progname,
-		"--show-depends", "mod-simple",
+		"--show-depends",
+		"mod-simple",
 		NULL,
 	};
 
@@ -342,13 +344,13 @@ DEFINE_TEST_WITH_FUNC(modprobe_param_kcmdline8, modprobe_param_kcmdline,
 	.modules_loaded = "",
 	);
 
-
 static noreturn int modprobe_force(const struct test *t)
 {
 	const char *progname = TOOLS_DIR "/modprobe";
 	const char *const args[] = {
 		progname,
-		"--force", "mod-simple",
+		"--force",
+		"mod-simple",
 		NULL,
 	};
 
@@ -392,7 +394,8 @@ static noreturn int modprobe_oldkernel_force(const struct test *t)
 	const char *progname = TOOLS_DIR "/modprobe";
 	const char *const args[] = {
 		progname,
-		"--force", "mod-simple",
+		"--force",
+		"mod-simple",
 		NULL,
 	};
 

--- a/testsuite/test-scratchbuf.c
+++ b/testsuite/test-scratchbuf.c
@@ -34,8 +34,7 @@ static int test_scratchbuf_onlystack(const struct test *t)
 	return 0;
 }
 DEFINE_TEST(test_scratchbuf_onlystack,
-		.description = "test scratchbuf for buffer on stack only");
-
+	    .description = "test scratchbuf for buffer on stack only");
 
 static int test_scratchbuf_heap(const struct test *t)
 {
@@ -72,6 +71,6 @@ static int test_scratchbuf_heap(const struct test *t)
 	return 0;
 }
 DEFINE_TEST(test_scratchbuf_heap,
-		.description = "test scratchbuf for buffer on that grows to heap");
+	    .description = "test scratchbuf for buffer on that grows to heap");
 
 TESTSUITE_MAIN();

--- a/testsuite/test-strbuf.c
+++ b/testsuite/test-strbuf.c
@@ -29,7 +29,7 @@ static int test_strbuf_pushchar(const struct test *t)
 	for (c = TEXT; *c != '\0'; c++)
 		strbuf_pushchar(&buf, *c);
 
-	result1 = (char *) strbuf_str(&buf);
+	result1 = (char *)strbuf_str(&buf);
 	assert_return(result1 == buf.bytes, EXIT_FAILURE);
 	assert_return(streq(result1, TEXT), EXIT_FAILURE);
 	result1 = strdup(result1);
@@ -42,8 +42,7 @@ static int test_strbuf_pushchar(const struct test *t)
 
 	return 0;
 }
-DEFINE_TEST(test_strbuf_pushchar,
-		.description = "test strbuf_{pushchar, str, steal}");
+DEFINE_TEST(test_strbuf_pushchar, .description = "test strbuf_{pushchar, str, steal}");
 
 static int test_strbuf_pushchars(const struct test *t)
 {
@@ -62,7 +61,7 @@ static int test_strbuf_pushchars(const struct test *t)
 	}
 
 	strbuf_popchar(&buf);
-	result1 = (char *) strbuf_str(&buf);
+	result1 = (char *)strbuf_str(&buf);
 	assert_return(result1 == buf.bytes, EXIT_FAILURE);
 	assert_return(streq(result1, TEXT), EXIT_FAILURE);
 
@@ -71,8 +70,7 @@ static int test_strbuf_pushchars(const struct test *t)
 	assert_return(!streq(TEXT, result2), EXIT_FAILURE);
 	assert_return(strncmp(TEXT, result2, strlen(TEXT) - lastwordlen) == 0,
 		      EXIT_FAILURE);
-	assert_return(result2[strlen(TEXT) - lastwordlen] == '\0',
-		      EXIT_FAILURE);
+	assert_return(result2[strlen(TEXT) - lastwordlen] == '\0', EXIT_FAILURE);
 
 	free(str);
 	free(result2);
@@ -80,7 +78,6 @@ static int test_strbuf_pushchars(const struct test *t)
 	return 0;
 }
 DEFINE_TEST(test_strbuf_pushchars,
-		.description = "test strbuf_{pushchars, popchar, popchars}");
-
+	    .description = "test strbuf_{pushchars, popchar, popchars}");
 
 TESTSUITE_MAIN();

--- a/testsuite/test-testsuite.c
+++ b/testsuite/test-testsuite.c
@@ -20,7 +20,6 @@
 
 #include "testsuite.h"
 
-
 #define TEST_UNAME "4.0.20-kmod"
 static noreturn int testsuite_uname(const struct test *t)
 {

--- a/testsuite/test-util.c
+++ b/testsuite/test-util.c
@@ -101,8 +101,7 @@ static int test_strchr_replace(const struct test *t)
 
 	return EXIT_SUCCESS;
 }
-DEFINE_TEST(test_strchr_replace,
-	.description = "check implementation of strchr_replace()")
+DEFINE_TEST(test_strchr_replace, .description = "check implementation of strchr_replace()")
 
 static int test_underscores(const struct test *t)
 {
@@ -127,8 +126,7 @@ static int test_underscores(const struct test *t)
 
 	return EXIT_SUCCESS;
 }
-DEFINE_TEST(test_underscores,
-	.description = "check implementation of underscores()")
+DEFINE_TEST(test_underscores, .description = "check implementation of underscores()")
 
 static int test_path_ends_with_kmod_ext(const struct test *t)
 {
@@ -154,15 +152,15 @@ static int test_path_ends_with_kmod_ext(const struct test *t)
 	}, *iter;
 
 	for (iter = &teststr[0]; iter->val != NULL; iter++) {
-		assert_return(path_ends_with_kmod_ext(iter->val,
-						      strlen(iter->val)) == iter->res,
+		assert_return(path_ends_with_kmod_ext(iter->val, strlen(iter->val)) ==
+				      iter->res,
 			      EXIT_FAILURE);
 	}
 
 	return EXIT_SUCCESS;
 }
 DEFINE_TEST(test_path_ends_with_kmod_ext,
-	.description = "check implementation of path_ends_with_kmod_ext()")
+	    .description = "check implementation of path_ends_with_kmod_ext()")
 
 #define TEST_WRITE_STR_SAFE_FILE "/write-str-safe"
 #define TEST_WRITE_STR_SAFE_PATH TESTSUITE_ROOTFS "test-util2/" TEST_WRITE_STR_SAFE_FILE
@@ -171,7 +169,7 @@ static int test_write_str_safe(const struct test *t)
 	const char *s = "test";
 	int fd;
 
-	fd = open(TEST_WRITE_STR_SAFE_FILE ".txt", O_CREAT|O_TRUNC|O_WRONLY, 0644);
+	fd = open(TEST_WRITE_STR_SAFE_FILE ".txt", O_CREAT | O_TRUNC | O_WRONLY, 0644);
 	assert_return(fd >= 0, EXIT_FAILURE);
 
 	write_str_safe(fd, s, strlen(s));
@@ -208,8 +206,7 @@ static int test_addu64_overflow(const struct test *t)
 	return EXIT_SUCCESS;
 }
 DEFINE_TEST(test_addu64_overflow,
-	.description = "check implementation of addu4_overflow()")
-
+	    .description = "check implementation of addu4_overflow()")
 
 static int test_backoff_time(const struct test *t)
 {
@@ -247,7 +244,6 @@ static int test_backoff_time(const struct test *t)
 	return EXIT_SUCCESS;
 }
 DEFINE_TEST(test_backoff_time,
-	.description = "check implementation of get_backoff_delta_msec()")
-
+	    .description = "check implementation of get_backoff_delta_msec()")
 
 TESTSUITE_MAIN();

--- a/testsuite/testsuite.c
+++ b/testsuite/testsuite.c
@@ -27,7 +27,7 @@
 
 static const char *ANSI_HIGHLIGHT_GREEN_ON = "\x1B[1;32m";
 static const char *ANSI_HIGHLIGHT_YELLOW_ON = "\x1B[1;33m";
-static const char *ANSI_HIGHLIGHT_RED_ON =  "\x1B[1;31m";
+static const char *ANSI_HIGHLIGHT_RED_ON = "\x1B[1;31m";
 static const char *ANSI_HIGHLIGHT_OFF = "\x1B[0m";
 
 static const char *progname;
@@ -45,10 +45,12 @@ static const struct {
 	const char *key;
 	const char *ldpreload;
 } env_config[_TC_LAST] = {
-	[TC_UNAME_R] = { S_TC_UNAME_R, OVERRIDE_LIBDIR  "uname.so" },
+	[TC_UNAME_R] = { S_TC_UNAME_R, OVERRIDE_LIBDIR "uname.so" },
 	[TC_ROOTFS] = { S_TC_ROOTFS, OVERRIDE_LIBDIR "path.so" },
-	[TC_INIT_MODULE_RETCODES] = { S_TC_INIT_MODULE_RETCODES, OVERRIDE_LIBDIR "init_module.so" },
-	[TC_DELETE_MODULE_RETCODES] = { S_TC_DELETE_MODULE_RETCODES, OVERRIDE_LIBDIR "delete_module.so" },
+	[TC_INIT_MODULE_RETCODES] = { S_TC_INIT_MODULE_RETCODES,
+				      OVERRIDE_LIBDIR "init_module.so" },
+	[TC_DELETE_MODULE_RETCODES] = { S_TC_DELETE_MODULE_RETCODES,
+					OVERRIDE_LIBDIR "delete_module.so" },
 };
 
 static void help(void)
@@ -58,10 +60,11 @@ static void help(void)
 
 	printf("Usage:\n"
 	       "\t%s [options] <test>\n"
-	       "Options:\n", basename(progname));
+	       "Options:\n",
+	       basename(progname));
 
-	for (itr = options, itr_short = options_short;
-				itr->name != NULL; itr++, itr_short++)
+	for (itr = options, itr_short = options_short; itr->name != NULL;
+	     itr++, itr_short++)
 		printf("\t-%c, --%s\n", *itr_short, itr->name);
 }
 
@@ -74,8 +77,8 @@ static void test_list(const struct test *start, const struct test *stop)
 		printf("\t%s, %s\n", t->name, t->description);
 }
 
-int test_init(const struct test *start, const struct test *stop,
-	      int argc, char *const argv[])
+int test_init(const struct test *start, const struct test *stop, int argc,
+	      char *const argv[])
 {
 	progname = argv[0];
 
@@ -111,8 +114,8 @@ int test_init(const struct test *start, const struct test *stop,
 	return optind;
 }
 
-const struct test *test_find(const struct test *start,
-			     const struct test *stop, const char *name)
+const struct test *test_find(const struct test *start, const struct test *stop,
+			     const char *name)
 {
 	const struct test *t;
 
@@ -128,7 +131,7 @@ static int test_spawn_test(const struct test *t)
 {
 	const char *const args[] = { progname, "-n", t->name, NULL };
 
-	execv(progname, (char *const *) args);
+	execv(progname, (char *const *)args);
 
 	ERR("failed to spawn %s for %s: %m\n", progname, t->name);
 	return EXIT_FAILURE;
@@ -144,7 +147,7 @@ static int test_run_spawned(const struct test *t)
 
 int test_spawn_prog(const char *prog, const char *const args[])
 {
-	execv(prog, (char *const *) args);
+	execv(prog, (char *const *)args);
 
 	ERR("failed to spawn %s\n", prog);
 	ERR("did you forget to build tools?\n");
@@ -195,8 +198,8 @@ static void test_export_environ(const struct test *t)
 		setenv(env->key, env->val, 1);
 }
 
-static inline int test_run_child(const struct test *t, int fdout[2],
-						int fderr[2], int fdmonitor[2])
+static inline int test_run_child(const struct test *t, int fdout[2], int fderr[2],
+				 int fdmonitor[2])
 {
 	/* kill child if parent dies */
 	prctl(PR_SET_PDEATHSIG, SIGTERM);
@@ -239,7 +242,7 @@ static inline int test_run_child(const struct test *t, int fdout[2],
 
 		if (stat_mstamp(&rootfsst) > stat_mstamp(&stampst)) {
 			ERR("rootfs %s is dirty, please run 'make rootfs' before running this test\n",
-								rootfs);
+			    rootfs);
 			exit(EXIT_FAILURE);
 		}
 	}
@@ -284,8 +287,7 @@ static int fd_cmp_check_activity(struct fd_cmp *fd_cmp)
 	if (stat(fd_cmp->path, &st) == 0 && st.st_size == 0)
 		return 0;
 
-	ERR("Expecting output on %s, but test didn't produce any\n",
-	    fd_cmp->name);
+	ERR("Expecting output on %s, but test didn't produce any\n", fd_cmp->name);
 
 	return -1;
 }
@@ -309,8 +311,7 @@ static int fd_cmp_open_monitor(struct fd_cmp *fd_cmp, int fd, int fd_ep)
 	return 0;
 }
 
-static int fd_cmp_open_std(struct fd_cmp *fd_cmp,
-			   const char *fn, int fd, int fd_ep)
+static int fd_cmp_open_std(struct fd_cmp *fd_cmp, const char *fn, int fd, int fd_ep)
 {
 	struct epoll_event ep = {};
 	int fd_match;
@@ -332,9 +333,8 @@ static int fd_cmp_open_std(struct fd_cmp *fd_cmp,
 }
 
 /* opens output file AND adds descriptor to epoll */
-static int fd_cmp_open(struct fd_cmp **fd_cmp_out,
-		       enum fd_cmp_type type, const char *fn, int fd,
-		       int fd_ep)
+static int fd_cmp_open(struct fd_cmp **fd_cmp_out, enum fd_cmp_type type, const char *fn,
+		       int fd, int fd_ep)
 {
 	int err = 0;
 	struct fd_cmp *fd_cmp;
@@ -407,9 +407,9 @@ static void fd_cmp_close(struct fd_cmp *fd_cmp)
 
 static bool fd_cmp_regex_one(const char *pattern, const char *s)
 {
-	_cleanup_(regfree) regex_t re = { };
+	_cleanup_(regfree) regex_t re = {};
 
-	return !regcomp(&re, pattern, REG_EXTENDED|REG_NOSUB) &&
+	return !regcomp(&re, pattern, REG_EXTENDED | REG_NOSUB) &&
 	       !regexec(&re, s, 0, NULL, 0);
 }
 
@@ -450,8 +450,10 @@ static bool fd_cmp_regex(struct fd_cmp *fd_cmp, const struct test *t)
 				 fd_cmp->head_match - done_match);
 		if (!p_match) {
 			if (fd_cmp->head_match >= sizeof(fd_cmp->buf_match)) {
-				ERR("Read %zu bytes without a match\n", sizeof(fd_cmp->buf_match));
-				ERR("output: %.*s", (int)sizeof(fd_cmp->buf_match), fd_cmp->buf_match);
+				ERR("Read %zu bytes without a match\n",
+				    sizeof(fd_cmp->buf_match));
+				ERR("output: %.*s", (int)sizeof(fd_cmp->buf_match),
+				    fd_cmp->buf_match);
 				return false;
 			}
 
@@ -466,13 +468,15 @@ static bool fd_cmp_regex(struct fd_cmp *fd_cmp, const struct test *t)
 			p_match = memchr(fd_cmp->buf_match + done_match, '\n',
 					 fd_cmp->head_match - done_match);
 			if (!p_match) {
-				ERR("could not find match line from fd %d\n", fd_cmp->fd_match);
+				ERR("could not find match line from fd %d\n",
+				    fd_cmp->fd_match);
 				return false;
 			}
 		}
 		*p_match = '\0';
 
-		if (!fd_cmp_regex_one(fd_cmp->buf_match + done_match, fd_cmp->buf + done)) {
+		if (!fd_cmp_regex_one(fd_cmp->buf_match + done_match,
+				      fd_cmp->buf + done)) {
 			ERR("Output does not match pattern on %s:\n", fd_cmp->name);
 			ERR("pattern: %s\n", fd_cmp->buf_match + done_match);
 			ERR("output : %s\n", fd_cmp->buf + done);
@@ -545,9 +549,8 @@ static bool fd_cmp_exact(struct fd_cmp *fd_cmp, const struct test *t)
 	return true;
 }
 
-static bool test_run_parent_check_outputs(const struct test *t,
-					  int fdout, int fderr, int fdmonitor,
-					  pid_t child)
+static bool test_run_parent_check_outputs(const struct test *t, int fdout, int fderr,
+					  int fdmonitor, pid_t child)
 {
 	int err, fd_ep;
 	unsigned long long end_usec, start_usec;
@@ -563,16 +566,14 @@ static bool test_run_parent_check_outputs(const struct test *t,
 	}
 
 	if (t->output.out != NULL) {
-		err = fd_cmp_open(&fd_cmp_out,
-				  FD_CMP_OUT, t->output.out, fdout, fd_ep);
+		err = fd_cmp_open(&fd_cmp_out, FD_CMP_OUT, t->output.out, fdout, fd_ep);
 		if (err < 0)
 			goto out;
 		n_fd++;
 	}
 
 	if (t->output.err != NULL) {
-		err = fd_cmp_open(&fd_cmp_err,
-				  FD_CMP_ERR, t->output.err, fderr, fd_ep);
+		err = fd_cmp_open(&fd_cmp_err, FD_CMP_ERR, t->output.err, fderr, fd_ep);
 		if (err < 0)
 			goto out;
 		n_fd++;
@@ -604,7 +605,7 @@ static bool test_run_parent_check_outputs(const struct test *t,
 			goto out;
 		}
 
-		for (i = 0;  i < fdcount; i++) {
+		for (i = 0; i < fdcount; i++) {
 			struct fd_cmp *fd_cmp = ev[i].data.ptr;
 			bool ret;
 
@@ -763,14 +764,12 @@ static int cmp_modnames(const void *m1, const void *m2)
  * Auxiliary function to store the module names in buf and return a list
  * of pointers to them.
  */
-static const char **read_modules(const char* modules,
-		char **buf, int *count)
+static const char **read_modules(const char *modules, char **buf, int *count)
 {
 	const char **res;
 	int len;
 	int i;
 	char *p;
-
 
 	*buf = strdup(modules);
 	if (!*buf) {
@@ -804,8 +803,7 @@ static const char **read_modules(const char* modules,
  * Store the expected module names in buf and return a list of pointers to
  * them.
  */
-static const char **read_expected_modules(const struct test *t,
-		char **buf, int *count)
+static const char **read_expected_modules(const struct test *t, char **buf, int *count)
 {
 	if (t->modules_loaded[0] == '\0') {
 		*count = 0;
@@ -819,8 +817,7 @@ static const char **read_expected_modules(const struct test *t,
  * Store the unexpected module names in buf and return a list of pointers to
  * them.
  */
-static const char **read_unexpected_modules(const struct test *t,
-		char **buf, int *count)
+static const char **read_unexpected_modules(const struct test *t, char **buf, int *count)
 {
 	if (t->modules_not_loaded[0] == '\0') {
 		*count = 0;
@@ -842,8 +839,8 @@ static char **read_loaded_modules(const struct test *t, char **buf, int *count)
 	const char *rootfs = t->config[TC_ROOTFS] ? t->config[TC_ROOTFS] : "";
 
 	/* Store the entries in /sys/module to res */
-	if (snprintf(dirname, sizeof(dirname), "%s/sys/module", rootfs)
-			>= (int)sizeof(dirname)) {
+	if (snprintf(dirname, sizeof(dirname), "%s/sys/module", rootfs) >=
+	    (int)sizeof(dirname)) {
 		ERR("rootfs path too long: %s\n", rootfs);
 		*buf = NULL;
 		len = -1;
@@ -932,7 +929,7 @@ static int check_loaded_modules(const struct test *t)
 			err = false;
 			ERR("module %s not loaded\n", a1[i1]);
 			i1++;
-		} else  {
+		} else {
 			err = false;
 			ERR("module %s is loaded but should not be \n", a2[i2]);
 			i2++;
@@ -980,7 +977,7 @@ static int check_not_loaded_modules(const struct test *t)
 		} else if (cmp < 0) {
 			i1++;
 			i2++;
-		} else  {
+		} else {
 			err = false;
 			ERR("module %s is loaded but should not be\n", a2[i2]);
 			i2++;
@@ -994,17 +991,16 @@ out_a1:
 	return err;
 }
 
-static inline int test_run_parent(const struct test *t, int fdout[2],
-				int fderr[2], int fdmonitor[2], pid_t child)
+static inline int test_run_parent(const struct test *t, int fdout[2], int fderr[2],
+				  int fdmonitor[2], pid_t child)
 {
 	pid_t pid;
 	int err;
 	bool matchout, match_modules;
 
 	if (t->skip) {
-		LOG("%sSKIPPED%s: %s\n",
-			ANSI_HIGHLIGHT_YELLOW_ON, ANSI_HIGHLIGHT_OFF,
-			t->name);
+		LOG("%sSKIPPED%s: %s\n", ANSI_HIGHLIGHT_YELLOW_ON, ANSI_HIGHLIGHT_OFF,
+		    t->name);
 		err = EXIT_SUCCESS;
 		goto exit;
 	}
@@ -1016,8 +1012,8 @@ static inline int test_run_parent(const struct test *t, int fdout[2],
 		close(fderr[1]);
 	close(fdmonitor[1]);
 
-	matchout = test_run_parent_check_outputs(t, fdout[0], fderr[0],
-							fdmonitor[0], child);
+	matchout =
+		test_run_parent_check_outputs(t, fdout[0], fderr[0], fdmonitor[0], child);
 
 	/*
 	 * break pipe on the other end: either child already closed or we want
@@ -1040,14 +1036,14 @@ static inline int test_run_parent(const struct test *t, int fdout[2],
 
 	if (WIFEXITED(err)) {
 		if (WEXITSTATUS(err) != 0)
-			ERR("'%s' [%u] exited with return code %d\n",
-					t->name, pid, WEXITSTATUS(err));
+			ERR("'%s' [%u] exited with return code %d\n", t->name, pid,
+			    WEXITSTATUS(err));
 		else
-			LOG("'%s' [%u] exited with return code %d\n",
-					t->name, pid, WEXITSTATUS(err));
+			LOG("'%s' [%u] exited with return code %d\n", t->name, pid,
+			    WEXITSTATUS(err));
 	} else if (WIFSIGNALED(err)) {
 		ERR("'%s' [%u] terminated by signal %d (%s)\n", t->name, pid,
-				WTERMSIG(err), strsignal(WTERMSIG(err)));
+		    WTERMSIG(err), strsignal(WTERMSIG(err)));
 		err = t->expected_fail ? EXIT_SUCCESS : EXIT_FAILURE;
 		goto exit;
 	}
@@ -1064,44 +1060,38 @@ static inline int test_run_parent(const struct test *t, int fdout[2],
 	if (t->expected_fail == false) {
 		if (err == 0) {
 			if (matchout && match_modules)
-				LOG("%sPASSED%s: %s\n",
-					ANSI_HIGHLIGHT_GREEN_ON, ANSI_HIGHLIGHT_OFF,
-					t->name);
+				LOG("%sPASSED%s: %s\n", ANSI_HIGHLIGHT_GREEN_ON,
+				    ANSI_HIGHLIGHT_OFF, t->name);
 			else {
 				ERR("%sFAILED%s: exit ok but %s do not match: %s\n",
-					ANSI_HIGHLIGHT_RED_ON, ANSI_HIGHLIGHT_OFF,
-					matchout ? "loaded modules" : "outputs",
-					t->name);
+				    ANSI_HIGHLIGHT_RED_ON, ANSI_HIGHLIGHT_OFF,
+				    matchout ? "loaded modules" : "outputs", t->name);
 				err = EXIT_FAILURE;
 			}
 		} else {
-			ERR("%sFAILED%s: %s\n",
-					ANSI_HIGHLIGHT_RED_ON, ANSI_HIGHLIGHT_OFF,
-					t->name);
+			ERR("%sFAILED%s: %s\n", ANSI_HIGHLIGHT_RED_ON, ANSI_HIGHLIGHT_OFF,
+			    t->name);
 		}
 	} else {
 		if (err == 0) {
 			if (matchout) {
 				ERR("%sUNEXPECTED PASS%s: exit with 0: %s\n",
-					ANSI_HIGHLIGHT_RED_ON, ANSI_HIGHLIGHT_OFF,
-					t->name);
+				    ANSI_HIGHLIGHT_RED_ON, ANSI_HIGHLIGHT_OFF, t->name);
 				err = EXIT_FAILURE;
 			} else {
 				ERR("%sUNEXPECTED PASS%s: exit with 0 and outputs do not match: %s\n",
-					ANSI_HIGHLIGHT_RED_ON, ANSI_HIGHLIGHT_OFF,
-					t->name);
+				    ANSI_HIGHLIGHT_RED_ON, ANSI_HIGHLIGHT_OFF, t->name);
 				err = EXIT_FAILURE;
 			}
 		} else {
 			if (matchout) {
-				LOG("%sEXPECTED FAIL%s: %s\n",
-					ANSI_HIGHLIGHT_GREEN_ON, ANSI_HIGHLIGHT_OFF,
-					t->name);
+				LOG("%sEXPECTED FAIL%s: %s\n", ANSI_HIGHLIGHT_GREEN_ON,
+				    ANSI_HIGHLIGHT_OFF, t->name);
 				err = EXIT_SUCCESS;
 			} else {
 				LOG("%sEXPECTED FAIL%s: exit with %d but outputs do not match: %s\n",
-					ANSI_HIGHLIGHT_GREEN_ON, ANSI_HIGHLIGHT_OFF,
-					WEXITSTATUS(err), t->name);
+				    ANSI_HIGHLIGHT_GREEN_ON, ANSI_HIGHLIGHT_OFF,
+				    WEXITSTATUS(err), t->name);
 				err = EXIT_FAILURE;
 			}
 		}

--- a/testsuite/testsuite.h
+++ b/testsuite/testsuite.h
@@ -103,71 +103,68 @@ struct test {
 	bool print_outputs;
 } __attribute__((aligned(8)));
 
-
-int test_init(const struct test *start, const struct test *stop,
-	      int argc, char *const argv[]);
+int test_init(const struct test *start, const struct test *stop, int argc,
+	      char *const argv[]);
 const struct test *test_find(const struct test *start, const struct test *stop,
 			     const char *name);
 int test_spawn_prog(const char *prog, const char *const args[]);
 int test_run(const struct test *t);
 
-#define TS_EXPORT __attribute__ ((visibility("default")))
+#define TS_EXPORT __attribute__((visibility("default")))
 
-#define _LOG(prefix, fmt, ...) printf("TESTSUITE: " prefix fmt, ## __VA_ARGS__)
-#define LOG(fmt, ...) _LOG("", fmt, ## __VA_ARGS__)
-#define WARN(fmt, ...) _LOG("WARN: ", fmt, ## __VA_ARGS__)
-#define ERR(fmt, ...) _LOG("ERR: ", fmt, ## __VA_ARGS__)
+#define _LOG(prefix, fmt, ...) printf("TESTSUITE: " prefix fmt, ##__VA_ARGS__)
+#define LOG(fmt, ...) _LOG("", fmt, ##__VA_ARGS__)
+#define WARN(fmt, ...) _LOG("WARN: ", fmt, ##__VA_ARGS__)
+#define ERR(fmt, ...) _LOG("ERR: ", fmt, ##__VA_ARGS__)
 
-#define assert_return(expr, r)						\
-	do {								\
-		if ((!(expr))) {					\
-			ERR("Failed assertion: " #expr " %s:%d %s\n",	\
-			    __FILE__, __LINE__, __PRETTY_FUNCTION__);	\
-			return (r);					\
-		}							\
+#define assert_return(expr, r)                                                  \
+	do {                                                                    \
+		if ((!(expr))) {                                                \
+			ERR("Failed assertion: " #expr " %s:%d %s\n", __FILE__, \
+			    __LINE__, __PRETTY_FUNCTION__);                     \
+			return (r);                                             \
+		}                                                               \
 	} while (false)
 
-
 /* Test definitions */
-#define DEFINE_TEST_WITH_FUNC(_name, _func, ...) \
-	static const struct test UNIQ(s##_name) \
-	__attribute__((used, section("kmod_tests"), aligned(8))) = { \
-		.name = #_name, \
-		.func = _func, \
-		## __VA_ARGS__ \
-	};
+#define DEFINE_TEST_WITH_FUNC(_name, _func, ...)                             \
+	static const struct test UNIQ(s##_name)                              \
+		__attribute__((used, section("kmod_tests"), aligned(8))) = { \
+			.name = #_name, .func = _func, ##__VA_ARGS__         \
+		};
 
 #define DEFINE_TEST(_name, ...) DEFINE_TEST_WITH_FUNC(_name, _name, __VA_ARGS__)
 
-#define TESTSUITE_MAIN() \
-	extern struct test __start_kmod_tests[] __attribute__((weak, visibility("hidden")));	\
-	extern struct test __stop_kmod_tests[] __attribute__((weak, visibility("hidden")));	\
-	int main(int argc, char *argv[])							\
-	{											\
-		const struct test *t;								\
-		int arg;									\
-												\
-		arg = test_init(__start_kmod_tests, __stop_kmod_tests, argc, argv);		\
-		if (arg == 0)									\
-			return 0;								\
-		if (arg < 0)									\
-			return EXIT_FAILURE;							\
-												\
-		if (arg < argc) {								\
-			t = test_find(__start_kmod_tests, __stop_kmod_tests, argv[arg]);	\
-			if (t == NULL) {							\
-				fprintf(stderr, "could not find test %s\n", argv[arg]);		\
-				exit(EXIT_FAILURE);						\
-			}									\
-												\
-			return test_run(t);							\
-		}										\
-												\
-		for (t = __start_kmod_tests; t < __stop_kmod_tests; t++) {			\
-			if (test_run(t) != 0)							\
-				exit(EXIT_FAILURE);						\
-		}										\
-												\
-		exit(EXIT_SUCCESS);								\
-	}											\
-
+#define TESTSUITE_MAIN()                                                                 \
+	extern struct test __start_kmod_tests[]                                          \
+		__attribute__((weak, visibility("hidden")));                             \
+	extern struct test __stop_kmod_tests[]                                           \
+		__attribute__((weak, visibility("hidden")));                             \
+	int main(int argc, char *argv[])                                                 \
+	{                                                                                \
+		const struct test *t;                                                    \
+		int arg;                                                                 \
+                                                                                         \
+		arg = test_init(__start_kmod_tests, __stop_kmod_tests, argc, argv);      \
+		if (arg == 0)                                                            \
+			return 0;                                                        \
+		if (arg < 0)                                                             \
+			return EXIT_FAILURE;                                             \
+                                                                                         \
+		if (arg < argc) {                                                        \
+			t = test_find(__start_kmod_tests, __stop_kmod_tests, argv[arg]); \
+			if (t == NULL) {                                                 \
+				fprintf(stderr, "could not find test %s\n", argv[arg]);  \
+				exit(EXIT_FAILURE);                                      \
+			}                                                                \
+                                                                                         \
+			return test_run(t);                                              \
+		}                                                                        \
+                                                                                         \
+		for (t = __start_kmod_tests; t < __stop_kmod_tests; t++) {               \
+			if (test_run(t) != 0)                                            \
+				exit(EXIT_FAILURE);                                      \
+		}                                                                        \
+                                                                                         \
+		exit(EXIT_SUCCESS);                                                      \
+	}

--- a/testsuite/uname.c
+++ b/testsuite/uname.c
@@ -43,16 +43,16 @@ TS_EXPORT int uname(struct utsname *u)
 
 	release = getenv(S_TC_UNAME_R);
 	if (release == NULL) {
-		fprintf(stderr, "TRAP uname(): missing export %s?\n",
-							S_TC_UNAME_R);
+		fprintf(stderr, "TRAP uname(): missing export %s?\n", S_TC_UNAME_R);
 		return 0;
 	}
 
 	sz = strlen(release) + 1;
 	if (sz > sizeof(u->release)) {
-		fprintf(stderr, "uname(): sizeof release (%s) "
-				"is greater than available space: %zu",
-				release, sizeof(u->release));
+		fprintf(stderr,
+			"uname(): sizeof release (%s) "
+			"is greater than available space: %zu",
+			release, sizeof(u->release));
 		errno = -EFAULT;
 		return -1;
 	}

--- a/tools/depmod.c
+++ b/tools/depmod.c
@@ -68,43 +68,43 @@ static const struct option cmdopts[] = {
 	{ "warn", no_argument, 0, 'w' },
 	{ "version", no_argument, 0, 'V' },
 	{ "help", no_argument, 0, 'h' },
-	{ },
+	{},
 };
 
 static void help(void)
 {
 	printf("Usage:\n"
-		"\t%s -[aA] [options] [forced_version]\n"
-		"\n"
-		"If no arguments (except options) are given, \"depmod -a\" is assumed\n"
-		"\n"
-		"depmod will output a dependency list suitable for the modprobe utility.\n"
-		"\n"
-		"Options:\n"
-		"\t-a, --all            Probe all modules\n"
-		"\t-A, --quick          Only does the work if there's a new module\n"
-		"\t-e, --errsyms        Report not supplied symbols\n"
-		"\t-n, --show           Write the dependency file on stdout only\n"
-		"\t-P, --symbol-prefix  Architecture symbol prefix\n"
-		"\t-C, --config=PATH    Read configuration from PATH\n"
-		"\t-v, --verbose        Enable verbose mode\n"
-		"\t-w, --warn           Warn on duplicates\n"
-		"\t-V, --version        show version\n"
-		"\t-h, --help           show this help\n"
-		"\n"
-		"The following options are useful for people managing distributions:\n"
-		"\t-b, --basedir=DIR    Root path (default: /).\n"
-		"\t-m, --moduledir=DIR  Module directory (default: " MODULE_DIRECTORY ").\n"
-		"\t-o, --outdir=DIR     Output root path (default: same as <basedir>).\n"
-		"\t-F, --filesyms=FILE  Use the file instead of the\n"
-		"\t                     current kernel symbols.\n"
-		"\t-E, --symvers=FILE   Use Module.symvers file to check\n"
-		"\t                     symbol versions.\n",
-		program_invocation_short_name);
+	       "\t%s -[aA] [options] [forced_version]\n"
+	       "\n"
+	       "If no arguments (except options) are given, \"depmod -a\" is assumed\n"
+	       "\n"
+	       "depmod will output a dependency list suitable for the modprobe utility.\n"
+	       "\n"
+	       "Options:\n"
+	       "\t-a, --all            Probe all modules\n"
+	       "\t-A, --quick          Only does the work if there's a new module\n"
+	       "\t-e, --errsyms        Report not supplied symbols\n"
+	       "\t-n, --show           Write the dependency file on stdout only\n"
+	       "\t-P, --symbol-prefix  Architecture symbol prefix\n"
+	       "\t-C, --config=PATH    Read configuration from PATH\n"
+	       "\t-v, --verbose        Enable verbose mode\n"
+	       "\t-w, --warn           Warn on duplicates\n"
+	       "\t-V, --version        show version\n"
+	       "\t-h, --help           show this help\n"
+	       "\n"
+	       "The following options are useful for people managing distributions:\n"
+	       "\t-b, --basedir=DIR    Root path (default: /).\n"
+	       "\t-m, --moduledir=DIR  Module directory (default: " MODULE_DIRECTORY
+	       ").\n"
+	       "\t-o, --outdir=DIR     Output root path (default: same as <basedir>).\n"
+	       "\t-F, --filesyms=FILE  Use the file instead of the\n"
+	       "\t                     current kernel symbols.\n"
+	       "\t-E, --symvers=FILE   Use Module.symvers file to check\n"
+	       "\t                     symbol versions.\n",
+	       program_invocation_short_name);
 }
 
-_printf_format_(1, 2)
-static inline void _show(const char *fmt, ...)
+_printf_format_(1, 2) static inline void _show(const char *fmt, ...)
 {
 	va_list args;
 
@@ -118,12 +118,11 @@ static inline void _show(const char *fmt, ...)
 }
 #define SHOW(...) _show(__VA_ARGS__)
 
-
 /* see documentation in libkmod/libkmod-index.c */
 #define INDEX_MAGIC 0xB007F457
 #define INDEX_VERSION_MAJOR 0x0002
 #define INDEX_VERSION_MINOR 0x0001
-#define INDEX_VERSION ((INDEX_VERSION_MAJOR<<16)|INDEX_VERSION_MINOR)
+#define INDEX_VERSION ((INDEX_VERSION_MAJOR << 16) | INDEX_VERSION_MINOR)
 #define INDEX_CHILDMAX 128
 
 struct index_value {
@@ -134,22 +133,21 @@ struct index_value {
 
 /* In-memory index (depmod only) */
 struct index_node {
-	char *prefix;		/* path compression */
+	char *prefix; /* path compression */
 	struct index_value *values;
-	unsigned char first;	/* range of child nodes */
+	unsigned char first; /* range of child nodes */
 	unsigned char last;
 	struct index_node *children[INDEX_CHILDMAX]; /* indexed by character */
 };
 
-
 /* Format of node offsets within index file */
 enum node_offset {
-	INDEX_NODE_FLAGS    = 0xF0000000, /* Flags in high nibble */
-	INDEX_NODE_PREFIX   = 0x80000000,
+	INDEX_NODE_FLAGS = 0xF0000000, /* Flags in high nibble */
+	INDEX_NODE_PREFIX = 0x80000000,
 	INDEX_NODE_VALUES = 0x40000000,
-	INDEX_NODE_CHILDS   = 0x20000000,
+	INDEX_NODE_CHILDS = 0x20000000,
 
-	INDEX_NODE_MASK     = 0x0FFFFFFF, /* Offset value */
+	INDEX_NODE_MASK = 0x0FFFFFFF, /* Offset value */
 };
 
 static noreturn void fatal_oom(void)
@@ -211,12 +209,13 @@ static void index__checkstring(const char *str)
 
 		if (ch >= INDEX_CHILDMAX)
 			CRIT("Module index: bad character '%c'=0x%x - only 7-bit ASCII is supported:"
-			      "\n%s\n", (char) ch, (int) ch, str);
+			     "\n%s\n",
+			     (char)ch, (int)ch, str);
 	}
 }
 
-static int index_add_value(struct index_value **values,
-				const char *value, unsigned int priority)
+static int index_add_value(struct index_value **values, const char *value,
+			   unsigned int priority)
 {
 	struct index_value *v;
 	int duplicate = 0;
@@ -244,8 +243,8 @@ static int index_add_value(struct index_value **values,
 	return duplicate;
 }
 
-static int index_insert(struct index_node *node, const char *key,
-			const char *value, unsigned int priority)
+static int index_insert(struct index_node *node, const char *key, const char *value,
+			unsigned int priority)
 {
 	int i = 0; /* index within str */
 	int ch;
@@ -253,7 +252,7 @@ static int index_insert(struct index_node *node, const char *key,
 	index__checkstring(key);
 	index__checkstring(value);
 
-	while(1) {
+	while (1) {
 		int j; /* index within node->prefix */
 
 		/* Ensure node->prefix is a prefix of &str[i].
@@ -261,7 +260,7 @@ static int index_insert(struct index_node *node, const char *key,
 		for (j = 0; node->prefix[j]; j++) {
 			ch = node->prefix[j];
 
-			if (ch != key[i+j]) {
+			if (ch != key[i + j]) {
 				char *prefix = node->prefix;
 				struct index_node *n;
 
@@ -270,7 +269,7 @@ static int index_insert(struct index_node *node, const char *key,
 				if (n == NULL)
 					fatal_oom();
 				memcpy(n, node, sizeof(struct index_node));
-				n->prefix = strdup(&prefix[j+1]);
+				n->prefix = strdup(&prefix[j + 1]);
 				if (n->prefix == NULL)
 					fatal_oom();
 
@@ -289,7 +288,7 @@ static int index_insert(struct index_node *node, const char *key,
 		i += j;
 
 		ch = key[i];
-		if(ch == '\0')
+		if (ch == '\0')
 			return index_add_value(&node->values, value, priority);
 
 		if (!node->children[ch]) {
@@ -304,7 +303,7 @@ static int index_insert(struct index_node *node, const char *key,
 				fatal_oom();
 
 			child = node->children[ch];
-			child->prefix = strdup(&key[i+1]);
+			child->prefix = strdup(&key[i + 1]);
 			if (child->prefix == NULL)
 				fatal_oom();
 			child->first = INDEX_CHILDMAX;
@@ -525,8 +524,7 @@ static int cfg_override_add(struct cfg *cfg, const char *modname, const char *su
 	size_t subdirlen = strlen(subdir);
 	size_t i;
 
-	o = malloc(sizeof(struct cfg_override) + subdirlen + 1
-		   + modnamelen + 1);
+	o = malloc(sizeof(struct cfg_override) + subdirlen + 1 + modnamelen + 1);
 	if (o == NULL) {
 		ERR("override add: out of memory\n");
 		return -ENOMEM;
@@ -613,7 +611,7 @@ static int cfg_kernel_matches(const struct cfg *cfg, const char *pattern)
 	if (streq(pattern, "*"))
 		return 1;
 
-	if (regcomp(&re, pattern, REG_EXTENDED|REG_NOSUB) != 0)
+	if (regcomp(&re, pattern, REG_EXTENDED | REG_NOSUB) != 0)
 		return 0;
 
 	status = regexec(&re, cfg->kversion, 0, NULL, 0);
@@ -656,13 +654,12 @@ static int cfg_file_parse(struct cfg *cfg, const char *filename)
 			const char *version = strtok_r(NULL, "\t ", &saveptr);
 			const char *subdir = strtok_r(NULL, "\t ", &saveptr);
 
-			if (modname == NULL || version == NULL ||
-					subdir == NULL)
+			if (modname == NULL || version == NULL || subdir == NULL)
 				goto syntax_error;
 
 			if (!cfg_kernel_matches(cfg, version)) {
-				INF("%s:%u: override kernel did not match %s\n",
-				    filename, linenum, version);
+				INF("%s:%u: override kernel did not match %s\n", filename,
+				    linenum, version);
 				goto done_next;
 			}
 
@@ -686,14 +683,13 @@ static int cfg_file_parse(struct cfg *cfg, const char *filename)
 			while ((sp = strtok_r(NULL, "\t ", &saveptr)) != NULL) {
 				cfg_exclude_add(cfg, sp);
 			}
-		} else if (streq(cmd, "include")
-				|| streq(cmd, "make_map_files")) {
-			INF("%s:%u: command %s not implemented yet\n",
-			    filename, linenum, cmd);
+		} else if (streq(cmd, "include") || streq(cmd, "make_map_files")) {
+			INF("%s:%u: command %s not implemented yet\n", filename, linenum,
+			    cmd);
 		} else {
 syntax_error:
-			ERR("%s:%u: ignoring bad line starting with '%s'\n",
-			    filename, linenum, cmd);
+			ERR("%s:%u: ignoring bad line starting with '%s'\n", filename,
+			    linenum, cmd);
 		}
 
 done_next:
@@ -720,8 +716,8 @@ static int cfg_files_filter_out(DIR *d, const char *dir, const char *name)
 
 	fstatat(dirfd(d), name, &st, 0);
 	if (S_ISDIR(st.st_mode)) {
-		ERR("Directories inside directories are not supported: %s/%s\n",
-		    dir, name);
+		ERR("Directories inside directories are not supported: %s/%s\n", dir,
+		    name);
 		return 1;
 	}
 
@@ -741,7 +737,7 @@ static void cfg_file_free(struct cfg_file *f)
 }
 
 static int cfg_files_insert_sorted(struct cfg_file ***p_files, size_t *p_n_files,
-					const char *dir, const char *name)
+				   const char *dir, const char *name)
 {
 	struct cfg_file **files, *f;
 	size_t i, n_files, namelen, dirlen;
@@ -761,8 +757,8 @@ static int cfg_files_insert_sorted(struct cfg_file ***p_files, size_t *p_n_files
 	for (i = 0; i < n_files; i++) {
 		int cmp = strcmp(name, files[i]->name);
 		if (cmp == 0) {
-			DBG("Ignoring duplicate config file: %.*s/%s\n",
-			    (int)dirlen, dir, name);
+			DBG("Ignoring duplicate config file: %.*s/%s\n", (int)dirlen, dir,
+			    name);
 			return -EEXIST;
 		} else if (cmp < 0)
 			break;
@@ -803,8 +799,7 @@ static int cfg_files_insert_sorted(struct cfg_file ***p_files, size_t *p_n_files
 /*
  * Insert configuration files ignoring duplicates
  */
-static int cfg_files_list(struct cfg_file ***p_files, size_t *p_n_files,
-				const char *path)
+static int cfg_files_list(struct cfg_file ***p_files, size_t *p_n_files, const char *path)
 {
 	struct dirent *dent;
 	DIR *d;
@@ -840,7 +835,7 @@ static int cfg_files_list(struct cfg_file ***p_files, size_t *p_n_files,
 	return err;
 }
 
-static int cfg_load(struct cfg *cfg, const char * const *cfg_paths)
+static int cfg_load(struct cfg *cfg, const char *const *cfg_paths)
 {
 	size_t i, n_files = 0;
 	struct cfg_file **files = NULL;
@@ -893,7 +888,6 @@ static void cfg_free(struct cfg *cfg)
 		cfg_exclude_free(tmp);
 	}
 }
-
 
 /* depmod calculations ***********************************************/
 struct vertex;
@@ -957,8 +951,8 @@ static int mod_add_dependency(struct mod *mod, struct symbol *sym)
 	if (err == -EEXIST)
 		return 0;
 	if (err < 0) {
-		CRIT("failed to add symbol %s to module %s: %s\n",
-		    sym->name, mod->path, strerror(-err));
+		CRIT("failed to add symbol %s to module %s: %s\n", sym->name, mod->path,
+		     strerror(-err));
 		return err;
 	}
 
@@ -974,8 +968,7 @@ static void symbol_free(struct symbol *sym)
 	free(sym);
 }
 
-static int depmod_init(struct depmod *depmod, struct cfg *cfg,
-							struct kmod_ctx *ctx)
+static int depmod_init(struct depmod *depmod, struct cfg *cfg, struct kmod_ctx *ctx)
 {
 	int err = 0;
 
@@ -1059,7 +1052,7 @@ static int depmod_module_add(struct depmod *depmod, struct kmod_module *kmod)
 	lastslash = strrchr(mod->path, '/');
 	mod->baselen = lastslash - mod->path;
 	if (strncmp(mod->path, cfg->dirname, cfg->dirnamelen) == 0 &&
-			mod->path[cfg->dirnamelen] == '/')
+	    mod->path[cfg->dirnamelen] == '/')
 		mod->relpath = mod->path + cfg->dirnamelen + 1;
 	else
 		mod->relpath = NULL;
@@ -1071,15 +1064,13 @@ static int depmod_module_add(struct depmod *depmod, struct kmod_module *kmod)
 	}
 
 	if (mod->relpath != NULL) {
-		size_t uncrelpathlen = lastslash - mod->relpath + modnamesz
-				       + strlen(KMOD_EXTENSION_UNCOMPRESSED);
+		size_t uncrelpathlen = lastslash - mod->relpath + modnamesz +
+				       strlen(KMOD_EXTENSION_UNCOMPRESSED);
 		mod->uncrelpath = memdup(mod->relpath, uncrelpathlen + 1);
 		mod->uncrelpath[uncrelpathlen] = '\0';
-		err = hash_add_unique(depmod->modules_by_uncrelpath,
-				      mod->uncrelpath, mod);
+		err = hash_add_unique(depmod->modules_by_uncrelpath, mod->uncrelpath, mod);
 		if (err < 0) {
-			ERR("hash_add_unique %s: %s\n",
-			    mod->uncrelpath, strerror(-err));
+			ERR("hash_add_unique %s: %s\n", mod->uncrelpath, strerror(-err));
 			hash_del(depmod->modules_by_name, mod->modname);
 			goto fail;
 		}
@@ -1110,7 +1101,7 @@ static int depmod_module_del(struct depmod *depmod, struct mod *mod)
 
 static const char *search_to_string(const struct cfg_search *s)
 {
-	switch(s->type) {
+	switch (s->type) {
 	case SEARCH_EXTERNAL:
 		return "external";
 	case SEARCH_BUILTIN:
@@ -1120,10 +1111,8 @@ static const char *search_to_string(const struct cfg_search *s)
 	}
 }
 
-static bool depmod_is_path_starts_with(const char *path,
-				       size_t pathlen,
-				       const char *prefix,
-				       size_t prefix_len)
+static bool depmod_is_path_starts_with(const char *path, size_t pathlen,
+				       const char *prefix, size_t prefix_len)
 {
 	if (pathlen <= prefix_len)
 		return false;
@@ -1138,7 +1127,10 @@ static bool depmod_is_path_starts_with(const char *path,
 /* returns if existing module @mod is higher priority than newpath.
  * note this is the inverse of module-init-tools is_higher_priority()
  */
-static int depmod_module_is_higher_priority(const struct depmod *depmod, const struct mod *mod, size_t baselen, size_t namelen, size_t modnamelen, const char *newpath)
+static int depmod_module_is_higher_priority(const struct depmod *depmod,
+					    const struct mod *mod, size_t baselen,
+					    size_t namelen, size_t modnamelen,
+					    const char *newpath)
 {
 	const struct cfg *cfg = depmod->cfg;
 	const struct cfg_override *ov;
@@ -1157,8 +1149,7 @@ static int depmod_module_is_higher_priority(const struct depmod *depmod, const s
 	const char *relnewpath = NULL;
 	const char *reloldpath = NULL;
 
-	DBG("comparing priorities of %s and %s\n",
-	    oldpath, newpath);
+	DBG("comparing priorities of %s and %s\n", oldpath, newpath);
 
 	if (strncmp(newpath, cfg->dirname, cfg->dirnamelen) == 0) {
 		relnewpath = newpath + cfg->dirnamelen + 1;
@@ -1171,11 +1162,9 @@ static int depmod_module_is_higher_priority(const struct depmod *depmod, const s
 
 	for (ov = cfg->overrides; ov != NULL; ov = ov->next) {
 		DBG("override %s\n", ov->path);
-		if (relnewlen == ov->len &&
-		    memcmp(ov->path, relnewpath, relnewlen) == 0)
+		if (relnewlen == ov->len && memcmp(ov->path, relnewpath, relnewlen) == 0)
 			return 0;
-		if (reloldlen == ov->len &&
-		    memcmp(ov->path, reloldpath, reloldlen) == 0)
+		if (reloldlen == ov->len && memcmp(ov->path, reloldpath, reloldlen) == 0)
 			return 1;
 	}
 
@@ -1185,19 +1174,15 @@ static int depmod_module_is_higher_priority(const struct depmod *depmod, const s
 			bprio = i;
 		else if (se->type == SEARCH_EXTERNAL) {
 			for (ext = cfg->externals; ext != NULL; ext = ext->next, i++) {
-				if (depmod_is_path_starts_with(newpath,
-							       newlen,
-							       ext->path,
+				if (depmod_is_path_starts_with(newpath, newlen, ext->path,
 							       ext->len))
 					newprio = i;
-				if (depmod_is_path_starts_with(oldpath,
-							       oldlen,
-							       ext->path,
+				if (depmod_is_path_starts_with(oldpath, oldlen, ext->path,
 							       ext->len))
 					oldprio = i;
 			}
 		} else if (relnewlen > se->len && relnewpath[se->len] == '/' &&
-			 memcmp(se->path, relnewpath, se->len) == 0)
+			   memcmp(se->path, relnewpath, se->len) == 0)
 			newprio = i;
 		else if (reloldlen > se->len && reloldpath[se->len] == '/' &&
 			 memcmp(se->path, reloldpath, se->len) == 0)
@@ -1209,13 +1194,13 @@ static int depmod_module_is_higher_priority(const struct depmod *depmod, const s
 	if (oldprio < 0)
 		oldprio = bprio;
 
-	DBG("priorities: built-in: %d, old: %d, new: %d\n",
-	    bprio, oldprio, newprio);
+	DBG("priorities: built-in: %d, old: %d, new: %d\n", bprio, oldprio, newprio);
 
 	return newprio <= oldprio;
 }
 
-static int depmod_modules_search_file(struct depmod *depmod, size_t baselen, size_t namelen, const char *path)
+static int depmod_modules_search_file(struct depmod *depmod, size_t baselen,
+				      size_t namelen, const char *path)
 {
 	struct kmod_module *kmod;
 	struct mod *mod;
@@ -1239,15 +1224,13 @@ static int depmod_modules_search_file(struct depmod *depmod, size_t baselen, siz
 	if (mod == NULL)
 		goto add;
 
-	if (depmod_module_is_higher_priority(depmod, mod, baselen,
-						namelen, modnamelen, path)) {
-		DBG("Ignored lower priority: %s, higher: %s\n",
-		    path, mod->path);
+	if (depmod_module_is_higher_priority(depmod, mod, baselen, namelen, modnamelen,
+					     path)) {
+		DBG("Ignored lower priority: %s, higher: %s\n", path, mod->path);
 		return 0;
 	}
 
-	DBG("Replace lower priority %s with new module %s\n",
-	    mod->relpath, relpath);
+	DBG("Replace lower priority %s with new module %s\n", mod->relpath, relpath);
 	err = depmod_module_del(depmod, mod);
 	if (err < 0) {
 		ERR("could not del module %s: %s\n", mod->path, strerror(-err));
@@ -1263,8 +1246,7 @@ add:
 
 	err = depmod_module_add(depmod, kmod);
 	if (err < 0) {
-		ERR("could not add module %s: %s\n",
-		    path, strerror(-err));
+		ERR("could not add module %s: %s\n", path, strerror(-err));
 		kmod_module_unref(kmod);
 		return err;
 	}
@@ -1275,8 +1257,7 @@ static bool should_exclude_dir(const struct cfg *cfg, const char *name)
 {
 	struct cfg_exclude *exc;
 
-	if (name[0] == '.' && (name[1] == '\0' ||
-			(name[1] == '.' && name[2] == '\0')))
+	if (name[0] == '.' && (name[1] == '\0' || (name[1] == '.' && name[2] == '\0')))
 		return true;
 
 	if (streq(name, "build") || streq(name, "source"))
@@ -1290,7 +1271,8 @@ static bool should_exclude_dir(const struct cfg *cfg, const char *name)
 	return false;
 }
 
-static int depmod_modules_search_dir(struct depmod *depmod, DIR *d, size_t baselen, struct scratchbuf *s_path)
+static int depmod_modules_search_dir(struct depmod *depmod, DIR *d, size_t baselen,
+				     struct scratchbuf *s_path)
 {
 	struct dirent *de;
 	int err = 0, dfd = dirfd(d);
@@ -1328,8 +1310,8 @@ static int depmod_modules_search_dir(struct depmod *depmod, DIR *d, size_t basel
 			else if (S_ISDIR(st.st_mode))
 				is_dir = 1;
 			else {
-				ERR("unsupported file type %s: %o\n",
-				    path, st.st_mode & S_IFMT);
+				ERR("unsupported file type %s: %o\n", path,
+				    st.st_mode & S_IFMT);
 				continue;
 			}
 		}
@@ -1339,8 +1321,7 @@ static int depmod_modules_search_dir(struct depmod *depmod, DIR *d, size_t basel
 			DIR *subdir;
 			fd = openat(dfd, name, O_RDONLY);
 			if (fd < 0) {
-				ERR("openat(%d, %s, O_RDONLY): %m\n",
-				    dfd, name);
+				ERR("openat(%d, %s, O_RDONLY): %m\n", dfd, name);
 				continue;
 			}
 			subdir = fdopendir(fd);
@@ -1352,12 +1333,10 @@ static int depmod_modules_search_dir(struct depmod *depmod, DIR *d, size_t basel
 			path[baselen + namelen] = '/';
 			path[baselen + namelen + 1] = '\0';
 			err = depmod_modules_search_dir(depmod, subdir,
-							baselen + namelen + 1,
-							s_path);
+							baselen + namelen + 1, s_path);
 			closedir(subdir);
 		} else {
-			err = depmod_modules_search_file(depmod, baselen,
-							 namelen, path);
+			err = depmod_modules_search_file(depmod, baselen, namelen, path);
 		}
 
 		if (err < 0) {
@@ -1369,8 +1348,7 @@ static int depmod_modules_search_dir(struct depmod *depmod, DIR *d, size_t basel
 	return err;
 }
 
-static int depmod_modules_search_path(struct depmod *depmod,
-				      const char *path)
+static int depmod_modules_search_path(struct depmod *depmod, const char *path)
 {
 	char buf[256];
 	_cleanup_(scratchbuf_release) struct scratchbuf s_path_buf =
@@ -1425,7 +1403,8 @@ static int depmod_modules_search(struct depmod *depmod)
 	return 0;
 }
 
-static int mod_cmp(const void *pa, const void *pb) {
+static int mod_cmp(const void *pa, const void *pb)
+{
 	const struct mod *a = *(const struct mod **)pa;
 	const struct mod *b = *(const struct mod **)pb;
 	return a->sort_idx - b->sort_idx;
@@ -1439,7 +1418,7 @@ static int depmod_modules_build_array(struct depmod *depmod)
 
 	hash_iter_init(depmod->modules_by_name, &module_iter);
 	while (hash_iter_next(&module_iter, NULL, &v)) {
-		struct mod *mod = (struct mod *) v;
+		struct mod *mod = (struct mod *)v;
 		mod->idx = depmod->modules.count;
 		err = array_append(&depmod->modules, mod);
 		if (err < 0)
@@ -1449,8 +1428,7 @@ static int depmod_modules_build_array(struct depmod *depmod)
 	return 0;
 }
 
-static FILE *dfdopen(const char *dname, const char *filename, int flags,
-		     const char *mode)
+static FILE *dfdopen(const char *dname, const char *filename, int flags, const char *mode)
 {
 	int fd, dfd;
 	FILE *ret;
@@ -1476,8 +1454,6 @@ static FILE *dfdopen(const char *dname, const char *filename, int flags,
 	return ret;
 }
 
-
-
 static void depmod_modules_sort(struct depmod *depmod)
 {
 	char line[PATH_MAX];
@@ -1496,7 +1472,7 @@ static void depmod_modules_sort(struct depmod *depmod)
 			continue;
 		if (line[len - 1] != '\n') {
 			ERR("%s/%s:%u corrupted line misses '\\n'\n",
-				depmod->cfg->dirname, order_file, idx);
+			    depmod->cfg->dirname, order_file, idx);
 			goto corrupted;
 		}
 	}
@@ -1528,9 +1504,8 @@ corrupted:
 	fclose(fp);
 }
 
-static int depmod_symbol_add(struct depmod *depmod, const char *name,
-					bool prefix_skipped, uint64_t crc,
-					const struct mod *owner)
+static int depmod_symbol_add(struct depmod *depmod, const char *name, bool prefix_skipped,
+			     uint64_t crc, const struct mod *owner)
 {
 	size_t namelen;
 	int err;
@@ -1560,8 +1535,7 @@ static int depmod_symbol_add(struct depmod *depmod, const char *name,
 	return 0;
 }
 
-static struct symbol *depmod_symbol_find(const struct depmod *depmod,
-							const char *name)
+static struct symbol *depmod_symbol_find(const struct depmod *depmod, const char *name)
 {
 	if (name[0] == '.') /* PPC64 needs this: .foo == foo */
 		name++;
@@ -1586,8 +1560,8 @@ static int depmod_load_modules(struct depmod *depmod)
 			if (err == -ENODATA)
 				DBG("ignoring %s: no symbols\n", mod->path);
 			else
-				ERR("failed to load symbols from %s: %s\n",
-						mod->path, strerror(-err));
+				ERR("failed to load symbols from %s: %s\n", mod->path,
+				    strerror(-err));
 			goto load_info;
 		}
 		kmod_list_foreach(l, list) {
@@ -1599,14 +1573,13 @@ static int depmod_load_modules(struct depmod *depmod)
 
 load_info:
 		kmod_module_get_info(mod->kmod, &mod->info_list);
-		kmod_module_get_dependency_symbols(mod->kmod,
-						   &mod->dep_sym_list);
+		kmod_module_get_dependency_symbols(mod->kmod, &mod->dep_sym_list);
 		kmod_module_unref(mod->kmod);
 		mod->kmod = NULL;
 	}
 
-	DBG("loaded symbols (%zd modules, %u symbols)\n",
-	    depmod->modules.count, hash_get_count(depmod->symbols));
+	DBG("loaded symbols (%zd modules, %u symbols)\n", depmod->modules.count,
+	    hash_get_count(depmod->symbols));
 
 	return 0;
 }
@@ -1627,16 +1600,15 @@ static int depmod_load_module_dependencies(struct depmod *depmod, struct mod *mo
 		int err;
 
 		if (sym == NULL) {
-			DBG("%s needs (%c) unknown symbol %s\n",
-			    mod->path, bindtype, name);
+			DBG("%s needs (%c) unknown symbol %s\n", mod->path, bindtype,
+			    name);
 			if (cfg->print_unknown && !is_weak)
-				WRN("%s needs unknown symbol %s\n",
-				    mod->path, name);
+				WRN("%s needs unknown symbol %s\n", mod->path, name);
 			continue;
 		}
 
 		if (cfg->check_symvers && sym->crc != crc && !is_weak) {
-			DBG("symbol %s (%#"PRIx64") module %s (%#"PRIx64")\n",
+			DBG("symbol %s (%#" PRIx64 ") module %s (%#" PRIx64 ")\n",
 			    sym->name, sym->crc, mod->path, crc);
 			if (cfg->print_unknown)
 				WRN("%s disagrees about version of symbol %s\n",
@@ -1656,8 +1628,8 @@ static int depmod_load_dependencies(struct depmod *depmod)
 	struct mod **itr, **itr_end;
 	int ret = 0;
 
-	DBG("load dependencies (%zd modules, %u symbols)\n",
-	    depmod->modules.count, hash_get_count(depmod->symbols));
+	DBG("load dependencies (%zd modules, %u symbols)\n", depmod->modules.count,
+	    hash_get_count(depmod->symbols));
 
 	itr = (struct mod **)depmod->modules.array;
 	itr_end = itr + depmod->modules.count;
@@ -1675,8 +1647,8 @@ static int depmod_load_dependencies(struct depmod *depmod)
 			ret = err;
 	}
 
-	DBG("loaded dependencies (%zd modules, %u symbols)\n",
-	    depmod->modules.count, hash_get_count(depmod->symbols));
+	DBG("loaded dependencies (%zd modules, %u symbols)\n", depmod->modules.count,
+	    hash_get_count(depmod->symbols));
 
 	return ret;
 }
@@ -1726,10 +1698,8 @@ static void depmod_list_remove_data(struct kmod_list **list, void *data)
 	*list = l;
 }
 
-static int depmod_report_one_cycle(struct depmod *depmod,
-				   struct vertex *vertex,
-				   struct kmod_list **roots,
-				   struct hash *loop_set)
+static int depmod_report_one_cycle(struct depmod *depmod, struct vertex *vertex,
+				   struct kmod_list **roots, struct hash *loop_set)
 {
 	const char sep[] = " -> ";
 	size_t sz;
@@ -1743,10 +1713,7 @@ static int depmod_report_one_cycle(struct depmod *depmod,
 	array_init(&reverse, 3);
 
 	sz = 0;
-	for (v = vertex->parent, n = 0;
-	     v != NULL;
-	     v = v->parent, n++) {
-
+	for (v = vertex->parent, n = 0; v != NULL; v = v->parent, n++) {
 		sz += v->mod->modnamesz - 1;
 		rc = array_append(&reverse, v);
 		if (rc < 0)
@@ -1783,12 +1750,9 @@ static int depmod_report_one_cycle(struct depmod *depmod,
 	return 0;
 }
 
-static int depmod_report_cycles_from_root(struct depmod *depmod,
-					  struct mod *root_mod,
-					  struct kmod_list **roots,
-					  void **stack,
-					  size_t stack_size,
-					  struct hash *loop_set)
+static int depmod_report_cycles_from_root(struct depmod *depmod, struct mod *root_mod,
+					  struct kmod_list **roots, void **stack,
+					  size_t stack_size, struct hash *loop_set)
 {
 	struct kmod_list *free_list = NULL; /* struct vertex */
 	struct kmod_list *l;
@@ -1825,8 +1789,7 @@ static int depmod_report_cycles_from_root(struct depmod *depmod,
 		 */
 		if (m->visited && m == root->mod) {
 			int rc;
-			rc = depmod_report_one_cycle(depmod, vertex,
-						     roots, loop_set);
+			rc = depmod_report_one_cycle(depmod, vertex, roots, loop_set);
 			if (rc != 0) {
 				ret = rc;
 				goto out;
@@ -1850,7 +1813,7 @@ static int depmod_report_cycles_from_root(struct depmod *depmod,
 			continue;
 		}
 
-		itr = (struct mod **) m->deps.array;
+		itr = (struct mod **)m->deps.array;
 		itr_end = itr + m->deps.count;
 		for (; itr < itr_end; itr++) {
 			struct mod *dep = *itr;
@@ -1868,7 +1831,6 @@ static int depmod_report_cycles_from_root(struct depmod *depmod,
 				goto out;
 			}
 			free_list = l;
-
 		}
 	}
 	ret = 0;
@@ -1884,8 +1846,7 @@ out:
 	return ret;
 }
 
-static void depmod_report_cycles(struct depmod *depmod, uint16_t n_mods,
-				 uint16_t *users)
+static void depmod_report_cycles(struct depmod *depmod, uint16_t n_mods, uint16_t *users)
 {
 	int num_cyclic = 0;
 	struct kmod_list *roots = NULL; /* struct mod */
@@ -1927,10 +1888,8 @@ static void depmod_report_cycles(struct depmod *depmod, uint16_t n_mods,
 		root = roots->data;
 		l = kmod_list_remove(roots);
 		roots = l;
-		err = depmod_report_cycles_from_root(depmod,
-						     root,
-						     &roots,
-						     stack, n_r, loop_set);
+		err = depmod_report_cycles_from_root(depmod, root, &roots, stack, n_r,
+						     loop_set);
 		if (err < 0)
 			goto out_hash;
 	}
@@ -2044,7 +2003,9 @@ static size_t mod_count_all_dependencies(const struct mod *mod)
 	return count;
 }
 
-static int mod_fill_all_unique_dependencies(const struct mod *mod, const struct mod **deps, size_t n_deps, size_t *last)
+static int mod_fill_all_unique_dependencies(const struct mod *mod,
+					    const struct mod **deps, size_t n_deps,
+					    size_t *last)
 {
 	size_t i;
 	int err = 0;
@@ -2074,7 +2035,8 @@ static int mod_fill_all_unique_dependencies(const struct mod *mod, const struct 
 	return err;
 }
 
-static const struct mod **mod_get_all_sorted_dependencies(const struct mod *mod, size_t *n_deps)
+static const struct mod **mod_get_all_sorted_dependencies(const struct mod *mod,
+							  size_t *n_deps)
 {
 	const struct mod **deps;
 	size_t last = 0;
@@ -2129,7 +2091,7 @@ static int output_deps(struct depmod *depmod, FILE *out)
 			fprintf(out, " %s", mod_get_compressed_path(d));
 		}
 		free(deps);
-	end:
+end:
 		putc('\n', out);
 	}
 
@@ -2264,11 +2226,10 @@ static int output_aliases_bin(struct depmod *depmod, FILE *out)
 			}
 			alias = buf;
 
-			duplicate = index_insert(idx, alias, mod->modname,
-						 mod->idx);
+			duplicate = index_insert(idx, alias, mod->modname, mod->idx);
 			if (duplicate && depmod->cfg->warn_dups)
-				WRN("duplicate module alias:\n%s %s\n",
-				    alias, mod->modname);
+				WRN("duplicate module alias:\n%s %s\n", alias,
+				    mod->modname);
 		}
 	}
 
@@ -2340,8 +2301,7 @@ static int output_symbols(struct depmod *depmod, FILE *out)
 		if (sym->owner == NULL)
 			continue;
 
-		fprintf(out, "alias symbol:%s %s\n",
-					sym->name, sym->owner->modname);
+		fprintf(out, "alias symbol:%s %s\n", sym->name, sym->owner->modname);
 	}
 
 	return 0;
@@ -2384,12 +2344,11 @@ static int output_symbols_bin(struct depmod *depmod, FILE *out)
 			goto err_scratchbuf;
 		}
 		memcpy(scratchbuf_str(&salias) + baselen, sym->name, len + 1);
-		duplicate = index_insert(idx, alias, sym->owner->modname,
-							sym->owner->idx);
+		duplicate =
+			index_insert(idx, alias, sym->owner->modname, sym->owner->idx);
 
 		if (duplicate && depmod->cfg->warn_dups)
-			WRN("duplicate module syms:\n%s %s\n",
-						alias, sym->owner->modname);
+			WRN("duplicate module syms:\n%s %s\n", alias, sym->owner->modname);
 	}
 
 	index_write(idx, out);
@@ -2444,9 +2403,7 @@ static int flush_stream(FILE *in, int endchar)
 	size_t i = 0;
 	int c;
 
-	for (c = fgetc(in);
-	     c != EOF && c != endchar && c != '\0';
-	     c = fgetc(in))
+	for (c = fgetc(in); c != EOF && c != endchar && c != '\0'; c = fgetc(in))
 		;
 
 	return c == endchar ? i : 0;
@@ -2457,14 +2414,13 @@ static int flush_stream_to(FILE *in, int endchar, char *dst, size_t dst_sz)
 	size_t i = 0;
 	int c;
 
-	for (c = fgetc(in);
-	     c != EOF && c != endchar && c != '\0' && i < dst_sz;
+	for (c = fgetc(in); c != EOF && c != endchar && c != '\0' && i < dst_sz;
 	     c = fgetc(in))
 		dst[i++] = c;
 
 	if (i == dst_sz) {
-		WRN("Could not flush stream: %d. Partial content: %.*s\n",
-		    ENOSPC, (int) dst_sz, dst);
+		WRN("Could not flush stream: %d. Partial content: %.*s\n", ENOSPC,
+		    (int)dst_sz, dst);
 		i--;
 	}
 
@@ -2558,13 +2514,11 @@ static int output_devname(struct depmod *depmod, FILE *out)
 
 			if (strstartswith(value, "devname:"))
 				devname = value + sizeof("devname:") - 1;
-			else if (sscanf(value, "char-major-%u-%u",
-						&maj, &min) == 2) {
+			else if (sscanf(value, "char-major-%u-%u", &maj, &min) == 2) {
 				type = 'c';
 				major = maj;
 				minor = min;
-			} else if (sscanf(value, "block-major-%u-%u",
-						&maj, &min) == 2) {
+			} else if (sscanf(value, "block-major-%u-%u", &maj, &min) == 2) {
 				type = 'b';
 				major = maj;
 				minor = min;
@@ -2581,12 +2535,13 @@ static int output_devname(struct depmod *depmod, FILE *out)
 					      out);
 					empty = false;
 				}
-				fprintf(out, "%s %s %c%u:%u\n", mod->modname,
-					devname, type, major, minor);
-                        } else
+				fprintf(out, "%s %s %c%u:%u\n", mod->modname, devname,
+					type, major, minor);
+			} else
 				ERR("Module '%s' has devname (%s) but "
 				    "lacks major and minor information. "
-				    "Ignoring.\n", mod->modname, devname);
+				    "Ignoring.\n",
+				    mod->modname, devname);
 		}
 	}
 
@@ -2610,7 +2565,7 @@ static int depmod_output(struct depmod *depmod, FILE *out)
 		{ "modules.builtin.bin", output_builtin_bin },
 		{ "modules.builtin.alias.bin", output_builtin_alias_bin },
 		{ "modules.devname", output_devname },
-		{ },
+		{},
 	};
 	const char *dname = depmod->cfg->outdirname;
 	int dfd, err = 0;
@@ -2645,18 +2600,19 @@ static int depmod_output(struct depmod *depmod, FILE *out)
 			int fd;
 			int n;
 
-			n = snprintf(tmp, sizeof(tmp), "%s.%i.%lli.%lli", itr->name, getpid(),
-					(long long)tv.tv_usec, (long long)tv.tv_sec);
+			n = snprintf(tmp, sizeof(tmp), "%s.%i.%lli.%lli", itr->name,
+				     getpid(), (long long)tv.tv_usec,
+				     (long long)tv.tv_sec);
 			if (n >= (int)sizeof(tmp)) {
 				ERR("bad filename: %s.%i.%lli.%lli: path too long\n",
-					itr->name, getpid(), (long long)tv.tv_usec,
-					(long long)tv.tv_sec);
+				    itr->name, getpid(), (long long)tv.tv_usec,
+				    (long long)tv.tv_sec);
 				continue;
 			}
 			fd = openat(dfd, tmp, flags, mode);
 			if (fd < 0) {
-				ERR("openat(%s, %s, %o, %o): %m\n",
-				    dname, tmp, flags, mode);
+				ERR("openat(%s, %s, %o, %o): %m\n", dname, tmp, flags,
+				    mode);
 				continue;
 			}
 			fp = fdopen(fd, "wb");
@@ -2677,23 +2633,22 @@ static int depmod_output(struct depmod *depmod, FILE *out)
 			if (unlinkat(dfd, tmp, 0) != 0)
 				ERR("unlinkat(%s, %s): %m\n", dname, tmp);
 
-			ERR("Could not write index '%s': %s\n", itr->name,
-								strerror(-r));
+			ERR("Could not write index '%s': %s\n", itr->name, strerror(-r));
 			err = -errno;
 			break;
 		}
 
 		if (renameat(dfd, tmp, dfd, itr->name) != 0) {
 			err = -errno;
-			CRIT("renameat(%s, %s, %s, %s): %m\n",
-					dname, tmp, dname, itr->name);
+			CRIT("renameat(%s, %s, %s, %s): %m\n", dname, tmp, dname,
+			     itr->name);
 			break;
 		}
 
 		if (ferr) {
 			err = -ENOSPC;
 			ERR("Could not create index '%s'. Output is truncated: %s\n",
-						itr->name, strerror(-err));
+			    itr->name, strerror(-err));
 			break;
 		}
 	}
@@ -2748,8 +2703,8 @@ static int depmod_load_symvers(struct depmod *depmod, const char *filename)
 
 		crc = strtoull(ver, &verend, 16);
 		if (verend[0] != '\0') {
-			ERR("%s:%u Invalid symbol version %s: %m\n",
-			    filename, linenum, ver);
+			ERR("%s:%u Invalid symbol version %s: %m\n", filename, linenum,
+			    ver);
 			continue;
 		}
 
@@ -2809,7 +2764,7 @@ static int depmod_load_system_map(struct depmod *depmod, const char *filename)
 		depmod_symbol_add(depmod, p + ksymstr_len, true, 0, NULL);
 		continue;
 
-	invalid_syntax:
+invalid_syntax:
 		ERR("%s:%u: invalid line: %s\n", filename, linenum, line);
 	}
 	depmod_add_fake_syms(depmod);
@@ -2819,7 +2774,6 @@ static int depmod_load_system_map(struct depmod *depmod, const char *filename)
 	fclose(fp);
 	return 0;
 }
-
 
 static int depfile_up_to_date_dir(DIR *d, time_t mtime, size_t baselen, char *path)
 {
@@ -2831,8 +2785,8 @@ static int depfile_up_to_date_dir(DIR *d, time_t mtime, size_t baselen, char *pa
 		size_t namelen;
 		struct stat st;
 
-		if (name[0] == '.' && (name[1] == '\0' ||
-				       (name[1] == '.' && name[2] == '\0')))
+		if (name[0] == '.' &&
+		    (name[1] == '\0' || (name[1] == '.' && name[2] == '\0')))
 			continue;
 		if (streq(name, "build") || streq(name, "source"))
 			continue;
@@ -2858,8 +2812,7 @@ static int depfile_up_to_date_dir(DIR *d, time_t mtime, size_t baselen, char *pa
 			}
 			fd = openat(dfd, name, O_RDONLY);
 			if (fd < 0) {
-				ERR("openat(%d, %s, O_RDONLY): %m\n",
-				    dfd, name);
+				ERR("openat(%d, %s, O_RDONLY): %m\n", dfd, name);
 				continue;
 			}
 			subdir = fdopendir(fd);
@@ -2870,8 +2823,7 @@ static int depfile_up_to_date_dir(DIR *d, time_t mtime, size_t baselen, char *pa
 			}
 			path[baselen + namelen] = '/';
 			path[baselen + namelen + 1] = '\0';
-			err = depfile_up_to_date_dir(subdir, mtime,
-						     baselen + namelen + 1,
+			err = depfile_up_to_date_dir(subdir, mtime, baselen + namelen + 1,
 						     path);
 			closedir(subdir);
 		} else if (S_ISREG(st.st_mode)) {
@@ -2881,13 +2833,11 @@ static int depfile_up_to_date_dir(DIR *d, time_t mtime, size_t baselen, char *pa
 			memcpy(path + baselen, name, namelen + 1);
 			err = st.st_mtime <= mtime;
 			if (err == 0) {
-				DBG("%s %"PRIu64" is newer than %"PRIu64"\n",
-				    path, (uint64_t)st.st_mtime,
-				    (uint64_t)mtime);
+				DBG("%s %" PRIu64 " is newer than %" PRIu64 "\n", path,
+				    (uint64_t)st.st_mtime, (uint64_t)mtime);
 			}
 		} else {
-			ERR("unsupported file type %s: %o\n",
-			    path, st.st_mode & S_IFMT);
+			ERR("unsupported file type %s: %o\n", path, st.st_mode & S_IFMT);
 			continue;
 		}
 
@@ -3058,22 +3008,20 @@ static int do_depmod(int argc, char *argv[])
 		cfg.kversion = un.release;
 	}
 
-	cfg.dirnamelen = snprintf(cfg.dirname, PATH_MAX,
-				  "%s%s/%s",
-				  root ?: "", module_directory, cfg.kversion);
+	cfg.dirnamelen = snprintf(cfg.dirname, PATH_MAX, "%s%s/%s", root ?: "",
+				  module_directory, cfg.kversion);
 	if (cfg.dirnamelen >= PATH_MAX) {
-		ERR("Bad directory %s" MODULE_DIRECTORY
-		    "/%s: path too long\n", root ?: "", cfg.kversion);
+		ERR("Bad directory %s" MODULE_DIRECTORY "/%s: path too long\n",
+		    root ?: "", cfg.kversion);
 		goto cmdline_failed;
 	}
 
-	cfg.outdirnamelen = snprintf(cfg.outdirname, PATH_MAX,
-				     "%s%s/%s",
-				     out_root ?: (root ?: ""), module_directory, cfg.kversion);
+	cfg.outdirnamelen = snprintf(cfg.outdirname, PATH_MAX, "%s%s/%s",
+				     out_root ?: (root ?: ""), module_directory,
+				     cfg.kversion);
 	if (cfg.outdirnamelen >= PATH_MAX) {
-		ERR("Bad directory %s" MODULE_DIRECTORY
-		    "/%s: path too long\n", out_root ?: (root ?: ""),
-		    cfg.kversion);
+		ERR("Bad directory %s" MODULE_DIRECTORY "/%s: path too long\n",
+		    out_root ?: (root ?: ""), cfg.kversion);
 		goto cmdline_failed;
 	}
 
@@ -3107,15 +3055,13 @@ static int do_depmod(int argc, char *argv[])
 	if (module_symvers != NULL) {
 		err = depmod_load_symvers(&depmod, module_symvers);
 		if (err < 0) {
-			CRIT("could not load %s: %s\n", module_symvers,
-			     strerror(-err));
+			CRIT("could not load %s: %s\n", module_symvers, strerror(-err));
 			goto cmdline_failed;
 		}
 	} else if (system_map != NULL) {
 		err = depmod_load_system_map(&depmod, system_map);
 		if (err < 0) {
-			CRIT("could not load %s: %s\n", system_map,
-			     strerror(-err));
+			CRIT("could not load %s: %s\n", system_map, strerror(-err));
 			goto cmdline_failed;
 		}
 	} else if (cfg.print_unknown) {
@@ -3148,15 +3094,15 @@ static int do_depmod(int argc, char *argv[])
 
 			err = kmod_module_new_from_path(depmod.ctx, path, &mod);
 			if (err < 0) {
-				CRIT("could not create module %s: %s\n",
-				     path, strerror(-err));
+				CRIT("could not create module %s: %s\n", path,
+				     strerror(-err));
 				goto cmdline_modules_failed;
 			}
 
 			err = depmod_module_add(&depmod, mod);
 			if (err < 0) {
-				CRIT("could not add module %s: %s\n",
-				     path, strerror(-err));
+				CRIT("could not add module %s: %s\n", path,
+				     strerror(-err));
 				kmod_module_unref(mod);
 				goto cmdline_modules_failed;
 			}
@@ -3165,8 +3111,7 @@ static int do_depmod(int argc, char *argv[])
 
 	err = depmod_modules_build_array(&depmod);
 	if (err < 0) {
-		CRIT("could not build module array: %s\n",
-		     strerror(-err));
+		CRIT("could not build module array: %s\n", strerror(-err));
 		goto cmdline_modules_failed;
 	}
 

--- a/tools/insmod.c
+++ b/tools/insmod.c
@@ -30,15 +30,15 @@ static const struct option cmdopts[] = {
 static void help(void)
 {
 	printf("Usage:\n"
-		"\t%s [options] filename [args]\n"
-		"Options:\n"
-		"\t-f, --force       DANGEROUS: forces a module load, may cause\n"
-		"\t                  data corruption and crash your machine\n"
-		"\t-s, --syslog      print to syslog, not stderr\n"
-		"\t-v, --verbose     enables more messages\n"
-		"\t-V, --version     show version\n"
-		"\t-h, --help        show this help\n",
-		program_invocation_short_name);
+	       "\t%s [options] filename [args]\n"
+	       "Options:\n"
+	       "\t-f, --force       DANGEROUS: forces a module load, may cause\n"
+	       "\t                  data corruption and crash your machine\n"
+	       "\t-s, --syslog      print to syslog, not stderr\n"
+	       "\t-v, --verbose     enables more messages\n"
+	       "\t-V, --version     show version\n"
+	       "\t-h, --help        show this help\n",
+	       program_invocation_short_name);
 }
 
 static const char *mod_strerror(int err)
@@ -95,8 +95,7 @@ static int do_insmod(int argc, char *argv[])
 		case '?':
 			return EXIT_FAILURE;
 		default:
-			ERR("unexpected getopt_long() value '%c'.\n",
-				c);
+			ERR("unexpected getopt_long() value '%c'.\n", c);
 			return EXIT_FAILURE;
 		}
 	}
@@ -145,16 +144,14 @@ static int do_insmod(int argc, char *argv[])
 
 	err = kmod_module_new_from_path(ctx, filename, &mod);
 	if (err < 0) {
-		ERR("could not load module %s: %s\n", filename,
-		    strerror(-err));
+		ERR("could not load module %s: %s\n", filename, strerror(-err));
 		r++;
 		goto end;
 	}
 
 	err = kmod_module_insert_module(mod, flags, opts);
 	if (err < 0) {
-		ERR("could not insert module %s: %s\n", filename,
-		    mod_strerror(-err));
+		ERR("could not insert module %s: %s\n", filename, mod_strerror(-err));
 		r++;
 	}
 	kmod_module_unref(mod);

--- a/tools/kmod.c
+++ b/tools/kmod.c
@@ -47,17 +47,17 @@ static int kmod_help(int argc, char *argv[])
 	size_t i;
 
 	printf("kmod - Manage kernel modules: list, load, unload, etc\n"
-			"Usage:\n"
-			"\t%s [options] command [command_options]\n\n"
-			"Options:\n"
-			"\t-V, --version     show version\n"
-			"\t-h, --help        show this help\n\n"
-			"Commands:\n", basename(argv[0]));
+	       "Usage:\n"
+	       "\t%s [options] command [command_options]\n\n"
+	       "Options:\n"
+	       "\t-V, --version     show version\n"
+	       "\t-h, --help        show this help\n\n"
+	       "Commands:\n",
+	       basename(argv[0]));
 
 	for (i = 0; i < ARRAY_SIZE(kmod_cmds); i++) {
 		if (kmod_cmds[i]->help != NULL) {
-			printf("  %-12s %s\n", kmod_cmds[i]->name,
-							kmod_cmds[i]->help);
+			printf("  %-12s %s\n", kmod_cmds[i]->name, kmod_cmds[i]->help);
 		}
 	}
 
@@ -66,7 +66,7 @@ static int kmod_help(int argc, char *argv[])
 	for (i = 0; i < ARRAY_SIZE(kmod_compat_cmds); i++) {
 		if (kmod_compat_cmds[i]->help != NULL) {
 			printf("  %-12s %s\n", kmod_compat_cmds[i]->name,
-						kmod_compat_cmds[i]->help);
+			       kmod_compat_cmds[i]->help);
 		}
 	}
 
@@ -102,7 +102,8 @@ static int handle_kmod_commands(int argc, char *argv[])
 		case '?':
 			return EXIT_FAILURE;
 		default:
-			fprintf(stderr, "Error: unexpected getopt_long() value '%c'.\n", c);
+			fprintf(stderr, "Error: unexpected getopt_long() value '%c'.\n",
+				c);
 			return EXIT_FAILURE;
 		}
 	}
@@ -132,7 +133,6 @@ fail:
 	kmod_help(argc, argv);
 	return EXIT_FAILURE;
 }
-
 
 static int handle_kmod_compat_commands(int argc, char *argv[])
 {

--- a/tools/log.c
+++ b/tools/log.c
@@ -48,9 +48,9 @@ static const char *prio_to_str(char buf[static PRIO_MAX_SIZE], int prio)
 	return prioname;
 }
 
-_printf_format_(6, 0)
-static void log_kmod(void *data, int priority, const char *file, int line,
-		     const char *fn, const char *format, va_list args)
+_printf_format_(6, 0) static void log_kmod(void *data, int priority, const char *file,
+					   int line, const char *fn, const char *format,
+					   va_list args)
 {
 	char buf[PRIO_MAX_SIZE];
 	const char *prioname;
@@ -63,19 +63,17 @@ static void log_kmod(void *data, int priority, const char *file, int line,
 
 	if (log_use_syslog) {
 #ifdef ENABLE_DEBUG
-		syslog(priority, "%s: %s:%d %s() %s", prioname, file, line,
-		       fn, str);
+		syslog(priority, "%s: %s:%d %s() %s", prioname, file, line, fn, str);
 #else
 		syslog(priority, "%s: %s", prioname, str);
 #endif
 	} else {
 #ifdef ENABLE_DEBUG
-		fprintf(stderr, "%s: %s: %s:%d %s() %s",
-			program_invocation_short_name, prioname, file, line,
-			fn, str);
+		fprintf(stderr, "%s: %s: %s:%d %s() %s", program_invocation_short_name,
+			prioname, file, line, fn, str);
 #else
-		fprintf(stderr, "%s: %s: %s", program_invocation_short_name,
-			prioname, str);
+		fprintf(stderr, "%s: %s: %s", program_invocation_short_name, prioname,
+			str);
 #endif
 	}
 
@@ -118,8 +116,8 @@ void log_printf(int prio, const char *fmt, ...)
 	if (log_use_syslog)
 		syslog(prio, "%s: %s", prioname, msg);
 	else
-		fprintf(stderr, "%s: %s: %s", program_invocation_short_name,
-			prioname, msg);
+		fprintf(stderr, "%s: %s: %s", program_invocation_short_name, prioname,
+			msg);
 	free(msg);
 
 	if (prio <= LOG_CRIT)

--- a/tools/lsmod.c
+++ b/tools/lsmod.c
@@ -29,13 +29,13 @@ static const struct option cmdopts[] = {
 static void help(void)
 {
 	printf("Usage:\n"
-		"\t%s [options]\n"
-		"Options:\n"
-		"\t-s, --syslog      print to syslog, not stderr\n"
-		"\t-v, --verbose     enables more messages\n"
-		"\t-V, --version     show version\n"
-		"\t-h, --help        show this help\n",
-		program_invocation_short_name);
+	       "\t%s [options]\n"
+	       "Options:\n"
+	       "\t-s, --syslog      print to syslog, not stderr\n"
+	       "\t-v, --verbose     enables more messages\n"
+	       "\t-V, --version     show version\n"
+	       "\t-h, --help        show this help\n",
+	       program_invocation_short_name);
 }
 
 static int do_lsmod(int argc, char *argv[])

--- a/tools/modinfo.c
+++ b/tools/modinfo.c
@@ -34,13 +34,14 @@ struct param {
 	int typelen;
 };
 
-static struct param *add_param(const char *name, int namelen, const char *param, int paramlen, const char *type, int typelen, struct param **list)
+static struct param *add_param(const char *name, int namelen, const char *param,
+			       int paramlen, const char *type, int typelen,
+			       struct param **list)
 {
 	struct param *it;
 
 	for (it = *list; it != NULL; it = it->next) {
-		if (it->namelen == namelen &&
-			memcmp(it->name, name, namelen) == 0)
+		if (it->namelen == namelen && memcmp(it->name, name, namelen) == 0)
 			break;
 	}
 
@@ -78,8 +79,7 @@ static int process_parm(const char *key, const char *value, struct param **param
 	struct param *it;
 	const char *colon = strchr(value, ':');
 	if (colon == NULL) {
-		ERR("Found invalid \"%s=%s\": missing ':'\n",
-		    key, value);
+		ERR("Found invalid \"%s=%s\": missing ':'\n", key, value);
 		return 0;
 	}
 
@@ -128,19 +128,13 @@ static int modinfo_params_do(const struct kmod_list *list)
 		params = p->next;
 
 		if (p->param == NULL)
-			printf("%.*s: (%.*s)%c",
-			       p->namelen, p->name, p->typelen, p->type,
+			printf("%.*s: (%.*s)%c", p->namelen, p->name, p->typelen, p->type,
 			       separator);
 		else if (p->type != NULL)
-			printf("%.*s:%.*s (%.*s)%c",
-			       p->namelen, p->name,
-			       p->paramlen, p->param,
-			       p->typelen, p->type,
-			       separator);
+			printf("%.*s:%.*s (%.*s)%c", p->namelen, p->name, p->paramlen,
+			       p->param, p->typelen, p->type, separator);
 		else
-			printf("%.*s:%.*s%c",
-			       p->namelen, p->name,
-			       p->paramlen, p->param,
+			printf("%.*s:%.*s%c", p->namelen, p->name, p->paramlen, p->param,
 			       separator);
 
 		free(p);
@@ -167,8 +161,7 @@ static int modinfo_do(struct kmod_module *mod)
 
 	if (is_builtin) {
 		if (field == NULL)
-			printf("%-16s%s%c", "name:",
-			       kmod_module_get_name(mod), separator);
+			printf("%-16s%s%c", "name:", kmod_module_get_name(mod), separator);
 		else if (field != NULL && streq(field, "name"))
 			printf("%s%c", kmod_module_get_name(mod), separator);
 		filename = "(builtin)";
@@ -178,8 +171,7 @@ static int modinfo_do(struct kmod_module *mod)
 		printf("%s%c", filename, separator);
 		return 0;
 	} else if (field == NULL) {
-		printf("%-16s%s%c", "filename:",
-		       filename, separator);
+		printf("%-16s%s%c", "filename:", filename, separator);
 	}
 
 	err = kmod_module_get_info(mod, &list);
@@ -191,8 +183,8 @@ static int modinfo_do(struct kmod_module *mod)
 			 */
 			return 0;
 		}
-		ERR("could not get modinfo from '%s': %s\n",
-			kmod_module_get_name(mod), strerror(-err));
+		ERR("could not get modinfo from '%s': %s\n", kmod_module_get_name(mod),
+		    strerror(-err));
 		return err;
 	}
 
@@ -238,21 +230,14 @@ static int modinfo_do(struct kmod_module *mod)
 		params = p->next;
 
 		if (p->param == NULL)
-			printf("%-16s%.*s:%.*s%c", "parm:",
-			       p->namelen, p->name, p->typelen, p->type,
-			       separator);
+			printf("%-16s%.*s:%.*s%c", "parm:", p->namelen, p->name,
+			       p->typelen, p->type, separator);
 		else if (p->type != NULL)
-			printf("%-16s%.*s:%.*s (%.*s)%c", "parm:",
-			       p->namelen, p->name,
-			       p->paramlen, p->param,
-			       p->typelen, p->type,
-			       separator);
+			printf("%-16s%.*s:%.*s (%.*s)%c", "parm:", p->namelen, p->name,
+			       p->paramlen, p->param, p->typelen, p->type, separator);
 		else
-			printf("%-16s%.*s:%.*s%c",
-			       "parm:",
-			       p->namelen, p->name,
-			       p->paramlen, p->param,
-			       separator);
+			printf("%-16s%.*s:%.*s%c", "parm:", p->namelen, p->name,
+			       p->paramlen, p->param, separator);
 
 		free(p);
 	}
@@ -298,7 +283,6 @@ static int modinfo_name_do(struct kmod_ctx *ctx, const char *name)
 	return err;
 }
 
-
 static int modinfo_alias_do(struct kmod_ctx *ctx, const char *alias)
 {
 	struct kmod_list *l, *list = NULL;
@@ -326,39 +310,40 @@ static int modinfo_alias_do(struct kmod_ctx *ctx, const char *alias)
 
 static const char cmdopts_s[] = "adlpn0mF:k:b:Vh";
 static const struct option cmdopts[] = {
-	{"author", no_argument, 0, 'a'},
-	{"description", no_argument, 0, 'd'},
-	{"license", no_argument, 0, 'l'},
-	{"parameters", no_argument, 0, 'p'},
-	{"filename", no_argument, 0, 'n'},
-	{"null", no_argument, 0, '0'},
-	{"modname", no_argument, 0, 'm'},
-	{"field", required_argument, 0, 'F'},
-	{"set-version", required_argument, 0, 'k'},
-	{"basedir", required_argument, 0, 'b'},
-	{"version", no_argument, 0, 'V'},
-	{"help", no_argument, 0, 'h'},
-	{NULL, 0, 0, 0},
+	{ "author", no_argument, 0, 'a' },
+	{ "description", no_argument, 0, 'd' },
+	{ "license", no_argument, 0, 'l' },
+	{ "parameters", no_argument, 0, 'p' },
+	{ "filename", no_argument, 0, 'n' },
+	{ "null", no_argument, 0, '0' },
+	{ "modname", no_argument, 0, 'm' },
+	{ "field", required_argument, 0, 'F' },
+	{ "set-version", required_argument, 0, 'k' },
+	{ "basedir", required_argument, 0, 'b' },
+	{ "version", no_argument, 0, 'V' },
+	{ "help", no_argument, 0, 'h' },
+	{ NULL, 0, 0, 0 },
 };
 
 static void help(void)
 {
 	printf("Usage:\n"
-		"\t%s [options] <modulename|filename> [args]\n"
-		"Options:\n"
-		"\t-a, --author                Print only 'author'\n"
-		"\t-d, --description           Print only 'description'\n"
-		"\t-l, --license               Print only 'license'\n"
-		"\t-p, --parameters            Print only 'parm'\n"
-		"\t-n, --filename              Print only 'filename'\n"
-		"\t-0, --null                  Use \\0 instead of \\n\n"
-		"\t-m, --modname               Handle argument as module name instead of alias or filename\n"
-		"\t-F, --field=FIELD           Print only provided FIELD\n"
-		"\t-k, --set-version=VERSION   Use VERSION instead of `uname -r`\n"
-		"\t-b, --basedir=DIR           Use DIR as filesystem root for " MODULE_DIRECTORY "\n"
-		"\t-V, --version               Show version\n"
-		"\t-h, --help                  Show this help\n",
-		program_invocation_short_name);
+	       "\t%s [options] <modulename|filename> [args]\n"
+	       "Options:\n"
+	       "\t-a, --author                Print only 'author'\n"
+	       "\t-d, --description           Print only 'description'\n"
+	       "\t-l, --license               Print only 'license'\n"
+	       "\t-p, --parameters            Print only 'parm'\n"
+	       "\t-n, --filename              Print only 'filename'\n"
+	       "\t-0, --null                  Use \\0 instead of \\n\n"
+	       "\t-m, --modname               Handle argument as module name instead of alias or filename\n"
+	       "\t-F, --field=FIELD           Print only provided FIELD\n"
+	       "\t-k, --set-version=VERSION   Use VERSION instead of `uname -r`\n"
+	       "\t-b, --basedir=DIR           Use DIR as filesystem root for " MODULE_DIRECTORY
+	       "\n"
+	       "\t-V, --version               Show version\n"
+	       "\t-h, --help                  Show this help\n",
+	       program_invocation_short_name);
 }
 
 static bool is_module_filename(const char *name)
@@ -366,8 +351,8 @@ static bool is_module_filename(const char *name)
 	struct stat st;
 
 	if (stat(name, &st) == 0 && S_ISREG(st.st_mode) &&
-		path_ends_with_kmod_ext(name, strlen(name)))
-			return true;
+	    path_ends_with_kmod_ext(name, strlen(name)))
+		return true;
 
 	return false;
 }
@@ -452,10 +437,10 @@ static int do_modinfo(int argc, char *argv[])
 		}
 
 		n = snprintf(dirname_buf, sizeof(dirname_buf),
-		             "%s" MODULE_DIRECTORY "/%s", root, kversion);
+			     "%s" MODULE_DIRECTORY "/%s", root, kversion);
 		if (n >= (int)sizeof(dirname_buf)) {
-			ERR("bad directory %s" MODULE_DIRECTORY
-			    "/%s: path too long\n", root, kversion);
+			ERR("bad directory %s" MODULE_DIRECTORY "/%s: path too long\n",
+			    root, kversion);
 			return EXIT_FAILURE;
 		}
 		dirname = dirname_buf;

--- a/tools/modprobe.c
+++ b/tools/modprobe.c
@@ -49,102 +49,102 @@ static int quiet_inuse = 0;
 
 static const char cmdopts_s[] = "arw:RibfDcnC:d:S:sqvVh";
 static const struct option cmdopts[] = {
-	{"all", no_argument, 0, 'a'},
+	{ "all", no_argument, 0, 'a' },
 
-	{"remove", no_argument, 0, 'r'},
-	{"remove-dependencies", no_argument, 0, 5},
-	{"remove-holders", no_argument, 0, 5},
-	{"wait", required_argument, 0, 'w'},
+	{ "remove", no_argument, 0, 'r' },
+	{ "remove-dependencies", no_argument, 0, 5 },
+	{ "remove-holders", no_argument, 0, 5 },
+	{ "wait", required_argument, 0, 'w' },
 
-	{"resolve-alias", no_argument, 0, 'R'},
-	{"first-time", no_argument, 0, 3},
-	{"ignore-install", no_argument, 0, 'i'},
-	{"ignore-remove", no_argument, 0, 'i'},
-	{"use-blacklist", no_argument, 0, 'b'},
-	{"force", no_argument, 0, 'f'},
-	{"force-modversion", no_argument, 0, 2},
-	{"force-vermagic", no_argument, 0, 1},
+	{ "resolve-alias", no_argument, 0, 'R' },
+	{ "first-time", no_argument, 0, 3 },
+	{ "ignore-install", no_argument, 0, 'i' },
+	{ "ignore-remove", no_argument, 0, 'i' },
+	{ "use-blacklist", no_argument, 0, 'b' },
+	{ "force", no_argument, 0, 'f' },
+	{ "force-modversion", no_argument, 0, 2 },
+	{ "force-vermagic", no_argument, 0, 1 },
 
-	{"show-depends", no_argument, 0, 'D'},
-	{"showconfig", no_argument, 0, 'c'},
-	{"show-config", no_argument, 0, 'c'},
-	{"show-modversions", no_argument, 0, 4},
-	{"dump-modversions", no_argument, 0, 4},
-	{"show-exports", no_argument, 0, 6},
+	{ "show-depends", no_argument, 0, 'D' },
+	{ "showconfig", no_argument, 0, 'c' },
+	{ "show-config", no_argument, 0, 'c' },
+	{ "show-modversions", no_argument, 0, 4 },
+	{ "dump-modversions", no_argument, 0, 4 },
+	{ "show-exports", no_argument, 0, 6 },
 
-	{"dry-run", no_argument, 0, 'n'},
-	{"show", no_argument, 0, 'n'},
+	{ "dry-run", no_argument, 0, 'n' },
+	{ "show", no_argument, 0, 'n' },
 
-	{"config", required_argument, 0, 'C'},
-	{"dirname", required_argument, 0, 'd'},
-	{"set-version", required_argument, 0, 'S'},
+	{ "config", required_argument, 0, 'C' },
+	{ "dirname", required_argument, 0, 'd' },
+	{ "set-version", required_argument, 0, 'S' },
 
-	{"syslog", no_argument, 0, 's'},
-	{"quiet", no_argument, 0, 'q'},
-	{"verbose", no_argument, 0, 'v'},
-	{"version", no_argument, 0, 'V'},
-	{"help", no_argument, 0, 'h'},
-	{NULL, 0, 0, 0},
+	{ "syslog", no_argument, 0, 's' },
+	{ "quiet", no_argument, 0, 'q' },
+	{ "verbose", no_argument, 0, 'v' },
+	{ "version", no_argument, 0, 'V' },
+	{ "help", no_argument, 0, 'h' },
+	{ NULL, 0, 0, 0 },
 };
 
 static void help(void)
 {
 	printf("Usage:\n"
-		"\t%s [options] [-i] [-b] modulename\n"
-		"\t%s [options] -a [-i] [-b] modulename [modulename...]\n"
-		"\t%s [options] -r [-i] modulename\n"
-		"\t%s [options] -r -a [-i] modulename [modulename...]\n"
-		"\t%s [options] -c\n"
-		"\t%s [options] --dump-modversions filename\n"
-		"Management Options:\n"
-		"\t-a, --all                   Consider every non-argument to\n"
-		"\t                            be a module name to be inserted\n"
-		"\t                            or removed (-r)\n"
-		"\t-r, --remove                Remove modules instead of inserting\n"
-		"\t    --remove-dependencies   Deprecated: use --remove-holders\n"
-		"\t    --remove-holders        Also remove module holders (use together with -r)\n"
-		"\t-w, --wait <MSEC>           When removing a module, wait up to MSEC for\n"
-		"\t                            module's refcount to become 0 so it can be\n"
-		"\t                            removed (use together with -r)\n"
-		"\t    --first-time            Fail if module already inserted or removed\n"
-		"\t-i, --ignore-install        Ignore install commands\n"
-		"\t-i, --ignore-remove         Ignore remove commands\n"
-		"\t-b, --use-blacklist         Apply blacklist to resolved alias.\n"
-		"\t-f, --force                 Force module insertion or removal.\n"
-		"\t                            implies --force-modversions and\n"
-		"\t                            --force-vermagic\n"
-		"\t    --force-modversion      Ignore module's version\n"
-		"\t    --force-vermagic        Ignore module's version magic\n"
-		"\n"
-		"Query Options:\n"
-		"\t-R, --resolve-alias         Only lookup and print alias and exit\n"
-		"\t-D, --show-depends          Only print module dependencies and exit\n"
-		"\t-c, --showconfig            Print out known configuration and exit\n"
-		"\t-c, --show-config           Same as --showconfig\n"
-		"\t    --show-modversions      Dump module symbol version and exit\n"
-		"\t    --dump-modversions      Same as --show-modversions\n"
-		"\t    --show-exports          Only print module exported symbol versions and exit\n"
-		"\n"
-		"General Options:\n"
-		"\t-n, --dry-run               Do not execute operations, just print out\n"
-		"\t-n, --show                  Same as --dry-run\n"
+	       "\t%s [options] [-i] [-b] modulename\n"
+	       "\t%s [options] -a [-i] [-b] modulename [modulename...]\n"
+	       "\t%s [options] -r [-i] modulename\n"
+	       "\t%s [options] -r -a [-i] modulename [modulename...]\n"
+	       "\t%s [options] -c\n"
+	       "\t%s [options] --dump-modversions filename\n"
+	       "Management Options:\n"
+	       "\t-a, --all                   Consider every non-argument to\n"
+	       "\t                            be a module name to be inserted\n"
+	       "\t                            or removed (-r)\n"
+	       "\t-r, --remove                Remove modules instead of inserting\n"
+	       "\t    --remove-dependencies   Deprecated: use --remove-holders\n"
+	       "\t    --remove-holders        Also remove module holders (use together with -r)\n"
+	       "\t-w, --wait <MSEC>           When removing a module, wait up to MSEC for\n"
+	       "\t                            module's refcount to become 0 so it can be\n"
+	       "\t                            removed (use together with -r)\n"
+	       "\t    --first-time            Fail if module already inserted or removed\n"
+	       "\t-i, --ignore-install        Ignore install commands\n"
+	       "\t-i, --ignore-remove         Ignore remove commands\n"
+	       "\t-b, --use-blacklist         Apply blacklist to resolved alias.\n"
+	       "\t-f, --force                 Force module insertion or removal.\n"
+	       "\t                            implies --force-modversions and\n"
+	       "\t                            --force-vermagic\n"
+	       "\t    --force-modversion      Ignore module's version\n"
+	       "\t    --force-vermagic        Ignore module's version magic\n"
+	       "\n"
+	       "Query Options:\n"
+	       "\t-R, --resolve-alias         Only lookup and print alias and exit\n"
+	       "\t-D, --show-depends          Only print module dependencies and exit\n"
+	       "\t-c, --showconfig            Print out known configuration and exit\n"
+	       "\t-c, --show-config           Same as --showconfig\n"
+	       "\t    --show-modversions      Dump module symbol version and exit\n"
+	       "\t    --dump-modversions      Same as --show-modversions\n"
+	       "\t    --show-exports          Only print module exported symbol versions and exit\n"
+	       "\n"
+	       "General Options:\n"
+	       "\t-n, --dry-run               Do not execute operations, just print out\n"
+	       "\t-n, --show                  Same as --dry-run\n"
 
-		"\t-C, --config=FILE           Use FILE instead of default search paths\n"
-		"\t-d, --dirname=DIR           Use DIR as filesystem root for " MODULE_DIRECTORY "\n"
-		"\t-S, --set-version=VERSION   Use VERSION instead of `uname -r`\n"
+	       "\t-C, --config=FILE           Use FILE instead of default search paths\n"
+	       "\t-d, --dirname=DIR           Use DIR as filesystem root for " MODULE_DIRECTORY
+	       "\n"
+	       "\t-S, --set-version=VERSION   Use VERSION instead of `uname -r`\n"
 
-		"\t-s, --syslog                print to syslog, not stderr\n"
-		"\t-q, --quiet                 disable messages\n"
-		"\t-v, --verbose               enables more messages\n"
-		"\t-V, --version               show version\n"
-		"\t-h, --help                  show this help\n",
-		program_invocation_short_name, program_invocation_short_name,
-		program_invocation_short_name, program_invocation_short_name,
-		program_invocation_short_name, program_invocation_short_name);
+	       "\t-s, --syslog                print to syslog, not stderr\n"
+	       "\t-q, --quiet                 disable messages\n"
+	       "\t-v, --verbose               enables more messages\n"
+	       "\t-V, --version               show version\n"
+	       "\t-h, --help                  show this help\n",
+	       program_invocation_short_name, program_invocation_short_name,
+	       program_invocation_short_name, program_invocation_short_name,
+	       program_invocation_short_name, program_invocation_short_name);
 }
 
-_printf_format_(1, 2)
-static inline void _show(const char *fmt, ...)
+_printf_format_(1, 2) static inline void _show(const char *fmt, ...)
 {
 	va_list args;
 
@@ -174,7 +174,7 @@ static int show_config(struct kmod_ctx *ctx)
 	};
 	size_t i;
 
-	for (i = 0;  i < ARRAY_SIZE(ci); i++) {
+	for (i = 0; i < ARRAY_SIZE(ci); i++) {
 		struct kmod_config_iter *iter = ci[i].get_iter(ctx);
 
 		if (iter == NULL)
@@ -183,8 +183,7 @@ static int show_config(struct kmod_ctx *ctx)
 		while (kmod_config_iter_next(iter)) {
 			const char *val;
 
-			printf("%s %s", ci[i].name,
-					kmod_config_iter_get_key(iter));
+			printf("%s %s", ci[i].name, kmod_config_iter_get_key(iter));
 			val = kmod_config_iter_get_value(iter);
 			if (val != NULL) {
 				putchar(' ');
@@ -217,8 +216,7 @@ static int show_modversions(struct kmod_ctx *ctx, const char *filename)
 
 	err = kmod_module_get_versions(mod, &list);
 	if (err < 0) {
-		LOG("could not get modversions of %s: %s\n",
-			filename, strerror(-err));
+		LOG("could not get modversions of %s: %s\n", filename, strerror(-err));
 		kmod_module_unref(mod);
 		return err;
 	}
@@ -226,7 +224,7 @@ static int show_modversions(struct kmod_ctx *ctx, const char *filename)
 	kmod_list_foreach(l, list) {
 		const char *symbol = kmod_module_version_get_symbol(l);
 		uint64_t crc = kmod_module_version_get_crc(l);
-		printf("0x%08"PRIx64"\t%s\n", crc, symbol);
+		printf("0x%08" PRIx64 "\t%s\n", crc, symbol);
 	}
 	kmod_module_versions_free_list(list);
 	kmod_module_unref(mod);
@@ -245,8 +243,7 @@ static int show_exports(struct kmod_ctx *ctx, const char *filename)
 
 	err = kmod_module_get_symbols(mod, &list);
 	if (err < 0) {
-		LOG("could not get symbols of %s: %s\n",
-			filename, strerror(-err));
+		LOG("could not get symbols of %s: %s\n", filename, strerror(-err));
 		kmod_module_unref(mod);
 		return err;
 	}
@@ -254,15 +251,15 @@ static int show_exports(struct kmod_ctx *ctx, const char *filename)
 	kmod_list_foreach(l, list) {
 		const char *symbol = kmod_module_symbol_get_symbol(l);
 		uint64_t crc = kmod_module_symbol_get_crc(l);
-		printf("0x%08"PRIx64"\t%s\n", crc, symbol);
+		printf("0x%08" PRIx64 "\t%s\n", crc, symbol);
 	}
 	kmod_module_symbols_free_list(list);
 	kmod_module_unref(mod);
 	return 0;
 }
 
-static int command_do(struct kmod_module *module, const char *type,
-				const char *command, const char *cmdline_opts)
+static int command_do(struct kmod_module *module, const char *type, const char *command,
+		      const char *cmdline_opts)
 {
 	const char *modname = kmod_module_get_name(module);
 	char *p, *cmd = NULL;
@@ -319,8 +316,7 @@ end:
 static int rmmod_do_remove_module(struct kmod_module *mod)
 {
 	const char *modname = kmod_module_get_name(mod);
-	unsigned long long interval_msec = 0, t0_msec = 0,
-		      tend_msec = 0;
+	unsigned long long interval_msec = 0, t0_msec = 0, tend_msec = 0;
 	int flags = 0, err;
 
 	SHOW("rmmod %s\n", modname);
@@ -352,7 +348,7 @@ static int rmmod_do_remove_module(struct kmod_module *mod)
 			}
 
 			until_msec = get_backoff_delta_msec(t0_msec, tend_msec,
-							  &interval_msec);
+							    &interval_msec);
 			err = sleep_until_msec(until_msec);
 
 			if (!t0_msec)
@@ -374,8 +370,8 @@ static int rmmod_do_remove_module(struct kmod_module *mod)
 	return err;
 }
 
-#define RMMOD_FLAG_REMOVE_HOLDERS	0x1
-#define RMMOD_FLAG_IGNORE_BUILTIN	0x2
+#define RMMOD_FLAG_REMOVE_HOLDERS 0x1
+#define RMMOD_FLAG_IGNORE_BUILTIN 0x2
 static int rmmod_do_module(struct kmod_module *mod, int flags);
 
 /* Remove modules in reverse order */
@@ -405,8 +401,8 @@ static int rmmod_do_module(struct kmod_module *mod, int flags)
 	if (!ignore_commands) {
 		err = kmod_module_get_softdeps(mod, &pre, &post);
 		if (err < 0) {
-			WRN("could not get softdeps of '%s': %s\n",
-						modname, strerror(-err));
+			WRN("could not get softdeps of '%s': %s\n", modname,
+			    strerror(-err));
 			return err;
 		}
 
@@ -535,14 +531,12 @@ static int rmmod_all(struct kmod_ctx *ctx, char **args, int nargs)
 	return err;
 }
 
-static void print_action(struct kmod_module *m, bool install,
-							const char *options)
+static void print_action(struct kmod_module *m, bool install, const char *options)
 {
 	const char *path;
 
 	if (install) {
-		printf("install %s %s\n", kmod_module_get_install_commands(m),
-								options);
+		printf("install %s %s\n", kmod_module_get_install_commands(m), options);
 		return;
 	}
 
@@ -559,12 +553,10 @@ static void print_action(struct kmod_module *m, bool install,
 		printf("insmod %s %s\n", kmod_module_get_path(m), options);
 }
 
-static int insmod_insert(struct kmod_module *mod, int flags,
-				const char *extra_options)
+static int insmod_insert(struct kmod_module *mod, int flags, const char *extra_options)
 {
 	int err = 0;
-	void (*show)(struct kmod_module *m, bool install,
-						const char *options) = NULL;
+	void (*show)(struct kmod_module *m, bool install, const char *options) = NULL;
 
 	if (do_show || verbose > DEFAULT_VERBOSE)
 		show = &print_action;
@@ -572,8 +564,8 @@ static int insmod_insert(struct kmod_module *mod, int flags,
 	if (lookup_only)
 		printf("%s\n", kmod_module_get_name(mod));
 	else
-		err = kmod_module_probe_insert_module(mod, flags,
-				extra_options, NULL, NULL, show);
+		err = kmod_module_probe_insert_module(mod, flags, extra_options, NULL,
+						      NULL, show);
 
 	if (err >= 0)
 		/* ignore flag return values such as a mod being blacklisted */
@@ -582,17 +574,16 @@ static int insmod_insert(struct kmod_module *mod, int flags,
 		switch (err) {
 		case -EEXIST:
 			ERR("could not insert '%s': Module already in kernel\n",
-						kmod_module_get_name(mod));
+			    kmod_module_get_name(mod));
 			break;
 		case -ENOENT:
 			ERR("could not insert '%s': Unknown symbol in module, "
-					"or unknown parameter (see dmesg)\n",
-					kmod_module_get_name(mod));
+			    "or unknown parameter (see dmesg)\n",
+			    kmod_module_get_name(mod));
 			break;
 		default:
-			ERR("could not insert '%s': %s\n",
-					kmod_module_get_name(mod),
-					strerror(-err));
+			ERR("could not insert '%s': %s\n", kmod_module_get_name(mod),
+			    strerror(-err));
 			break;
 		}
 	}
@@ -600,8 +591,7 @@ static int insmod_insert(struct kmod_module *mod, int flags,
 	return err;
 }
 
-static int insmod(struct kmod_ctx *ctx, const char *alias,
-						const char *extra_options)
+static int insmod(struct kmod_ctx *ctx, const char *alias, const char *extra_options)
 {
 	struct kmod_list *l, *list = NULL;
 	struct kmod_module *mod = NULL;
@@ -611,14 +601,14 @@ static int insmod(struct kmod_ctx *ctx, const char *alias,
 		err = kmod_module_new_from_path(ctx, alias, &mod);
 		if (err < 0) {
 			LOG("Failed to get module from path %s: %s\n", alias,
-				strerror(-err));
+			    strerror(-err));
 			return -ENOENT;
 		}
 	} else {
 		err = kmod_module_new_from_lookup(ctx, alias, &list);
 		if (list == NULL || err < 0) {
 			LOG("Module %s not found in directory %s\n", alias,
-				ctx ? kmod_get_dirname(ctx) : "(missing)");
+			    ctx ? kmod_get_dirname(ctx) : "(missing)");
 			return -ENOENT;
 		}
 	}
@@ -766,7 +756,7 @@ static char **prepend_options_from_env(int *p_argc, char **orig_argv)
 		return NULL;
 
 	new_argv[0] = orig_argv[0];
-	str = (char *) (new_argv + argc + space_count + 3);
+	str = (char *)(new_argv + argc + space_count + 3);
 	memcpy(str, env, envlen + 1);
 
 	str_end = str + envlen;
@@ -959,9 +949,7 @@ static int do_modprobe(int argc, char **orig_argv)
 	nargs = argc - optind;
 
 	if (!use_syslog &&
-	    (!stderr ||
-	     fileno(stderr) == -1 ||
-	     fstat(fileno(stderr), &stat_buf)))
+	    (!stderr || fileno(stderr) == -1 || fstat(fileno(stderr), &stat_buf)))
 		use_syslog = 1;
 
 	log_open(use_syslog);
@@ -988,10 +976,10 @@ static int do_modprobe(int argc, char **orig_argv)
 			kversion = u.release;
 		}
 		n = snprintf(dirname_buf, sizeof(dirname_buf),
-		             "%s" MODULE_DIRECTORY "/%s", root, kversion);
+			     "%s" MODULE_DIRECTORY "/%s", root, kversion);
 		if (n >= (int)sizeof(dirname_buf)) {
-			ERR("bad directory %s" MODULE_DIRECTORY
-			    "/%s: path too long\n", root, kversion);
+			ERR("bad directory %s" MODULE_DIRECTORY "/%s: path too long\n",
+			    root, kversion);
 			err = -1;
 			goto done;
 		}

--- a/tools/rmmod.c
+++ b/tools/rmmod.c
@@ -35,18 +35,19 @@ static const struct option cmdopts[] = {
 static void help(void)
 {
 	printf("Usage:\n"
-		"\t%s [options] modulename ...\n"
-		"Options:\n"
-		"\t-f, --force       DANGEROUS: forces a module unload and may\n"
-		"\t                  crash your machine\n"
-		"\t-s, --syslog      print to syslog, not stderr\n"
-		"\t-v, --verbose     enables more messages\n"
-		"\t-V, --version     show version\n"
-		"\t-h, --help        show this help\n",
-		program_invocation_short_name);
+	       "\t%s [options] modulename ...\n"
+	       "Options:\n"
+	       "\t-f, --force       DANGEROUS: forces a module unload and may\n"
+	       "\t                  crash your machine\n"
+	       "\t-s, --syslog      print to syslog, not stderr\n"
+	       "\t-v, --verbose     enables more messages\n"
+	       "\t-V, --version     show version\n"
+	       "\t-h, --help        show this help\n",
+	       program_invocation_short_name);
 }
 
-static int check_module_inuse(struct kmod_module *mod) {
+static int check_module_inuse(struct kmod_module *mod)
+{
 	struct kmod_list *holders;
 	int state, ret;
 
@@ -56,8 +57,7 @@ static int check_module_inuse(struct kmod_module *mod) {
 		ERR("Module %s is builtin.\n", kmod_module_get_name(mod));
 		return -ENOENT;
 	} else if (state < 0) {
-		ERR("Module %s is not currently loaded\n",
-				kmod_module_get_name(mod));
+		ERR("Module %s is not currently loaded\n", kmod_module_get_name(mod));
 		return -ENOENT;
 	}
 
@@ -154,8 +154,7 @@ static int do_rmmod(int argc, char *argv[])
 			err = kmod_module_new_from_name(ctx, arg, &mod);
 
 		if (err < 0) {
-			ERR("could not use module %s: %s\n", arg,
-			    strerror(-err));
+			ERR("could not use module %s: %s\n", arg, strerror(-err));
 			r = EXIT_FAILURE;
 			break;
 		}
@@ -167,8 +166,7 @@ static int do_rmmod(int argc, char *argv[])
 
 		err = kmod_module_remove_module(mod, flags);
 		if (err < 0) {
-			ERR("could not remove module %s: %s\n", arg,
-			    strerror(-err));
+			ERR("could not remove module %s: %s\n", arg, strerror(-err));
 			r++;
 		}
 next:

--- a/tools/static-nodes.c
+++ b/tools/static-nodes.c
@@ -41,24 +41,24 @@ static const struct static_nodes_format *static_nodes_formats[] = {
 
 static const char cmdopts_s[] = "o:f:h";
 static const struct option cmdopts[] = {
-	{ "output", required_argument, 0, 'o'},
-	{ "format", required_argument, 0, 'f'},
-	{ "help", no_argument, 0, 'h'},
-	{ },
+	{ "output", required_argument, 0, 'o' },
+	{ "format", required_argument, 0, 'f' },
+	{ "help", no_argument, 0, 'h' },
+	{},
 };
 
-static int write_human(FILE *out, char modname[], char devname[], char type, unsigned int maj, unsigned int min)
+static int write_human(FILE *out, char modname[], char devname[], char type,
+		       unsigned int maj, unsigned int min)
 {
 	int ret;
 
 	ret = fprintf(out,
-			"Module: %s\n"
-			"\tDevice node: /dev/%s\n"
-			"\t\tType: %s device\n"
-			"\t\tMajor: %u\n"
-			"\t\tMinor: %u\n",
-			modname, devname,
-			(type == 'c') ? "character" : "block", maj, min);
+		      "Module: %s\n"
+		      "\tDevice node: /dev/%s\n"
+		      "\t\tType: %s device\n"
+		      "\t\tMajor: %u\n"
+		      "\t\tMinor: %u\n",
+		      modname, devname, (type == 'c') ? "character" : "block", maj, min);
 	if (ret >= 0)
 		return EXIT_SUCCESS;
 	else
@@ -71,21 +71,21 @@ static const struct static_nodes_format static_nodes_format_human = {
 	.description = "(default) a human readable format. Do not parse.",
 };
 
-static int write_tmpfiles(FILE *out, char modname[], char devname[], char type, unsigned int maj, unsigned int min)
+static int write_tmpfiles(FILE *out, char modname[], char devname[], char type,
+			  unsigned int maj, unsigned int min)
 {
 	const char *dir;
 	int ret;
 
 	dir = strrchr(devname, '/');
 	if (dir) {
-		ret = fprintf(out, "d /dev/%.*s 0755 - - -\n",
-			      (int)(dir - devname), devname);
+		ret = fprintf(out, "d /dev/%.*s 0755 - - -\n", (int)(dir - devname),
+			      devname);
 		if (ret < 0)
 			return EXIT_FAILURE;
 	}
 
-	ret = fprintf(out, "%c! /dev/%s 0600 - - - %u:%u\n",
-		      type, devname, maj, min);
+	ret = fprintf(out, "%c! /dev/%s 0600 - - - %u:%u\n", type, devname, maj, min);
 	if (ret < 0)
 		return EXIT_FAILURE;
 
@@ -98,7 +98,8 @@ static const struct static_nodes_format static_nodes_format_tmpfiles = {
 	.description = "the tmpfiles.d(5) format used by systemd-tmpfiles.",
 };
 
-static int write_devname(FILE *out, char modname[], char devname[], char type, unsigned int maj, unsigned int min)
+static int write_devname(FILE *out, char modname[], char devname[], char type,
+			 unsigned int maj, unsigned int min)
 {
 	int ret;
 
@@ -130,7 +131,7 @@ static void help(void)
 	       "\t-h, --help           show this help\n"
 	       "\n"
 	       "Formats:\n",
-	 program_invocation_short_name);
+	       program_invocation_short_name);
 
 	for (i = 0; i < ARRAY_SIZE(static_nodes_formats); i++) {
 		if (static_nodes_formats[i]->description != NULL) {
@@ -172,8 +173,7 @@ static int do_static_nodes(int argc, char *argv[])
 			}
 
 			if (!valid) {
-				fprintf(stderr, "Unknown format: '%s'.\n",
-					optarg);
+				fprintf(stderr, "Unknown format: '%s'.\n", optarg);
 				help();
 				ret = EXIT_FAILURE;
 				goto finish;
@@ -186,8 +186,7 @@ static int do_static_nodes(int argc, char *argv[])
 			ret = EXIT_FAILURE;
 			goto finish;
 		default:
-			fprintf(stderr, "Unexpected commandline option '%c'.\n",
-				c);
+			fprintf(stderr, "Unexpected commandline option '%c'.\n", c);
 			help();
 			ret = EXIT_FAILURE;
 			goto finish;
@@ -200,9 +199,12 @@ static int do_static_nodes(int argc, char *argv[])
 		goto finish;
 	}
 
-	r = snprintf(modules, sizeof(modules), MODULE_DIRECTORY "/%s/modules.devname", kernel.release);
+	r = snprintf(modules, sizeof(modules), MODULE_DIRECTORY "/%s/modules.devname",
+		     kernel.release);
 	if (r >= (int)sizeof(modules)) {
-		fprintf(stderr, "Error: could not open " MODULE_DIRECTORY "/%s/modules.devname - path too long\n",
+		fprintf(stderr,
+			"Error: could not open " MODULE_DIRECTORY
+			"/%s/modules.devname - path too long\n",
 			kernel.release);
 		ret = EXIT_FAILURE;
 		goto finish;
@@ -210,11 +212,15 @@ static int do_static_nodes(int argc, char *argv[])
 	in = fopen(modules, "re");
 	if (in == NULL) {
 		if (errno == ENOENT) {
-			fprintf(stderr, "Warning: " MODULE_DIRECTORY "/%s/modules.devname not found - ignoring\n",
+			fprintf(stderr,
+				"Warning: " MODULE_DIRECTORY
+				"/%s/modules.devname not found - ignoring\n",
 				kernel.release);
 			ret = EXIT_SUCCESS;
 		} else {
-			fprintf(stderr, "Error: could not open " MODULE_DIRECTORY "/%s/modules.devname - %m\n",
+			fprintf(stderr,
+				"Error: could not open " MODULE_DIRECTORY
+				"/%s/modules.devname - %m\n",
 				kernel.release);
 			ret = EXIT_FAILURE;
 		}
@@ -223,7 +229,8 @@ static int do_static_nodes(int argc, char *argv[])
 
 	r = mkdir_parents(output, 0755);
 	if (r < 0) {
-		fprintf(stderr, "Error: could not create parent directory for %s - %m.\n", output);
+		fprintf(stderr, "Error: could not create parent directory for %s - %m.\n",
+			output);
 		ret = EXIT_FAILURE;
 		goto finish;
 	}
@@ -245,8 +252,8 @@ static int do_static_nodes(int argc, char *argv[])
 		if (buf[0] == '#')
 			continue;
 
-		matches = sscanf(buf, "%s %s %c%u:%u", modname, devname,
-				 &type, &maj, &min);
+		matches =
+			sscanf(buf, "%s %s %c%u:%u", modname, devname, &type, &maj, &min);
 		if (matches != 5 || (type != 'c' && type != 'b')) {
 			fprintf(stderr, "Error: invalid devname entry: %s", buf);
 			ret = EXIT_FAILURE;


### PR DESCRIPTION
This series builds on the initial work in https://github.com/kmod-project/kmod/pull/91

 - reformat and clang-format off various blocks of existing code
 - imports the .clang-format from the kernel and tweaks it
 - runs ^^ and commits the changes in 4 patches, one per top-level folder - do we want the mass conversion?
 - adds CI action which runs on PRs - do we want one for pushes as well?