### PR TITLE
Remove LD_PRELOAD wrappers, properly guard the rest

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,6 +40,7 @@ AC_PROG_CC_C99
 #####################################################################
 
 AC_CHECK_FUNCS_ONCE(__xstat)
+AC_CHECK_FUNCS_ONCE([open64 stat64 fopen64])
 AC_CHECK_FUNCS_ONCE([__secure_getenv secure_getenv])
 
 CC_CHECK_FUNC_BUILTIN([__builtin_clz])

--- a/configure.ac
+++ b/configure.ac
@@ -40,7 +40,7 @@ AC_PROG_CC_C99
 #####################################################################
 
 AC_CHECK_FUNCS_ONCE(__xstat)
-AC_CHECK_FUNCS_ONCE([open64 stat64 fopen64])
+AC_CHECK_FUNCS_ONCE([open64 stat64 fopen64 __stat64_time64])
 AC_CHECK_FUNCS_ONCE([__secure_getenv secure_getenv])
 
 CC_CHECK_FUNC_BUILTIN([__builtin_clz])

--- a/configure.ac
+++ b/configure.ac
@@ -40,7 +40,7 @@ AC_PROG_CC_C99
 #####################################################################
 
 AC_CHECK_FUNCS_ONCE([open64 stat64 fopen64 __stat64_time64])
-AC_CHECK_FUNCS_ONCE([__secure_getenv secure_getenv])
+AC_CHECK_FUNCS_ONCE([secure_getenv])
 
 CC_CHECK_FUNC_BUILTIN([__builtin_clz])
 CC_CHECK_FUNC_BUILTIN([__builtin_types_compatible_p])

--- a/configure.ac
+++ b/configure.ac
@@ -39,7 +39,6 @@ AC_PROG_CC_C99
 # Function and structure checks
 #####################################################################
 
-AC_CHECK_FUNCS_ONCE(__xstat)
 AC_CHECK_FUNCS_ONCE([open64 stat64 fopen64 __stat64_time64])
 AC_CHECK_FUNCS_ONCE([__secure_getenv secure_getenv])
 
@@ -48,16 +47,13 @@ CC_CHECK_FUNC_BUILTIN([__builtin_types_compatible_p])
 CC_CHECK_FUNC_BUILTIN([__builtin_uaddl_overflow], [ ], [ ])
 CC_CHECK_FUNC_BUILTIN([__builtin_uaddll_overflow], [ ], [ ])
 
-# Non glibc compilers (musl and newer versions of bionic) do not need
-# the 64 LFS API wrapping.
-AC_CHECK_DECLS_ONCE([[__GLIBC__]], [], [], [[#include <features.h>]])
-
 # dietlibc doesn't have st.st_mtim struct member
 AC_CHECK_MEMBERS([struct stat.st_mtim], [], [], [#include <sys/stat.h>])
 
 # basename may be only available in libgen.h with the POSIX behavior,
 # not desired here
 AC_CHECK_DECLS_ONCE([[basename]], [], [], [[#include <string.h>]])
+AC_CHECK_DECLS_ONCE([[__xstat]], [], [], [[#include <sys/stat.h]])
 
 AC_MSG_CHECKING([whether _Static_assert() is supported])
 AC_COMPILE_IFELSE(

--- a/meson.build
+++ b/meson.build
@@ -35,7 +35,7 @@ cdata.set10('_GNU_SOURCE', true)
 
 _funcs = [
   '__xstat',
-  'open64', 'stat64', 'fopen64',
+  'open64', 'stat64', 'fopen64', '__stat64_time64',
   '__secure_getenv', 'secure_getenv',
 ]
 foreach func : _funcs

--- a/meson.build
+++ b/meson.build
@@ -87,12 +87,12 @@ endforeach
 # basename may be only available in libgen.h with the POSIX behavior,
 # not desired here
 _decls = [
-  ['basename', '#include <string.h>'],
+  ['basename', 'string.h'],
 ]
 foreach tuple : _decls
   decl = tuple[0]
-  prefix = tuple[1]
-  have = cc.has_function(decl, prefix : prefix, args : '-D_GNU_SOURCE')
+  header = tuple[1]
+  glibc = cc.has_header_symbol(header, decl, args : '-D_GNU_SOURCE')
   cdata.set10('HAVE_DECL_@0@'.format(decl.to_upper()), have)
 endforeach
 

--- a/meson.build
+++ b/meson.build
@@ -34,7 +34,6 @@ cdata.set10('_GNU_SOURCE', true)
 ################################################################################
 
 _funcs = [
-  '__xstat',
   'open64', 'stat64', 'fopen64', '__stat64_time64',
   '__secure_getenv', 'secure_getenv',
 ]
@@ -88,11 +87,12 @@ endforeach
 # not desired here
 _decls = [
   ['basename', 'string.h'],
+  ['__xstat', 'sys/stat.h'],
 ]
 foreach tuple : _decls
   decl = tuple[0]
   header = tuple[1]
-  glibc = cc.has_header_symbol(header, decl, args : '-D_GNU_SOURCE')
+  have  = cc.has_header_symbol(header, decl, args : '-D_GNU_SOURCE')
   cdata.set10('HAVE_DECL_@0@'.format(decl.to_upper()), have)
 endforeach
 

--- a/meson.build
+++ b/meson.build
@@ -35,7 +35,7 @@ cdata.set10('_GNU_SOURCE', true)
 
 _funcs = [
   'open64', 'stat64', 'fopen64', '__stat64_time64',
-  '__secure_getenv', 'secure_getenv',
+  'secure_getenv',
 ]
 foreach func : _funcs
   if cc.has_function(func, args : '-D_GNU_SOURCE')

--- a/meson.build
+++ b/meson.build
@@ -33,9 +33,14 @@ cdata.set10('_GNU_SOURCE', true)
 # Function and structure checks
 ################################################################################
 
-foreach decl : ['__xstat', '__secure_getenv', 'secure_getenv']
-  if cc.has_function(decl, args : '-D_GNU_SOURCE')
-    cdata.set('HAVE_@0@'.format(decl.to_upper()), true)
+_funcs = [
+  '__xstat',
+  'open64', 'stat64', 'fopen64',
+  '__secure_getenv', 'secure_getenv',
+]
+foreach func : _funcs
+  if cc.has_function(func, args : '-D_GNU_SOURCE')
+    cdata.set('HAVE_@0@'.format(func.to_upper()), true)
   endif
 endforeach
 

--- a/testsuite/path.c
+++ b/testsuite/path.c
@@ -187,29 +187,23 @@ WRAP_2ARGS(FILE*, NULL, fopen, const char*);
 WRAP_2ARGS(int, -1, mkdir, mode_t);
 WRAP_2ARGS(int, -1, access, int);
 WRAP_2ARGS(int, -1, stat, struct stat*);
-WRAP_2ARGS(int, -1, lstat, struct stat*);
 
 WRAP_OPEN();
 
 #if HAVE_DECL___GLIBC__
 WRAP_2ARGS(FILE*, NULL, fopen64, const char*);
 WRAP_2ARGS(int, -1, stat64, struct stat64*);
-WRAP_2ARGS(int, -1, lstat64, struct stat64*);
 
 struct __stat64_t64;
 extern int __stat64_time64 (const char *file, struct __stat64_t64 *buf);
-extern int __lstat64_time64 (const char *file, struct __stat64_t64 *buf);
 WRAP_2ARGS(int, -1, __stat64_time64, struct __stat64_t64*);
-WRAP_2ARGS(int, -1, __lstat64_time64, struct __stat64_t64*);
 
 WRAP_OPEN(64);
 #endif
 
 #ifdef HAVE___XSTAT
 WRAP_VERSTAT(__x,);
-WRAP_VERSTAT(__lx,);
 #if HAVE_DECL___GLIBC__
 WRAP_VERSTAT(__x,64);
-WRAP_VERSTAT(__lx,64);
 #endif
 #endif

--- a/testsuite/path.c
+++ b/testsuite/path.c
@@ -152,15 +152,7 @@ TS_EXPORT int open ## suffix (const char *path, int flags, ...)	\
 	return _fn(p, flags);					\
 }
 
-/*
- * wrapper template for __xstat family
- * This family got deprecated/dropped in glibc 2.32.9000, but we still need
- * to keep it for a while for programs that were built against previous versions
- */
 #define WRAP_VERSTAT(prefix, suffix)			    \
-TS_EXPORT int prefix ## stat ## suffix (int ver,	    \
-			      const char *path,		    \
-	                      struct stat ## suffix *st);   \
 TS_EXPORT int prefix ## stat ## suffix (int ver,	    \
 			      const char *path,		    \
 	                      struct stat ## suffix *st)    \
@@ -205,9 +197,7 @@ WRAP_2ARGS(int, -1, __stat64_time64, void *);
 WRAP_OPEN(64);
 #endif
 
-#ifdef HAVE___XSTAT
+#if HAVE_DECL___XSTAT
 WRAP_VERSTAT(__x,);
-#if HAVE_DECL___GLIBC__
 WRAP_VERSTAT(__x,64);
-#endif
 #endif

--- a/testsuite/path.c
+++ b/testsuite/path.c
@@ -196,7 +196,7 @@ WRAP_2ARGS(FILE*, NULL, fopen64, const char*);
 WRAP_2ARGS(int, -1, stat64, struct stat64*);
 #endif
 
-#if HAVE_DECL___GLIBC__
+#ifdef HAVE___STAT64_TIME64
 extern int __stat64_time64 (const char *file, void *buf);
 WRAP_2ARGS(int, -1, __stat64_time64, void *);
 #endif

--- a/testsuite/path.c
+++ b/testsuite/path.c
@@ -197,9 +197,8 @@ WRAP_2ARGS(int, -1, stat64, struct stat64*);
 #endif
 
 #if HAVE_DECL___GLIBC__
-struct __stat64_t64;
-extern int __stat64_time64 (const char *file, struct __stat64_t64 *buf);
-WRAP_2ARGS(int, -1, __stat64_time64, struct __stat64_t64*);
+extern int __stat64_time64 (const char *file, void *buf);
+WRAP_2ARGS(int, -1, __stat64_time64, void *);
 #endif
 
 #ifdef HAVE_OPEN64

--- a/testsuite/path.c
+++ b/testsuite/path.c
@@ -189,14 +189,20 @@ WRAP_2ARGS(int, -1, stat, struct stat*);
 
 WRAP_OPEN();
 
-#if HAVE_DECL___GLIBC__
+#ifdef HAVE_FOPEN64
 WRAP_2ARGS(FILE*, NULL, fopen64, const char*);
+#endif
+#ifdef HAVE_STAT64
 WRAP_2ARGS(int, -1, stat64, struct stat64*);
+#endif
 
+#if HAVE_DECL___GLIBC__
 struct __stat64_t64;
 extern int __stat64_time64 (const char *file, struct __stat64_t64 *buf);
 WRAP_2ARGS(int, -1, __stat64_time64, struct __stat64_t64*);
+#endif
 
+#ifdef HAVE_OPEN64
 WRAP_OPEN(64);
 #endif
 

--- a/testsuite/path.c
+++ b/testsuite/path.c
@@ -185,7 +185,6 @@ WRAP_1ARG(int, -1, chdir);
 
 WRAP_2ARGS(FILE*, NULL, fopen, const char*);
 WRAP_2ARGS(int, -1, mkdir, mode_t);
-WRAP_2ARGS(int, -1, access, int);
 WRAP_2ARGS(int, -1, stat, struct stat*);
 
 WRAP_OPEN();

--- a/testsuite/test-testsuite.c
+++ b/testsuite/test-testsuite.c
@@ -105,14 +105,9 @@ DEFINE_TEST(testsuite_rootfs_open,
 	},
 	.need_spawn = true);
 
-static int testsuite_rootfs_stat_access(const struct test *t)
+static int testsuite_rootfs_stat(const struct test *t)
 {
 	struct stat st;
-
-	if (access(MODULE_DIRECTORY "/a", F_OK) < 0) {
-		ERR("access failed: %m\n");
-		return EXIT_FAILURE;
-	}
 
 	if (stat(MODULE_DIRECTORY "/a", &st) < 0) {
 		ERR("stat failed: %m\n");
@@ -121,8 +116,8 @@ static int testsuite_rootfs_stat_access(const struct test *t)
 
 	return EXIT_SUCCESS;
 }
-DEFINE_TEST(testsuite_rootfs_stat_access,
-	.description = "test if rootfs works - stat() and access()",
+DEFINE_TEST(testsuite_rootfs_stat,
+	.description = "test if rootfs works - stat()",
 	.config = {
 		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-rootfs/",
 	},


### PR DESCRIPTION
Namely: *lstat* and access - neither of which was ever used by kmod/libkmod. The latter was used solely in one sub-test - access_and_stat - where stat alone is sufficient.

In addition, we have proper checks in the build systems for the other symbols (effectively removing the `__GLIBC__` hack). See the individual commits for details.

Mind you: commit messages might be a bit much, so any specific suggestions are greatly appreciated.

Edit: add the post removal bits