### PR TITLE
man: add missing trailing slash in outdir example

### DIFF
--- a/man/depmod.8.scd
+++ b/man/depmod.8.scd
@@ -63,7 +63,7 @@ rather than the current kernel version (as returned by *uname -r*).
 		depmod -b /my/build/staging/dir/
 
 	This expects all input files under
-	_/my/build/staging/dir/@MODULE_DIRECTORY@/$(uname -r)_ and generates
+	_/my/build/staging/dir@MODULE_DIRECTORY@/$(uname -r)_ and generates
 	index files under that same directory.
 
 *-m* _moduledir_


### PR DESCRIPTION
Fixes: e2536ab ("man: Provide examples for paths")