### PR TITLE
libkmod: Remove fatal macro and NOFAIL usage

### DIFF
--- a/libkmod/libkmod-index.c
+++ b/libkmod/libkmod-index.c
@@ -237,7 +237,10 @@ static struct index_node_f *index_read(FILE *in, uint32_t offset)
 		}
 		prefix = strbuf_steal(&buf);
 	} else
-		prefix = NOFAIL(strdup(""));
+		prefix = strdup("");
+
+	if (prefix == NULL)
+		goto err;
 
 	if (offset & INDEX_NODE_CHILDS) {
 		int first = read_char(in);
@@ -248,8 +251,10 @@ static struct index_node_f *index_read(FILE *in, uint32_t offset)
 
 		child_count = last - first + 1;
 
-		node = NOFAIL(malloc(sizeof(struct index_node_f) +
-				     sizeof(uint32_t) * child_count));
+		node = malloc(sizeof(struct index_node_f) +
+			      sizeof(uint32_t) * child_count);
+		if (node == NULL)
+			goto err;
 
 		node->first = (unsigned char) first;
 		node->last = (unsigned char) last;
@@ -258,7 +263,10 @@ static struct index_node_f *index_read(FILE *in, uint32_t offset)
 			if (read_long(in, &node->children[i]) < 0)
 				goto err;
 	} else {
-		node = NOFAIL(malloc(sizeof(struct index_node_f)));
+		node = malloc(sizeof(struct index_node_f));
+		if (node == NULL)
+			goto err;
+
 		node->first = INDEX_CHILDMAX;
 		node->last = 0;
 	}
@@ -326,7 +334,10 @@ struct index_file *index_file_open(const char *filename)
 	    version >> 16 != INDEX_VERSION_MAJOR)
 		goto err;
 
-	new = NOFAIL(malloc(sizeof(struct index_file)));
+	new = malloc(sizeof(struct index_file));
+	if (new == NULL)
+		goto err;
+
 	new->file = file;
 	if (read_long(new->file, &new->root_offset) < 0)
 		goto err;

--- a/libkmod/libkmod-index.c
+++ b/libkmod/libkmod-index.c
@@ -166,12 +166,6 @@ static int add_value(struct index_value **values,
 	return 0;
 }
 
-static void read_error(void)
-{
-	fatal("Module index: unexpected error: %s\n"
-			"Try re-running depmod\n", errno ? strerror(errno) : "EOF");
-}
-
 static int read_char(FILE *in)
 {
 	int ch;
@@ -179,7 +173,7 @@ static int read_char(FILE *in)
 	errno = 0;
 	ch = getc_unlocked(in);
 	if (ch == EOF)
-		read_error();
+		errno = EINVAL;
 	return ch;
 }
 
@@ -189,7 +183,7 @@ static int read_long(FILE *in, uint32_t *l)
 
 	errno = 0;
 	if (fread(&val, sizeof(uint32_t), 1, in) != 1) {
-		read_error();
+		errno = EINVAL;
 		return -1;
 	}
 	*l = ntohl(val);

--- a/shared/macro.h
+++ b/shared/macro.h
@@ -41,7 +41,6 @@
 
 /* Temporaries for importing index handling */
 #define NOFAIL(x) (x)
-#define fatal(x...) do { } while (0)
 
 /* Attributes */
 


### PR DESCRIPTION
The macros `NOFAIL` and `fatal` have been introduced in late 2011 for import of index handling of module-init-tools, but haven't been implemented since then.

This means that memory allocations and file I/O wrapped with `NOFAIL` could still fail. Also the fatal message is never shown -- which is good, because the `read_long` function always fails an internal `fread` check but continues anyway.

Proof of Concept:

1. Create an illegal index file
```
MYBASE=$(mktemp -d)
mkdir -p $MYBASE/lib/modules/$(uname -r)
base64 -d <<< sAf0VwACAAGgAAYO > $MYBASE/lib/modules/$(uname -r)/modules.alias.bin
```

2. Run modprobe
```
modprobe -c -d $MYBASE
```

Because the EOF condition is never detected as error, the reading routines will use up all available memory.

Closes: #60