### PR TITLE
libkmod: Fix OOB write with illegal index files

### DIFF
--- a/libkmod/libkmod-index.c
+++ b/libkmod/libkmod-index.c
@@ -247,7 +247,7 @@ static struct index_node_f *index_read(FILE *in, uint32_t offset)
 		int first = read_char(in);
 		int last = read_char(in);
 
-		if (first == EOF || last == EOF)
+		if (first == EOF || last == EOF || first > last)
 			goto err;
 
 		child_count = last - first + 1;
@@ -699,6 +699,10 @@ static struct index_mm_node *index_mm_read_node(struct index_mm *idx,
 	if (offset & INDEX_NODE_CHILDS) {
 		first = read_char_mm(&p);
 		last = read_char_mm(&p);
+
+		if (first > last)
+			return NULL;
+
 		child_count = last - first + 1;
 		for (i = 0; i < child_count; i++)
 			children[i] = read_u32_mm(&p);


### PR DESCRIPTION
If an index file with INDEX_NODE_CHILDS flag contains illegal first and last markers for children, it is possible to trigger an out of boundary write.

Make sure that first value is not larger than last value while reading index files.

Proof of Concept:

1. Compile kmod with ASAN (or be lucky for effects to be seen with regular builds)
2. Create an illegal index file
```
MYBASE=$(mktemp -d)
mkdir -p $MYBASE/lib/modules/$(uname -r)
base64 -d <<< sAf0VwACAAEgAAAMAwA= > $MYBASE/lib/modules/$(uname -r)/modules.alias.bin
```
3. Run modprobe
```
modprobe -c -d $MYBASE
```

With ASAN:
```
==58479==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x503000000328 at pc 0x55f03f25519a bp 0x7ffe61f39c70 sp 0x7ffe61f39c60
```

Without on my glibc system:
```
malloc(): invalid size (unsorted)
Aborted (core dumped)
```

This happens because the integer overflow effectively reduces the allocated size so much that even storing the information about first and last values will already write outside the allocated area.