### PR TITLE
meson: Stop rebuilding modules over and over

### DIFF
--- a/.github/actions/setup-alpine/action.yml
+++ b/.github/actions/setup-alpine/action.yml
@@ -18,6 +18,7 @@ runs:
           linux-edge-dev \
           meson \
           openssl-dev \
+          rsync \
           scdoc \
           tar \
           xz-dev \

--- a/.github/actions/setup-archlinux/action.yml
+++ b/.github/actions/setup-archlinux/action.yml
@@ -20,6 +20,7 @@ runs:
           multilib-devel \
           linux-headers \
           meson \
+          rsync \
           scdoc \
           git \
           gtk-doc

--- a/.github/actions/setup-debian/action.yml
+++ b/.github/actions/setup-debian/action.yml
@@ -20,6 +20,7 @@ runs:
           libzstd-dev \
           linux-headers-generic \
           meson \
+          rsync \
           scdoc \
           zlib1g-dev \
           zstd

--- a/.github/actions/setup-fedora/action.yml
+++ b/.github/actions/setup-fedora/action.yml
@@ -21,6 +21,7 @@ runs:
           git \
           gtk-doc \
           libtool \
+          rsync \
           scdoc
         # CI builds with KDIR pointing to /usr/lib/modules/*/build
         # so just a foo/build pointing to the right place, assuming

--- a/.github/actions/setup-ubuntu/action.yml
+++ b/.github/actions/setup-ubuntu/action.yml
@@ -20,6 +20,7 @@ runs:
           libzstd-dev \
           linux-headers-generic \
           meson \
+          rsync \
           scdoc \
           zlib1g-dev \
           zstd

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Compilation and installation
 In order to compile the source code you need the following software packages:
 	- GCC/CLANG compiler
 	- GNU C library / musl / uClibc
+	- rsync
+
 
 Optional dependencies:
 	- ZLIB library

--- a/scripts/setup-modules.sh
+++ b/scripts/setup-modules.sh
@@ -10,9 +10,7 @@ export MODULE_DIRECTORY=$4
 
 # TODO: meson allows only out of tree builds
 if test "$SRCDIR" != "$BUILDDIR"; then
-    rm -rf "$MODULE_PLAYGROUND"
-    mkdir -p "$(dirname "$MODULE_PLAYGROUND")"
-    cp -r "$SRCDIR/$MODULE_PLAYGROUND" "$MODULE_PLAYGROUND"
+    rsync --recursive --times "$SRCDIR/$MODULE_PLAYGROUND/" "$MODULE_PLAYGROUND/"
 fi
 
 export MAKEFLAGS=${MAKEFLAGS-"-j$(nproc)"}


### PR DESCRIPTION
Instead of removing the sources every time and rebuilding, just use rsync to preserve the timestamps and allow Make to do its job of rebuilding if it changed.

There's a bug in meson that keeps building the testsuite even outside of `ninja test`, but if the build result is cached, we can greatly minimize the impact for developers.

Closes: https://github.com/kmod-project/kmod/issues/119