### PR TITLE
ci: add SPDX copyright/license identifiers

### DIFF
--- a/.github/actions/setup-alpine/action.yml
+++ b/.github/actions/setup-alpine/action.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2024 Emil Velikov <emil.l.velikov@gmail.com>
+# SPDX-FileCopyrightText: 2024 Lucas De Marchi <lucas.de.marchi@gmail.com>
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 name: 'setup Alpine'
 description: 'Setup an Alpine container for running CI'
 runs:

--- a/.github/actions/setup-archlinux/action.yml
+++ b/.github/actions/setup-archlinux/action.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2024 Emil Velikov <emil.l.velikov@gmail.com>
+# SPDX-FileCopyrightText: 2024 Lucas De Marchi <lucas.de.marchi@gmail.com>
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 name: 'setup Archlinux'
 description: 'Setup an Archlinux container for running CI'
 runs:

--- a/.github/actions/setup-debian/action.yml
+++ b/.github/actions/setup-debian/action.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2024 Emil Velikov <emil.l.velikov@gmail.com>
+# SPDX-FileCopyrightText: 2024 Lucas De Marchi <lucas.de.marchi@gmail.com>
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 name: 'setup Debian'
 description: 'Setup a Debian container for running CI'
 runs:

--- a/.github/actions/setup-fedora/action.yml
+++ b/.github/actions/setup-fedora/action.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2024 Emil Velikov <emil.l.velikov@gmail.com>
+# SPDX-FileCopyrightText: 2024 Lucas De Marchi <lucas.de.marchi@gmail.com>
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 name: 'setup Fedora'
 description: 'Setup a Fedora container for running CI'
 runs:

--- a/.github/actions/setup-ubuntu/action.yml
+++ b/.github/actions/setup-ubuntu/action.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2024 Emil Velikov <emil.l.velikov@gmail.com>
+# SPDX-FileCopyrightText: 2024 Lucas De Marchi <lucas.de.marchi@gmail.com>
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 name: 'setup Ubuntu'
 description: 'Setup an Ubuntu container for running CI'
 runs:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Emil Velikov <emil.l.velikov@gmail.com>
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 # To get started with Dependabot version updates, you'll need to specify which
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Emil Velikov <emil.l.velikov@gmail.com>
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 name: CodeQL
 
 on:

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Emil Velikov <emil.l.velikov@gmail.com>
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 name: Check spelling with codespell
 
 on:

--- a/build-dev.ini
+++ b/build-dev.ini
@@ -1,3 +1,8 @@
+; SPDX-FileCopyrightText: 2024 Emil Velikov <emil.l.velikov@gmail.com>
+; SPDX-FileCopyrightText: 2024 Lucas De Marchi <lucas.de.marchi@gmail.com>
+;
+; SPDX-License-Identifier: LGPL-2.1-or-later
+
 [project options]
 build-tests = true
 debug-messages = true


### PR DESCRIPTION
To make it clear and explicit on the topic. Inspired by me reusing some of those for usbutils and reuse-tool [1] flagging the lack of proper attribution.

[1] https://github.com/fsfe/reuse-tool

---

Done via the `reuse annotate` tool. Feel free to correct me wrt licensing and/or Lucas's attributions.