### PR TITLE
depmod: Remove NOFAIL usage

### DIFF
--- a/tools/depmod.c
+++ b/tools/depmod.c
@@ -156,8 +156,16 @@ static struct index_node *index_create(void)
 {
 	struct index_node *node;
 
-	node = NOFAIL(calloc(1, sizeof(struct index_node)));
-	node->prefix = NOFAIL(strdup(""));
+	node = calloc(1, sizeof(struct index_node));
+	if (node == NULL)
+		return NULL;
+
+	node->prefix = strdup("");
+	if (node->prefix == NULL) {
+		free(node);
+		return NULL;
+	}
+
 	node->first = INDEX_CHILDMAX;
 
 	return node;

--- a/tools/depmod.c
+++ b/tools/depmod.c
@@ -1034,6 +1034,10 @@ static int depmod_module_add(struct depmod *depmod, struct kmod_module *kmod)
 	array_init(&mod->deps, 4);
 
 	mod->path = strdup(kmod_module_get_path(kmod));
+	if (mod->path == NULL) {
+		free(mod);
+		return -ENOMEM;
+	}
 	lastslash = strrchr(mod->path, '/');
 	mod->baselen = lastslash - mod->path;
 	if (strncmp(mod->path, cfg->dirname, cfg->dirnamelen) == 0 &&


### PR DESCRIPTION
Split off from https://github.com/kmod-project/kmod/pull/123

Removes the unimplemented NOFAIL macro from depmod and adds another strdup NULL check.