### PR TITLE
Add depmod -M option to replace kmod.pc

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -121,7 +121,6 @@ libkmod_libkmod_internal_la_DEPENDENCIES  = $(libkmod_libkmod_la_DEPENDENCIES)
 libkmod_libkmod_internal_la_LIBADD = $(libkmod_libkmod_la_LIBADD)
 
 pkgconfig_DATA = libkmod/libkmod.pc
-noarch_pkgconfig_DATA = tools/kmod.pc
 
 bashcompletiondir=@bashcompletiondir@
 dist_bashcompletion_DATA = \

--- a/configure.ac
+++ b/configure.ac
@@ -312,7 +312,6 @@ AC_CONFIG_FILES([
 	libkmod/docs/Makefile
 	libkmod/docs/version.xml
 	libkmod/libkmod.pc
-	tools/kmod.pc
 ])
 
 

--- a/libkmod/libkmod.pc.in
+++ b/libkmod/libkmod.pc.in
@@ -2,6 +2,11 @@ prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
+sysconfdir=@sysconfdir@
+distconfdir=@distconfdir@
+module_directory=@module_directory@
+module_signatures=@module_signatures@
+module_compressions=@module_compressions@
 
 Name: libkmod
 Description: Library to deal with kernel modules

--- a/man/depmod.8.scd
+++ b/man/depmod.8.scd
@@ -12,6 +12,8 @@ depmod - Generate modules.dep and map files.
 *depmod* [*-e*] [*-E* _Module.symvers_] [*-F* _System.map_] [*-n*] [*-v*] [*-P* _prefix_]
 \ \ \ \ \ \ \ \[*-w*] [_version_] [_filename_...]
 
+*depmod* *-M*
+
 # DESCRIPTION
 
 Linux kernel modules can provide services (called "symbols") for other modules
@@ -79,6 +81,10 @@ rather than the current kernel version (as returned by *uname -r*).
 	This expects all input files under
 	_/tmp/build/kernel-modules/$(uname -r)_ and generates index files under
 	that same directory.
+
+*-M*
+*--moduledir-defualt*
+	Print the moduledir prefix @MODULE_DIRECTORY@ set at compile time.
 
 *-o* _outdir_
 *--outdir* _outdir_

--- a/meson.build
+++ b/meson.build
@@ -363,11 +363,25 @@ libkmod = shared_library(
   install : true,
 )
 
+_libkmod_variables = [
+  'sysconfdir=' + sysconfdir,
+  'distconfdir=' + distconfdir,
+  'module_directory=' + moduledir,
+  'module_signatures=' + module_signatures,
+]
+
+# XXX: Support for empty variables was added in meson v1.4.0.
+# pkgconf behaves identically on missing and empty variable.
+if module_compressions != ''
+  _libkmod_variables += ['module_compressions=' + module_compressions]
+endif
+
 pkg.generate(
   name : 'libkmod',
   description : 'Library to deal with kernel modules',
   libraries : libkmod,
   requires_private : libkmod_deps,
+  variables: _libkmod_variables
 )
 
 libkmod_internal = static_library(
@@ -401,17 +415,8 @@ kmod = executable(
 )
 
 _kmod_variables = [
-  'sysconfdir=' + sysconfdir,
-  'distconfdir=' + distconfdir,
   'module_directory=' + moduledir,
-  'module_signatures=' + module_signatures,
 ]
-
-# XXX: Support for empty variables was added in meson v1.4.0.
-# pkgconf behaves identically on missing and empty variable.
-if module_compressions != ''
-  _kmod_variables += ['module_compressions=' + module_compressions]
-endif
 
 pkg.generate(
   name : 'kmod',

--- a/meson.build
+++ b/meson.build
@@ -414,17 +414,6 @@ kmod = executable(
   install : get_option('tools'),
 )
 
-_kmod_variables = [
-  'module_directory=' + moduledir,
-]
-
-pkg.generate(
-  name : 'kmod',
-  description : 'Tools to deal with kernel modules',
-  install_dir : join_paths(get_option('datadir'), 'pkgconfig'),
-  variables : _kmod_variables,
-)
-
 _tools = [
   'depmod',
   'insmod',

--- a/tools/depmod.c
+++ b/tools/depmod.c
@@ -50,12 +50,13 @@ static const char *const default_cfg_paths[] = {
 	// clang-format on
 };
 
-static const char cmdopts_s[] = "aAb:m:o:C:E:F:evnP:wVh";
+static const char cmdopts_s[] = "aAb:m:Mo:C:E:F:evnP:wVh";
 static const struct option cmdopts[] = {
 	{ "all", no_argument, 0, 'a' },
 	{ "quick", no_argument, 0, 'A' },
 	{ "basedir", required_argument, 0, 'b' },
 	{ "moduledir", required_argument, 0, 'm' },
+	{ "moduledir-default", no_argument, 0, 'M' },
 	{ "outdir", required_argument, 0, 'o' },
 	{ "config", required_argument, 0, 'C' },
 	{ "symvers", required_argument, 0, 'E' },
@@ -96,6 +97,7 @@ static void help(void)
 	       "\t-b, --basedir=DIR    Root path (default: /).\n"
 	       "\t-m, --moduledir=DIR  Module directory (default: " MODULE_DIRECTORY
 	       ").\n"
+	       "\t-M, --moduledir-default  Print MODULE_DIRECTORY default value.\n"
 	       "\t-o, --outdir=DIR     Output root path (default: same as <basedir>).\n"
 	       "\t-F, --filesyms=FILE  Use the file instead of the\n"
 	       "\t                     current kernel symbols.\n"
@@ -2932,6 +2934,9 @@ static int do_depmod(int argc, char *argv[])
 		case 'm':
 			module_directory = optarg;
 			break;
+		case 'M':
+			puts(MODULE_DIRECTORY);
+			return EXIT_SUCCESS;
 		case 'o':
 			free(out_root);
 			out_root = path_make_absolute_cwd(optarg);

--- a/tools/kmod.pc.in
+++ b/tools/kmod.pc.in
@@ -1,5 +1,0 @@
-module_directory=@module_directory@
-
-Name: kmod
-Description: Tools to deal with kernel modules
-Version: @VERSION@

--- a/tools/kmod.pc.in
+++ b/tools/kmod.pc.in
@@ -1,9 +1,4 @@
-prefix=@prefix@
-sysconfdir=@sysconfdir@
-distconfdir=@distconfdir@
 module_directory=@module_directory@
-module_compressions=@module_compressions@
-module_signatures=@module_signatures@
 
 Name: kmod
 Description: Tools to deal with kernel modules


### PR DESCRIPTION
 Move ligkmod features from kmod.pc to libkmod.pc
    
    sysconfdir, distconfdir, module_compressions, and module_signatures are
    libkmod features, these should be in libkmod.pc, not kmod.pc.
    
    module_directory is special: While libkmod has a default for when the
    directory is not specified depmod does spefcify it, and has its own
    embetted value.
    
    Technically it's possible to have kmod and libkmod with mismatched
    values due to them being built separately. Also on a binary OS
    distribution the libkmod.pc would be installed only with libkmod
    development headers, not the tool.

depmod: Add -M parameter to print the value of MODULE_DIRECTORY
    
    This is the only value left in kmod.pc.
    
    It is an overkill to create a pkgconfig file for one value.
    
    Also this file was initially introduced, then moved to a different
    loaction because its purpose is misunderstood. Using it is awkward
    because the binary search path and pkgconfig path must be matched in
    case there is a possibility that multiple builds of kmod exist.
    
    As to why multiple build of kmod might exist on a system
    
     - custom test build
     - build of kbuild that matches some target system which has different
       settings for sysconfdit, distconfdir, or module_directory
     - per-architecture tools on 'multiarch' system that is set up for
       building binaries/boot images for arbitrary architectures
       - when these use a filesystem scheme in which per-architecture
         libraries and modules are stored in per-architecture directories
         Linux sticks out like a sore thumb with all modules in /lib
    
    While in the past it was fine to have One Kmod To Rule Them All because
    everything was hardcoded to a fixed value (and all compression methods
    and signature options could be built at the same time) this is no longer
    the case.
    
    Values for sysconfdir, distconfdir, and module_directory may differ
    between systems, and thus a build can be hosted on a system with one set
    of values but targeted for a system with different set of values.
    
    The -m option is provided to make it possible to override
    module_directory.
    
    However, for the modules to be installed in the correct location by
    kernel build the kernel build needs a way to determine the default value
    of module_directory, which this -M option provides.
    
    With a corresponding change to the Linux kbuild system installing
    modules should just work for both host with arbitrary module_directory
    and target for which correctly configured target-depmod is available and
    used during build.
    
    There is always the option to pass arbitrary value as argument to the -m
    option to build modules for a target system that uses different
    module_directory, or to move the installed modules after the fact.
    However, that requires somehow examining the target system out-of-band
    to determine the correct value, and hardcode such value in a build
    script. When working with multiple different targets regularly using a
    target-specific depmod is a way to manage the depmod build-time settings
    in a standardized way that works equally for other tools.
