### PR TITLE
{ls,ins,rm}mod: update help, man and {bash,fish,zsh} shell completion

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -126,15 +126,18 @@ noarch_pkgconfig_DATA = tools/kmod.pc
 bashcompletiondir=@bashcompletiondir@
 dist_bashcompletion_DATA = \
 	shell-completion/bash/kmod \
-	shell-completion/bash/lsmod
+	shell-completion/bash/lsmod \
+	shell-completion/bash/rmmod
 
 fishcompletiondir=@fishcompletiondir@
 dist_fishcompletion_DATA = \
-	shell-completion/fish/lsmod.fish
+	shell-completion/fish/lsmod.fish \
+	shell-completion/fish/rmmod.fish
 
 zshcompletiondir=@zshcompletiondir@
 dist_zshcompletion_DATA = \
-	shell-completion/zsh/_lsmod
+	shell-completion/zsh/_lsmod \
+	shell-completion/zsh/_rmmod
 
 install-exec-hook:
 if BUILD_TOOLS

--- a/Makefile.am
+++ b/Makefile.am
@@ -125,17 +125,20 @@ noarch_pkgconfig_DATA = tools/kmod.pc
 
 bashcompletiondir=@bashcompletiondir@
 dist_bashcompletion_DATA = \
+	shell-completion/bash/insmod \
 	shell-completion/bash/kmod \
 	shell-completion/bash/lsmod \
 	shell-completion/bash/rmmod
 
 fishcompletiondir=@fishcompletiondir@
 dist_fishcompletion_DATA = \
+	shell-completion/fish/insmod.fish \
 	shell-completion/fish/lsmod.fish \
 	shell-completion/fish/rmmod.fish
 
 zshcompletiondir=@zshcompletiondir@
 dist_zshcompletion_DATA = \
+	shell-completion/zsh/_insmod \
 	shell-completion/zsh/_lsmod \
 	shell-completion/zsh/_rmmod
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -125,7 +125,16 @@ noarch_pkgconfig_DATA = tools/kmod.pc
 
 bashcompletiondir=@bashcompletiondir@
 dist_bashcompletion_DATA = \
-	shell-completion/bash/kmod
+	shell-completion/bash/kmod \
+	shell-completion/bash/lsmod
+
+fishcompletiondir=@fishcompletiondir@
+dist_fishcompletion_DATA = \
+	shell-completion/fish/lsmod.fish
+
+zshcompletiondir=@zshcompletiondir@
+dist_zshcompletion_DATA = \
+	shell-completion/zsh/_lsmod
 
 install-exec-hook:
 if BUILD_TOOLS
@@ -338,7 +347,9 @@ EXTRA_DIST += testsuite/rootfs-pristine
 
 AM_DISTCHECK_CONFIGURE_FLAGS=--enable-gtk-doc --sysconfdir=/etc \
 	--with-zlib --with-zstd --with-xz --with-openssl \
-	--with-bashcompletiondir=$$dc_install_base/$(bashcompletiondir)
+	--with-bashcompletiondir=$$dc_install_base/$(bashcompletiondir) \
+	--with-fishcompletiondir=$$dc_install_base/$(fishcompletiondir) \
+	--with-zshcompletiondir=$$dc_install_base/$(zshcompletiondir)
 
 distclean-local: $(DISTCLEAN_LOCAL_HOOKS)
 

--- a/configure.ac
+++ b/configure.ac
@@ -163,6 +163,22 @@ AC_ARG_WITH([bashcompletiondir],
 	])])
 AC_SUBST([bashcompletiondir], [$with_bashcompletiondir])
 
+AC_ARG_WITH([fishcompletiondir],
+	AS_HELP_STRING([--with-fishcompletiondir=DIR], [Fish completions directory]),
+	[],
+	[AS_IF([$($PKG_CONFIG --exists fish)], [
+		with_fishcompletiondir=$($PKG_CONFIG --variable=completionsdir fish)
+	] , [
+		with_fishcompletiondir=${datadir}/fish/vendor_functions.d
+	])])
+AC_SUBST([fishcompletiondir], [$with_fishcompletiondir])
+
+AC_ARG_WITH([zshcompletiondir],
+	AS_HELP_STRING([--with-zshcompletiondir=DIR], [Zsh completions directory]),
+	[],
+	[with_zshcompletiondir=${datadir}/zsh/site-functions])
+AC_SUBST([zshcompletiondir], [$with_zshcompletiondir])
+
 #####################################################################
 # --enable-
 #####################################################################

--- a/meson.build
+++ b/meson.build
@@ -216,6 +216,7 @@ foreach tuple : _completiondirs
 
   _completions = [
     'lsmod',
+    'rmmod',
   ]
 
   if completiondir != 'no'

--- a/meson.build
+++ b/meson.build
@@ -215,6 +215,7 @@ foreach tuple : _completiondirs
   endif
 
   _completions = [
+    'insmod',
     'lsmod',
     'rmmod',
   ]

--- a/meson.build
+++ b/meson.build
@@ -191,16 +191,45 @@ if moduledir == ''
 endif
 cdata.set_quoted('MODULE_DIRECTORY', moduledir)
 
-bashcompletiondir = get_option('bashcompletiondir')
-if bashcompletiondir == ''
-  bashcompletion = dependency('bash-completion', required : false)
-  if bashcompletion.found()
-    bashcompletiondir = bashcompletion.get_variable(pkgconfig : 'completionsdir')
-  else
-    bashcompletiondir = join_paths(get_option('prefix'), get_option('datadir'),
-                                   'bash-completion/completions')
+_completiondirs = [
+  ['bashcompletiondir', 'bash-completion', 'bash-completion/completions', 'shell-completion/bash/@0@'],
+  ['fishcompletiondir', 'fish',            'fish/vendor_functions.d',     'shell-completion/fish/@0@.fish'],
+  ['zshcompletiondir',  '',                'zsh/site-functions',          'shell-completion/zsh/_@0@'],
+]
+
+foreach tuple : _completiondirs
+  dir_option = tuple[0]
+  pkg_dep = tuple[1]
+  def_path = tuple[2]
+  ins_path = tuple[3]
+
+  completiondir = get_option(dir_option)
+  if completiondir == ''
+    completion = dependency(pkg_dep, required : false)
+    if completion.found()
+      completiondir = completion.get_variable(pkgconfig : 'completionsdir')
+    else
+      completiondir = join_paths(get_option('prefix'), get_option('datadir'),
+                                 def_path)
+    endif
   endif
-endif
+
+  _completions = [
+    'lsmod',
+  ]
+
+  if completiondir != 'no'
+    foreach comp : _completions
+      install_data(
+        files(ins_path.format(comp)),
+        install_dir : completiondir,
+      )
+    endforeach
+  endif
+
+  # NEEDED solely for bash/kmod below
+  set_variable(dir_option, completiondir)
+endforeach
 
 if bashcompletiondir != 'no'
   install_data(

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -18,6 +18,18 @@ option(
   description : 'Bash completions directory. Use "no" to disable.',
 )
 
+option(
+  'fishcompletiondir',
+  type : 'string',
+  description : 'Fish completions directory. Use "no" to disable.',
+)
+
+option(
+  'zshcompletiondir',
+  type : 'string',
+  description : 'Zsh completions directory. Use "no" to disable.',
+)
+
 # Compression options
 option(
   'zstd',

--- a/shell-completion/bash/insmod
+++ b/shell-completion/bash/insmod
@@ -1,0 +1,35 @@
+# insmod(8) completion                                      -*- shell-script -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# SPDX-FileCopyrightText: 2024 Emil Velikov <emil.l.velikov@gmail.com>
+#
+# Formatted using:
+# shfmt --language-dialect bash --indent 4 --func-next-line
+
+_insmod()
+{
+    # long/short opt pairs
+    local -A opts=(
+        ['force']='f'
+        ['syslog']='s'
+        ['verbose']='v'
+        ['version']='V'
+        ['help']='h'
+    )
+
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+
+    if [[ $cur == --* ]]; then
+        COMPREPLY=($(compgen -P '--' -W "${!opts[*]}" -- "${cur:2}"))
+    elif [[ $cur == -* ]]; then
+        if (( ${#cur} != 2 )); then
+            COMPREPLY=($(compgen -P '--' -W "${!opts[*]}" -- "${cur:2}"))
+        fi
+        COMPREPLY+=($(compgen -P '-' -W "${opts[*]}" -- "${cur:1}"))
+    else
+        # TODO: match only one file
+        _filedir '@(ko?(.gz|.xz|.zst))'
+        # TODO: add module parameter completion, based of modinfo
+    fi
+} &&
+    complete -F _insmod insmod

--- a/shell-completion/bash/lsmod
+++ b/shell-completion/bash/lsmod
@@ -1,0 +1,30 @@
+# lsmod(8) completion                                       -*- shell-script -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# SPDX-FileCopyrightText: 2024 Emil Velikov <emil.l.velikov@gmail.com>
+#
+# Formatted using:
+# shfmt --language-dialect bash --indent 4 --func-next-line
+
+_lsmod()
+{
+    # long/short opt pairs
+    local -A opts=(
+        ['syslog']='s'
+        ['verbose']='v'
+        ['version']='V'
+        ['help']='h'
+    )
+
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+
+    if [[ $cur == --* ]]; then
+        COMPREPLY=($(compgen -P '--' -W "${!opts[*]}" -- "${cur:2}"))
+    elif [[ $cur == -* ]]; then
+        if (( ${#cur} != 2 )); then
+            COMPREPLY=($(compgen -P '--' -W "${!opts[*]}" -- "${cur:2}"))
+        fi
+        COMPREPLY+=($(compgen -P '-' -W "${opts[*]}" -- "${cur:1}"))
+    fi
+} &&
+    complete -F _lsmod lsmod

--- a/shell-completion/bash/rmmod
+++ b/shell-completion/bash/rmmod
@@ -1,0 +1,34 @@
+# rmmod(8) completion                                       -*- shell-script -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# SPDX-FileCopyrightText: 2024 Emil Velikov <emil.l.velikov@gmail.com>
+#
+# Formatted using:
+# shfmt --language-dialect bash --indent 4 --func-next-line
+
+_rmmod()
+{
+    # long/short opt pairs
+    local -A opts=(
+        ['force']='f'
+        ['syslog']='s'
+        ['verbose']='v'
+        ['version']='V'
+        ['help']='h'
+    )
+
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+
+    if [[ $cur == --* ]]; then
+        COMPREPLY=($(compgen -P '--' -W "${!opts[*]}" -- "${cur:2}"))
+    elif [[ $cur == -* ]]; then
+        if (( ${#cur} != 2 )); then
+            COMPREPLY=($(compgen -P '--' -W "${!opts[*]}" -- "${cur:2}"))
+        fi
+        COMPREPLY+=($(compgen -P '-' -W "${opts[*]}" -- "${cur:1}"))
+    else
+        local -a modules=($(lsmod | cut -f1 -d' '))
+        COMPREPLY=($(compgen -W "${modules[*]}" -- "${cur}"))
+    fi
+} &&
+    complete -F _rmmod rmmod

--- a/shell-completion/fish/insmod.fish
+++ b/shell-completion/fish/insmod.fish
@@ -1,0 +1,21 @@
+# insmod(8) completion                                      -*- shell-script -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# SPDX-FileCopyrightText: 2024 Emil Velikov <emil.l.velikov@gmail.com>
+
+# globally disable file completions
+complete -c insmod -f
+
+complete -c insmod -s f -l force   -d "DANGEROUS: forces a module load, may cause data corruption and crash your machine"
+complete -c insmod -s s -l syslog  -d 'print to syslog, not stderr'
+complete -c insmod -s v -l verbose -d 'enables more messages'
+complete -c insmod -s V -l version -d 'show version'
+complete -c insmod -s h -l help    -d 'show this help'
+
+# provide an exclusive (x) list of required (r) answers (a), keeping (k) the
+# matches at the top.
+# TODO: match only one file
+# BUG: fish lists everything, even when only the given suffix is requested. Plus
+# we need to explicitly keep them sorted.
+complete -c insmod -x -ra "(__fish_complete_suffix .ko .ko.gz .ko.xz .ko.zst)" -k
+# TODO: add module parameter completion, based of modinfo

--- a/shell-completion/fish/lsmod.fish
+++ b/shell-completion/fish/lsmod.fish
@@ -1,0 +1,12 @@
+# lsmod(8) completion                                       -*- shell-script -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# SPDX-FileCopyrightText: 2024 Emil Velikov <emil.l.velikov@gmail.com>
+
+# globally disable file completions
+complete -c lsmod -f
+
+complete -c lsmod -s s -l syslog  -d 'print to syslog, not stderr'
+complete -c lsmod -s v -l verbose -d 'enables more messages'
+complete -c lsmod -s V -l version -d 'show version'
+complete -c lsmod -s h -l help    -d 'show this help'

--- a/shell-completion/fish/rmmod.fish
+++ b/shell-completion/fish/rmmod.fish
@@ -1,0 +1,16 @@
+# rmmod(8) completion                                       -*- shell-script -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# SPDX-FileCopyrightText: 2024 Emil Velikov <emil.l.velikov@gmail.com>
+
+# globally disable file completions
+complete -c rmmod -f
+
+complete -c rmmod -s f -l force   -d "DANGEROUS: forces a module unload and may crash your machine"
+complete -c rmmod -s s -l syslog  -d 'print to syslog, not stderr'
+complete -c rmmod -s v -l verbose -d 'enables more messages'
+complete -c rmmod -s V -l version -d 'show version'
+complete -c rmmod -s h -l help    -d 'show this help'
+
+# provide an exclusive (x) list of required (r) answers (a)
+complete -c rmmod -x -ra "(lsmod | cut -f1 -d' ')"

--- a/shell-completion/zsh/_insmod
+++ b/shell-completion/zsh/_insmod
@@ -1,0 +1,14 @@
+#compdef insmod
+
+# insmod(8) completion                                      -*- shell-script -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# SPDX-FileCopyrightText: 2024 Emil Velikov <emil.l.velikov@gmail.com>
+
+_arguments \
+    {-f,--force}'[DANGEROUS: forces a module load, may cause data corruption and crash your machine]' \
+    {-s,--syslog}'[print to syslog, not stderr]' \
+    {-v,--verbose}'[enables more messages]' \
+    {-V,--version}'[show version]' \
+    {-h,--help}'[show this help]' \
+    '1::module:_files -g "*.ko(|.gz|.xz|.zst)"'

--- a/shell-completion/zsh/_lsmod
+++ b/shell-completion/zsh/_lsmod
@@ -1,0 +1,12 @@
+#compdef lsmod
+
+# lsmod(8) completion                                       -*- shell-script -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# SPDX-FileCopyrightText: 2024 Emil Velikov <emil.l.velikov@gmail.com>
+
+_arguments \
+    {-s,--syslog}'[print to syslog, not stderr]' \
+    {-v,--verbose}'[enables more messages]' \
+    {-V,--version}'[show version]' \
+    {-h,--help}'[show this help]'

--- a/shell-completion/zsh/_rmmod
+++ b/shell-completion/zsh/_rmmod
@@ -1,0 +1,21 @@
+#compdef rmmod
+
+# rmmod(8) completion                                       -*- shell-script -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# SPDX-FileCopyrightText: 2024 Emil Velikov <emil.l.velikov@gmail.com>
+
+(( $+functions[_rmmod_modules] )) || _rmmod_modules()
+{
+    local -a _modules
+    _modules=(${${(f)"$(_call_program modules lsmod)"}[2,-1]%% *})
+    _values 'modules' "$_modules[@]"
+}
+
+_arguments \
+    {-f,--force}'[DANGEROUS: forces a module unload and may crash your machine]' \
+    {-s,--syslog}'[print to syslog, not stderr]' \
+    {-v,--verbose}'[enables more messages]' \
+    {-V,--version}'[show version]' \
+    {-h,--help}'[show this help]' \
+    '*::modules:_rmmod_modules'


### PR DESCRIPTION
As the title says, this series focuses on lsmod/rmmod/insmod.

In general, we've ensured they're consistent among other another - syslog/verbose/version/help for all - aligning the help and manual pages.

Some _potentially_ picky bits:
 - removed unused and undocumented since day 1 - `rmmod` `-p` and `-s`
 - added longopt and documentation for `insmod` `-f`
 
Input welcome:
 - the rmmod/insmod force messages (in help and shell completion) should be trimmed and made scarier IMHO