### PR TITLE
ci: add more SPDX copyright/license identifiers

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -1,2 +1,6 @@
+# SPDX-FileCopyrightText: 2024 Emil Velikov <emil.l.velikov@gmail.com>
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 caf
 parm

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Emil Velikov <emil.l.velikov@gmail.com>
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 # To use this config on you editor, follow the instructions at:
 # http://editorconfig.org
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2024 Emil Velikov <emil.l.velikov@gmail.com>
+# SPDX-FileCopyrightText: 2024 Lucas De Marchi <lucas.de.marchi@gmail.com>
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2024 Emil Velikov <emil.l.velikov@gmail.com>
+# SPDX-FileCopyrightText: 2024 Lucas De Marchi <lucas.de.marchi@gmail.com>
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 name: Build and Test
 
 on:


### PR DESCRIPTION
This concludes the files, I'm planning to reuse in usbutils so I'll stop before it gets too annoying :-D

---

Ftr I did consider going project wide, although the results are quite drastic (as per `reuse lint`). If you think we could/(should?) continue let me know. Otherwise this will be the final PR on the topic.

```
* Files with copyright information: 90 / 435
* Files with license information: 80 / 435
```