### PR TITLE
kmod: Avoid negative exit codes

### DIFF
--- a/tools/kmod.c
+++ b/tools/kmod.c
@@ -147,7 +147,7 @@ static int handle_kmod_compat_commands(int argc, char *argv[])
 			return kmod_compat_cmds[i]->cmd(argc, argv);
 	}
 
-	return -ENOENT;
+	return EXIT_FAILURE;
 }
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
Exit codes shall be non-negative to comply with standards.

How to reproduce:

```
ln -s $(which kmod) something
./something
echo $?
```

On my system, the exit code is `254`, which falsely indicates that some signal has been used to terminate the process.