### PR TITLE
ci: do monthly dependabot runs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       prefix: "ci"
     groups:


### PR DESCRIPTION
The CodeQL action is getting 1-2 releases every week with only a handful of changes in each.

This is getting a bit too much, so let's change to monthly checks.

@lucasdemarchi we can try this as an alternative to disabling/removing codeql