### PR TITLE
libkmod: remove __secure_getenv handling

### DIFF
--- a/libkmod/libkmod-internal.h
+++ b/libkmod/libkmod-internal.h
@@ -40,12 +40,8 @@ static _always_inline_ _printf_format_(2, 3) void
 #define KCMD_LINE_SIZE 4096
 
 #ifndef HAVE_SECURE_GETENV
-#  ifdef HAVE___SECURE_GETENV
-#    define secure_getenv __secure_getenv
-#  else
-#    warning neither secure_getenv nor __secure_getenv is available
-#    define secure_getenv getenv
-#  endif
+#warning secure_getenv is not available
+#define secure_getenv getenv
 #endif
 
 _printf_format_(6, 7) _nonnull_(1, 3, 5) void kmod_log(const struct kmod_ctx *ctx,


### PR DESCRIPTION
The build-time checking for __secure_getenv was dropped earlier, yet I forgot to remove the actual users :facepalm:

Fixes: 9dc54a3 ("build: stop checking for __secure_getenv")

---

I'm wondering iif we'd want to use the secure variant for `MODPROBE_OPTIONS` handling... Program can be run both as non-root and root. It doesn't have the SUID bit (good) although I have no idea if sudo/doas/run0 will play nicely with `secure_getenv`.