### PR TITLE
docs: annotate when new API was introduced

### DIFF
--- a/libkmod/libkmod.h
+++ b/libkmod/libkmod.h
@@ -182,6 +182,8 @@ enum kmod_index {
  * order.
  *
  * Returns: 0 on success or < 0 otherwise.
+ *
+ * Since: 4
  */
 int kmod_dump_index(struct kmod_ctx *ctx, enum kmod_index type, int fd);
 
@@ -383,6 +385,8 @@ struct kmod_config_iter;
  *
  * Returns: a new iterator over the blacklists or NULL on failure. Free it
  * with kmod_config_iter_free_iter().
+ *
+ * Since: 4
  */
 struct kmod_config_iter *kmod_config_get_blacklists(const struct kmod_ctx *ctx);
 
@@ -397,6 +401,8 @@ struct kmod_config_iter *kmod_config_get_blacklists(const struct kmod_ctx *ctx);
  *
  * Returns: a new iterator over the install commands or NULL on failure. Free
  * it with kmod_config_iter_free_iter().
+ *
+ * Since: 4
  */
 struct kmod_config_iter *kmod_config_get_install_commands(const struct kmod_ctx *ctx);
 
@@ -411,6 +417,8 @@ struct kmod_config_iter *kmod_config_get_install_commands(const struct kmod_ctx 
  *
  * Returns: a new iterator over the remove commands or NULL on failure. Free
  * it with kmod_config_iter_free_iter().
+ *
+ * Since: 4
  */
 struct kmod_config_iter *kmod_config_get_remove_commands(const struct kmod_ctx *ctx);
 
@@ -425,6 +433,8 @@ struct kmod_config_iter *kmod_config_get_remove_commands(const struct kmod_ctx *
  *
  * Returns: a new iterator over the aliases or NULL on failure. Free it with
  * kmod_config_iter_free_iter().
+ *
+ * Since: 4
  */
 struct kmod_config_iter *kmod_config_get_aliases(const struct kmod_ctx *ctx);
 
@@ -439,6 +449,8 @@ struct kmod_config_iter *kmod_config_get_aliases(const struct kmod_ctx *ctx);
  *
  * Returns: a new iterator over the options or NULL on failure. Free it with
  * kmod_config_iter_free_iter().
+ *
+ * Since: 4
  */
 struct kmod_config_iter *kmod_config_get_options(const struct kmod_ctx *ctx);
 
@@ -453,6 +465,8 @@ struct kmod_config_iter *kmod_config_get_options(const struct kmod_ctx *ctx);
  *
  * Returns: a new iterator over the softdeps or NULL on failure. Free it with
  * kmod_config_iter_free_iter().
+ *
+ * Since: 4
  */
 struct kmod_config_iter *kmod_config_get_softdeps(const struct kmod_ctx *ctx);
 
@@ -479,6 +493,8 @@ struct kmod_config_iter *kmod_config_get_weakdeps(const struct kmod_ctx *ctx);
  * valid.
  *
  * Returns: the key of the current configuration pointed by @iter.
+ *
+ * Since: 4
  */
 const char *kmod_config_iter_get_key(const struct kmod_config_iter *iter);
 
@@ -491,6 +507,8 @@ const char *kmod_config_iter_get_key(const struct kmod_config_iter *iter);
  * valid.
  *
  * Returns: the value of the current configuration pointed by @iter.
+ *
+ * Since: 4
  */
 const char *kmod_config_iter_get_value(const struct kmod_config_iter *iter);
 
@@ -505,6 +523,8 @@ const char *kmod_config_iter_get_value(const struct kmod_config_iter *iter);
  *
  * Returns: true if next position of @iter is valid or false if its end is
  * reached.
+ *
+ * Since: 4
  */
 bool kmod_config_iter_next(struct kmod_config_iter *iter);
 
@@ -513,6 +533,8 @@ bool kmod_config_iter_next(struct kmod_config_iter *iter);
  * @iter: iterator over a certain configuration
  *
  * Free resources used by the iterator.
+ *
+ * Since: 4
  */
 void kmod_config_iter_free_iter(struct kmod_config_iter *iter);
 

--- a/libkmod/libkmod.h
+++ b/libkmod/libkmod.h
@@ -261,6 +261,8 @@ void *kmod_get_userdata(const struct kmod_ctx *ctx);
  *
  * Retrieve the absolute path used for linux modules in this context. The path
  * is computed from the arguments to kmod_new().
+ *
+ * Since: 22
  */
 const char *kmod_get_dirname(const struct kmod_ctx *ctx);
 

--- a/libkmod/libkmod.h
+++ b/libkmod/libkmod.h
@@ -312,6 +312,8 @@ struct kmod_list;
  * expected, and this is what differentiates from kmod_list_prev()).
  *
  * Returns: last node at @list or NULL if the list is empty.
+ *
+ * Since: 2
  */
 struct kmod_list *kmod_list_last(const struct kmod_list *list);
 
@@ -859,6 +861,8 @@ struct kmod_list *kmod_module_get_dependencies(const struct kmod_module *mod);
  * should be unreferenced with kmod_module_unref_list().
  *
  * Returns: 0 on success or < 0 otherwise.
+ *
+ * Since: 2
  */
 int kmod_module_get_softdeps(const struct kmod_module *mod,
 				struct kmod_list **pre, struct kmod_list **post);
@@ -1206,6 +1210,8 @@ void kmod_module_symbols_free_list(struct kmod_list *list);
  * After use, free the @list by calling kmod_module_versions_free_list().
  *
  * Returns: 0 on success or < 0 otherwise.
+ *
+ * Since: 2
  */
 int kmod_module_get_versions(const struct kmod_module *mod, struct kmod_list **list);
 
@@ -1216,6 +1222,8 @@ int kmod_module_get_versions(const struct kmod_module *mod, struct kmod_list **l
  * Get the crc of a kmod module version.
  *
  * Returns: the crc of this kmod module version if available, otherwise default to 0.
+ *
+ * Since: 2
  */
 uint64_t kmod_module_version_get_crc(const struct kmod_list *entry);
 
@@ -1227,6 +1235,8 @@ uint64_t kmod_module_version_get_crc(const struct kmod_list *entry);
  *
  * Returns: the symbol of this kmod module versions on success or NULL
  * on failure. The string is owned by the versions, do not free it.
+ *
+ * Since: 2
  */
 const char *kmod_module_version_get_symbol(const struct kmod_list *entry);
 
@@ -1235,6 +1245,8 @@ const char *kmod_module_version_get_symbol(const struct kmod_list *entry);
  * @list: kmod module versions list
  *
  * Release the resources taken by @list
+ *
+ * Since: 2
  */
 void kmod_module_versions_free_list(struct kmod_list *list);
 
@@ -1257,6 +1269,8 @@ void kmod_module_versions_free_list(struct kmod_list *list);
  * After use, free the @list by calling kmod_module_info_free_list().
  *
  * Returns: number of entries in @list on success or < 0 otherwise.
+ *
+ * Since: 2
  */
 int kmod_module_get_info(const struct kmod_module *mod, struct kmod_list **list);
 
@@ -1268,6 +1282,8 @@ int kmod_module_get_info(const struct kmod_module *mod, struct kmod_list **list)
  *
  * Returns: the key of this kmod module info on success or NULL on
  * failure. The string is owned by the info, do not free it.
+ *
+ * Since: 2
  */
 const char *kmod_module_info_get_key(const struct kmod_list *entry);
 
@@ -1279,6 +1295,8 @@ const char *kmod_module_info_get_key(const struct kmod_list *entry);
  *
  * Returns: the value of this kmod module info on success or NULL on
  * failure. The string is owned by the info, do not free it.
+ *
+ * Since: 2
  */
 const char *kmod_module_info_get_value(const struct kmod_list *entry);
 
@@ -1287,6 +1305,8 @@ const char *kmod_module_info_get_value(const struct kmod_list *entry);
  * @list: kmod module info list
  *
  * Release the resources taken by @list
+ *
+ * Since: 2
  */
 void kmod_module_info_free_list(struct kmod_list *list);
 

--- a/libkmod/libkmod.h
+++ b/libkmod/libkmod.h
@@ -611,6 +611,8 @@ int kmod_module_new_from_lookup(struct kmod_ctx *ctx, const char *given_alias,
  * Returns: 0 on success or < 0 otherwise. It fails if any of the lookup
  * methods failed, which is basically due to memory allocation failure. If
  * module is not found, it still returns 0, but @mod is left untouched.
+ *
+ * Since: 30
  */
 int kmod_module_new_from_name_lookup(struct kmod_ctx *ctx,
 				     const char *modname,

--- a/libkmod/libkmod.h
+++ b/libkmod/libkmod.h
@@ -52,6 +52,8 @@ struct kmod_ctx;
  * release the resources of the kmod library context.
  *
  * Returns: a new kmod library context
+ *
+ * Since: 1
  */
 struct kmod_ctx *kmod_new(const char *dirname, const char * const *config_paths);
 
@@ -62,6 +64,8 @@ struct kmod_ctx *kmod_new(const char *dirname, const char * const *config_paths)
  * Take a reference of the kmod library context.
  *
  * Returns: the passed kmod library context
+ *
+ * Since: 1
  */
 struct kmod_ctx *kmod_ref(struct kmod_ctx *ctx);
 
@@ -73,6 +77,8 @@ struct kmod_ctx *kmod_ref(struct kmod_ctx *ctx);
  * reaches zero, the resources of the context will be released.
  *
  * Returns: the passed kmod library context or NULL if it's freed
+ *
+ * Since: 1
  */
 struct kmod_ctx *kmod_unref(struct kmod_ctx *ctx);
 
@@ -91,6 +97,8 @@ struct kmod_ctx *kmod_unref(struct kmod_ctx *ctx);
  * this function will speedup the searches.
  *
  * Returns: 0 on success or < 0 otherwise.
+ *
+ * Since: 1
  */
 int kmod_load_resources(struct kmod_ctx *ctx);
 
@@ -108,6 +116,8 @@ int kmod_load_resources(struct kmod_ctx *ctx);
  * could free the resources by calling kmod_unload_resources().
  *
  * Returns: 0 on success or < 0 otherwise.
+ *
+ * Since: 1
  */
 void kmod_unload_resources(struct kmod_ctx *ctx);
 
@@ -181,6 +191,8 @@ int kmod_dump_index(struct kmod_ctx *ctx, enum kmod_index type, int fd);
  *
  * Set the current logging priority, as defined in syslog.h(0P). The value
  * controls which messages are logged.
+ *
+ * Since: 1
  */
 void kmod_set_log_priority(struct kmod_ctx *ctx, int priority);
 
@@ -191,6 +203,8 @@ void kmod_set_log_priority(struct kmod_ctx *ctx, int priority);
  * Get the current logging priority, as defined in syslog.h(0P).
  *
  * Returns: the current logging priority
+ *
+ * Since: 1
  */
 int kmod_get_log_priority(const struct kmod_ctx *ctx);
 
@@ -203,6 +217,8 @@ int kmod_get_log_priority(const struct kmod_ctx *ctx);
  * The built-in logging writes to stderr. It can be
  * overridden by a custom function, to plug log messages
  * into the user's logging functionality.
+ *
+ * Since: 1
  */
 void kmod_set_log_fn(struct kmod_ctx *ctx,
 			void (*log_fn)(void *log_data,
@@ -217,6 +233,8 @@ void kmod_set_log_fn(struct kmod_ctx *ctx,
  * @userdata: data pointer
  *
  * Store custom @userdata in the library context.
+ *
+ * Since: 1
  */
 void kmod_set_userdata(struct kmod_ctx *ctx, const void *userdata);
 
@@ -228,6 +246,8 @@ void kmod_set_userdata(struct kmod_ctx *ctx, const void *userdata);
  * to access from callbacks.
  *
  * Returns: stored userdata
+ *
+ * Since: 1
  */
 void *kmod_get_userdata(const struct kmod_ctx *ctx);
 
@@ -307,6 +327,8 @@ struct kmod_list *kmod_list_last(const struct kmod_list *list);
  *
  * Returns: node next to @curr or NULL if either this node is the last of or
  * list is empty.
+ *
+ * Since: 1
  */
 struct kmod_list *kmod_list_next(const struct kmod_list *list,
 						const struct kmod_list *curr);
@@ -323,6 +345,8 @@ struct kmod_list *kmod_list_next(const struct kmod_list *list,
  *
  * Returns: node previous to @curr or NULL if either this node is the head of
  * the list or the list is empty.
+ *
+ * Since: 1
  */
 struct kmod_list *kmod_list_prev(const struct kmod_list *list,
 						const struct kmod_list *curr);
@@ -530,6 +554,8 @@ struct kmod_module;
  * Returns: 0 on success or < 0 otherwise. It fails if any of the lookup
  * methods failed, which is basically due to memory allocation fail. If module
  * is not found, it still returns 0, but @list is an empty list.
+ *
+ * Since: 1
  */
 int kmod_module_new_from_lookup(struct kmod_ctx *ctx, const char *given_alias,
 						struct kmod_list **list);
@@ -583,6 +609,8 @@ int kmod_module_new_from_name_lookup(struct kmod_ctx *ctx,
  *
  * Returns: 0 on success or < 0 otherwise. It fails if name is not a valid
  * module name or if memory allocation failed.
+ *
+ * Since: 1
  */
 int kmod_module_new_from_name(struct kmod_ctx *ctx, const char *name,
 						struct kmod_module **mod);
@@ -607,6 +635,8 @@ int kmod_module_new_from_name(struct kmod_ctx *ctx, const char *name,
  *
  * Returns: 0 on success or < 0 otherwise. It fails if file does not exist, if
  * it's not a valid file for a kmod_module or if memory allocation failed.
+ *
+ * Since: 1
  */
 int kmod_module_new_from_path(struct kmod_ctx *ctx, const char *path,
 						struct kmod_module **mod);
@@ -619,6 +649,8 @@ int kmod_module_new_from_path(struct kmod_ctx *ctx, const char *path,
  * Take a reference of the kmod module, incrementing its refcount.
  *
  * Returns: the passed @module with its refcount incremented.
+ *
+ * Since: 1
  */
 struct kmod_module *kmod_module_ref(struct kmod_module *mod);
 
@@ -631,6 +663,8 @@ struct kmod_module *kmod_module_ref(struct kmod_module *mod);
  *
  * Returns: NULL if @mod is NULL or if the module was released. Otherwise it
  * returns the passed @mod with its refcount decremented.
+ *
+ * Since: 1
  */
 struct kmod_module *kmod_module_unref(struct kmod_module *mod);
 
@@ -642,6 +676,8 @@ struct kmod_module *kmod_module_unref(struct kmod_module *mod);
  * taken by the list itself.
  *
  * Returns: 0
+ *
+ * Since: 1
  */
 int kmod_module_unref_list(struct kmod_list *list);
 
@@ -670,6 +706,8 @@ enum kmod_insert {
  *
  * Returns: 0 on success or < 0 on failure. If module is already loaded it
  * returns -EEXIST.
+ *
+ * Since: 1
  */
 int kmod_module_insert_module(struct kmod_module *mod, unsigned int flags,
 							const char *options);
@@ -768,6 +806,8 @@ enum kmod_remove {
  * Remove a module from the kernel.
  *
  * Returns: 0 on success or < 0 on failure.
+ *
+ * Since: 1
  */
 int kmod_module_remove_module(struct kmod_module *mod, unsigned int flags);
 
@@ -783,6 +823,8 @@ int kmod_module_remove_module(struct kmod_module *mod, unsigned int flags);
  *
  * Returns: NULL on failure or the kmod_module contained in this list entry
  * with its refcount incremented.
+ *
+ * Since: 1
  */
 struct kmod_module *kmod_module_get_module(const struct kmod_list *entry);
 
@@ -796,6 +838,8 @@ struct kmod_module *kmod_module_get_module(const struct kmod_list *entry);
  *
  * Returns: NULL on failure. Otherwise it returns a list of kmod modules
  * that can be released by calling kmod_module_unref_list().
+ *
+ * Since: 1
  */
 struct kmod_list *kmod_module_get_dependencies(const struct kmod_module *mod);
 
@@ -881,6 +925,8 @@ int kmod_module_apply_filter(const struct kmod_ctx *ctx,
  *
  * Returns: 0 on success or < 0 otherwise. @output is saved with the updated
  * list.
+ *
+ * Since: 1
  */
 int kmod_module_get_filtered_blacklist(const struct kmod_ctx *ctx,
 					const struct kmod_list *input,
@@ -899,6 +945,8 @@ int kmod_module_get_filtered_blacklist(const struct kmod_ctx *ctx,
  *
  * Returns: a string with all install commands separated by semicolons. This
  * string is owned by @mod, do not free it.
+ *
+ * Since: 1
  */
 const char *kmod_module_get_install_commands(const struct kmod_module *mod);
 
@@ -915,6 +963,8 @@ const char *kmod_module_get_install_commands(const struct kmod_module *mod);
  *
  * Returns: a string with all remove commands separated by semicolons. This
  * string is owned by @mod, do not free it.
+ *
+ * Since: 1
  */
 const char *kmod_module_get_remove_commands(const struct kmod_module *mod);
 
@@ -927,6 +977,8 @@ const char *kmod_module_get_remove_commands(const struct kmod_module *mod);
  * it's always normalized (dashes are replaced with underscores).
  *
  * Returns: the name of this kmod module.
+ *
+ * Since: 1
  */
 const char *kmod_module_get_name(const struct kmod_module *mod);
 
@@ -940,6 +992,8 @@ const char *kmod_module_get_name(const struct kmod_module *mod);
  *
  * Returns: a string with all the options separated by spaces. This string is
  * owned by @mod, do not free it.
+ *
+ * Since: 1
  */
 const char *kmod_module_get_options(const struct kmod_module *mod);
 
@@ -953,6 +1007,8 @@ const char *kmod_module_get_options(const struct kmod_module *mod);
  *
  * Returns: the path of this kmod module or NULL if such information is not
  * available.
+ *
+ * Since: 1
  */
 const char *kmod_module_get_path(const struct kmod_module *mod);
 
@@ -1047,6 +1103,8 @@ void kmod_module_dependency_symbols_free_list(struct kmod_list *list);
  * After use, free the @list by calling kmod_module_section_free_list().
  *
  * Returns: a new list of kmod module sections on success or NULL on failure.
+ *
+ * Since: 1
  */
 struct kmod_list *kmod_module_get_sections(const struct kmod_module *mod);
 
@@ -1058,6 +1116,8 @@ struct kmod_list *kmod_module_get_sections(const struct kmod_module *mod);
  *
  * Returns: the address of this kmod module section on success or ULONG_MAX
  * on failure.
+ *
+ * Since: 1
  */
 unsigned long kmod_module_section_get_address(const struct kmod_list *entry);
 
@@ -1069,6 +1129,8 @@ unsigned long kmod_module_section_get_address(const struct kmod_list *entry);
  *
  * Returns: the name of this kmod module section on success or NULL on
  * failure. The string is owned by the section, do not free it.
+ *
+ * Since: 1
  */
 const char *kmod_module_section_get_name(const struct kmod_list *entry);
 
@@ -1077,6 +1139,8 @@ const char *kmod_module_section_get_name(const struct kmod_list *entry);
  * @list: kmod module section list
  *
  * Release the resources taken by @list
+ *
+ * Since: 1
  */
 void kmod_module_section_free_list(struct kmod_list *list);
 
@@ -1255,6 +1319,8 @@ void kmod_module_info_free_list(struct kmod_list *list);
  * completed.
  *
  * Returns: 0 on success or < 0 on error.
+ *
+ * Since: 1
  */
 int kmod_module_new_from_loaded(struct kmod_ctx *ctx,
 						struct kmod_list **list);
@@ -1287,6 +1353,8 @@ enum kmod_module_initstate {
  *
  * Returns: < 0 on error or module state if module is found in the kernel, valid
  * states are #kmod_module_initstate.
+ *
+ * Since: 1
  */
 int kmod_module_get_initstate(const struct kmod_module *mod);
 
@@ -1298,6 +1366,8 @@ int kmod_module_get_initstate(const struct kmod_module *mod);
  *
  * Returns: the string associated to the @state. This string is statically
  * allocated, do not free it.
+ *
+ * Since: 1
  */
 const char *kmod_module_initstate_str(enum kmod_module_initstate state);
 
@@ -1311,6 +1381,8 @@ const char *kmod_module_initstate_str(enum kmod_module_initstate state);
  * module to get its size.
  *
  * Returns: the size of this kmod module.
+ *
+ * Since: 1
  */
 long kmod_module_get_size(const struct kmod_module *mod);
 
@@ -1322,6 +1394,8 @@ long kmod_module_get_size(const struct kmod_module *mod);
  * /sys filesystem.
  *
  * Returns: the reference count on success or < 0 on failure.
+ *
+ * Since: 1
  */
 int kmod_module_get_refcnt(const struct kmod_module *mod);
 
@@ -1333,6 +1407,8 @@ int kmod_module_get_refcnt(const struct kmod_module *mod);
  * Kernel. After use, free the @list by calling kmod_module_unref_list().
  *
  * Returns: a new list of kmod modules on success or NULL on failure.
+ *
+ * Since: 1
  */
 struct kmod_list *kmod_module_get_holders(const struct kmod_module *mod);
 

--- a/libkmod/libkmod.h
+++ b/libkmod/libkmod.h
@@ -483,6 +483,8 @@ struct kmod_config_iter *kmod_config_get_softdeps(const struct kmod_ctx *ctx);
  *
  * Returns: a new iterator over the weakdeps or NULL on failure. Free it with
  * kmod_config_iter_free_iter().
+ *
+ * Since: 33
  */
 struct kmod_config_iter *kmod_config_get_weakdeps(const struct kmod_ctx *ctx);
 
@@ -912,6 +914,8 @@ int kmod_module_get_softdeps(const struct kmod_module *mod,
  * should be unreferenced with kmod_module_unref_list().
  *
  * Returns: 0 on success or < 0 otherwise.
+ *
+ * Since: 33
  */
 int kmod_module_get_weakdeps(const struct kmod_module *mod,
 				struct kmod_list **weak);

--- a/libkmod/libkmod.h
+++ b/libkmod/libkmod.h
@@ -146,6 +146,8 @@ enum kmod_resources {
  * context is not valid anymore.
  *
  * Returns: the resources state, valid states are #kmod_resources.
+ *
+ * Since: 3
  */
 int kmod_validate_resources(struct kmod_ctx *ctx);
 
@@ -774,6 +776,8 @@ enum kmod_probe {
  *
  * Returns: 0 on success, > 0 if stopped by a reason given in @flags or < 0 on
  * failure.
+ *
+ * Since: 3
  */
 int kmod_module_probe_insert_module(struct kmod_module *mod,
 			unsigned int flags, const char *extra_options,
@@ -1032,6 +1036,8 @@ const char *kmod_module_get_path(const struct kmod_module *mod);
  * kmod_module_dependency_symbols_free_list().
  *
  * Returns: 0 on success or < 0 otherwise.
+ *
+ * Since: 3
  */
 int kmod_module_get_dependency_symbols(const struct kmod_module *mod, struct kmod_list **list);
 
@@ -1061,6 +1067,8 @@ enum kmod_symbol_bind {
  *
  * Returns: the bind of this kmod module dependency_symbol on success,
  * or < 0 on failure. Valid bind types are #kmod_symbol_bind.
+ *
+ * Since: 3
  */
 int kmod_module_dependency_symbol_get_bind(const struct kmod_list *entry);
 
@@ -1071,6 +1079,8 @@ int kmod_module_dependency_symbol_get_bind(const struct kmod_list *entry);
  * Get the crc of a kmod module dependency_symbol.
  *
  * Returns: the crc of this kmod module dependency_symbol if available, otherwise default to 0.
+ *
+ * Since: 3
  */
 uint64_t kmod_module_dependency_symbol_get_crc(const struct kmod_list *entry);
 
@@ -1082,6 +1092,8 @@ uint64_t kmod_module_dependency_symbol_get_crc(const struct kmod_list *entry);
  *
  * Returns: the symbol of this kmod module dependency_symbols on success or NULL
  * on failure. The string is owned by the dependency_symbols, do not free it.
+ *
+ * Since: 3
  */
 const char *kmod_module_dependency_symbol_get_symbol(const struct kmod_list *entry);
 
@@ -1090,6 +1102,8 @@ const char *kmod_module_dependency_symbol_get_symbol(const struct kmod_list *ent
  * @list: kmod module dependency_symbols list
  *
  * Release the resources taken by @list
+ *
+ * Since: 3
  */
 void kmod_module_dependency_symbols_free_list(struct kmod_list *list);
 
@@ -1163,6 +1177,8 @@ void kmod_module_section_free_list(struct kmod_list *list);
  * After use, free the @list by calling kmod_module_symbols_free_list().
  *
  * Returns: 0 on success or < 0 otherwise.
+ *
+ * Since: 3
  */
 int kmod_module_get_symbols(const struct kmod_module *mod, struct kmod_list **list);
 
@@ -1173,6 +1189,8 @@ int kmod_module_get_symbols(const struct kmod_module *mod, struct kmod_list **li
  * Get the crc of a kmod module symbol.
  *
  * Returns: the crc of this kmod module symbol if available, otherwise default to 0.
+ *
+ * Since: 3
  */
 uint64_t kmod_module_symbol_get_crc(const struct kmod_list *entry);
 
@@ -1184,6 +1202,8 @@ uint64_t kmod_module_symbol_get_crc(const struct kmod_list *entry);
  *
  * Returns: the symbol of this kmod module symbols on success or NULL
  * on failure. The string is owned by the symbols, do not free it.
+ *
+ * Since: 3
  */
 const char *kmod_module_symbol_get_symbol(const struct kmod_list *entry);
 
@@ -1192,6 +1212,8 @@ const char *kmod_module_symbol_get_symbol(const struct kmod_list *entry);
  * @list: kmod module symbols list
  *
  * Release the resources taken by @list
+ *
+ * Since: 3
  */
 void kmod_module_symbols_free_list(struct kmod_list *list);
 

--- a/libkmod/libkmod.h
+++ b/libkmod/libkmod.h
@@ -936,6 +936,8 @@ enum kmod_filter {
  *
  * Returns: 0 on success or < 0 otherwise. @output is saved with the updated
  * list.
+ *
+ * Since: 6
  */
 int kmod_module_apply_filter(const struct kmod_ctx *ctx,
 					enum kmod_filter filter_type,

--- a/libkmod/libkmod.sym
+++ b/libkmod/libkmod.sym
@@ -1,3 +1,6 @@
+# With kmod v5 we bumped the DSO major and re-tagged all symbols.
+#
+# NOTE: Do not change the existing sections. Add new symbols to new sections.
 LIBKMOD_5 {
 global:
 	kmod_get_log_priority;


### PR DESCRIPTION
The alternative is going through release notes or inspecting the DSO exports list.

Closes: https://github.com/kmod-project/kmod/issues/98