### PR TITLE
build: Fix KDIR again

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -178,7 +178,7 @@ EXTRA_DIST += scripts/setup-modules.sh
 EXTRA_DIST += scripts/setup-rootfs.sh
 
 MODULE_PLAYGROUND = testsuite/module-playground
-BUILD_MODULES = $(AM_V_GEN) $(top_srcdir)/scripts/setup-modules.sh $(top_srcdir) $(top_builddir) $(MODULE_PLAYGROUND) $(module_directory)
+BUILD_MODULES = $(AM_V_GEN) $(top_srcdir)/scripts/setup-modules.sh $(top_srcdir) $(top_builddir) $(MODULE_PLAYGROUND)
 ROOTFS = testsuite/rootfs
 ROOTFS_PRISTINE = $(top_srcdir)/testsuite/rootfs-pristine
 CREATE_ROOTFS = $(AM_V_GEN) $(top_srcdir)/scripts/setup-rootfs.sh $(ROOTFS_PRISTINE) $(ROOTFS) $(MODULE_PLAYGROUND) $(top_builddir)/config.h $(sysconfdir) $(module_directory)

--- a/scripts/setup-modules.sh
+++ b/scripts/setup-modules.sh
@@ -5,8 +5,6 @@ set -euo pipefail
 SRCDIR=$1
 BUILDDIR=$2
 MODULE_PLAYGROUND=$3
-# shellcheck disable=SC2034 # used by the Makefile
-export MODULE_DIRECTORY=$4
 
 # TODO: meson allows only out of tree builds
 if test "$SRCDIR" != "$BUILDDIR"; then

--- a/testsuite/meson.build
+++ b/testsuite/meson.build
@@ -9,7 +9,6 @@ build_module_playground = custom_target(
     meson.project_source_root(),
     meson.project_build_root(),
     'testsuite/module-playground', # do not prepend source/build root
-    moduledir,
   ],
   output : 'bb-rootfs',
   console : true,

--- a/testsuite/module-playground/Makefile
+++ b/testsuite/module-playground/Makefile
@@ -1,4 +1,15 @@
-KDIR ?= $(MODULE_DIRECTORY)/$$(uname -r)/build
+# When KDIR is not manually set, use the MODULE_DIRECTORY for the pre-existent
+# kmod, not the one being built, to figure out how to get to the kernel
+# sources/headers for building our own dummy kernel modules.  The final
+# location of the modules may change later by scripts/setup-rootfs.sh that
+# assembles a per-test-rootfs.
+ifndef KDIR
+  MODULE_DIRECTORY := $(shell pkg-config --variable module_directory kmod)
+  ifeq ($(MODULE_DIRECTORY),)
+    MODULE_DIRECTORY := /lib/modules
+  endif
+  KDIR := $(MODULE_DIRECTORY)/$$(uname -r)/build
+endif
 
 ARCH_SPECIFIC_MODULES := mod-simple-x86_64.ko mod-simple-i386.ko mod-simple-sparc64.ko
 


### PR DESCRIPTION
KDIR is not related to the what we configure in kmod's build. It's only used in kmod to locate where the distro's kernel source/headers is, which may be different from what we are configuring the (under development) kmod with.

Remove the setting from meson/autotools and figure it out inside the module-playground Makefile what should be used. For advanced use cases, KDIR= can be passed to override the location.

For our own tests, which includes testing with a different module_directory, scripts/setup-rootfs.sh will copy the module to the desired location according to the map defined in the script.

Fixes: 27ff72732666 ("testsuite: correct the default KDIR")