### PR TITLE
libkmod: Fix ELFDBG usage

### DIFF
--- a/libkmod/libkmod-elf.c
+++ b/libkmod/libkmod-elf.c
@@ -344,7 +344,7 @@ struct kmod_elf *kmod_elf_new(const void *memory, off_t size)
 		uint64_t slen;
 		const char *s = elf_get_strings_section(elf, &slen);
 		if (slen == 0 || s[slen - 1] != '\0') {
-			ELFDBG(elf, "strings section does not ends with \\0\n");
+			ELFDBG(elf, "strings section does not end with \\0\n");
 			goto invalid;
 		}
 	}

--- a/libkmod/libkmod-elf.c
+++ b/libkmod/libkmod-elf.c
@@ -756,12 +756,13 @@ static uint64_t kmod_elf_resolve_crc(const struct kmod_elf *elf, uint64_t crc,
 
 	err = elf_get_section_info(elf, shndx, &off, &size, &nameoff);
 	if (err < 0) {
-		ELFDBG("Could not find section index %" PRIu16 " for crc", shndx);
+		ELFDBG(elf, "Could not find section index %" PRIu16 " for crc", shndx);
 		return (uint64_t)-1;
 	}
 
 	if (crc > (size - sizeof(uint32_t))) {
-		ELFDBG("CRC offset %" PRIu64 " is too big, section %" PRIu16
+		ELFDBG(elf,
+		       "CRC offset %" PRIu64 " is too big, section %" PRIu16
 		       " size is %" PRIu64 "\n",
 		       crc, shndx, size);
 		return (uint64_t)-1;


### PR DESCRIPTION
If debug is enabled through macro `ENABLE_ELFDBG` in libkmod-elf.c, compilation fails because two callers use wrong arguments.

While at it, fixed a typo.