### PR TITLE
libkmod: Improve strbuf handling in libkmod-index.c

### DIFF
--- a/libkmod/libkmod-index.c
+++ b/libkmod/libkmod-index.c
@@ -87,7 +87,7 @@
  *
  * == Key ==
  *  + Normal node
- *  * Marked node, representing a key and it's values.
+ *  * Marked node, representing a key and its values.
  *
  * +
  * |-a-+-s-+-k-*
@@ -101,7 +101,7 @@
  * Naive implementations tend to be very space inefficient; child pointers
  * are stored in arrays indexed by character, but most child pointers are null.
  *
- * Our implementation uses a scheme described by Wikipedia as a Patrica trie,
+ * Our implementation uses a scheme described by Wikipedia as a Patricia trie,
  *
  *     "easiest to understand as a space-optimized trie where
  *      each node with only one child is merged with its child"
@@ -118,7 +118,7 @@
  * We still use arrays of child pointers indexed by a single character;
  * the remaining characters of the label are stored as a "prefix" in the child.
  *
- * The paper describing the original Patrica trie works on individual bits -
+ * The paper describing the original Patricia trie works on individual bits -
  * each node has a maximum of two children, which increases space efficiency.
  * However for this application it is simpler to use the ASCII character set.
  * Since the index file is read-only, it can be compressed by omitting null

--- a/libkmod/libkmod-index.c
+++ b/libkmod/libkmod-index.c
@@ -145,7 +145,7 @@ void index_values_free(struct index_value *values)
 	}
 }
 
-static int add_value(struct index_value **values, const char *value, unsigned len,
+static int add_value(struct index_value **values, const char *value, size_t len,
 		     unsigned int priority)
 {
 	struct index_value *v;
@@ -619,13 +619,13 @@ struct index_mm {
 
 struct index_mm_value {
 	unsigned int priority;
-	unsigned int len;
+	size_t len;
 	const char *value;
 };
 
 struct index_mm_value_array {
 	struct index_mm_value *values;
-	unsigned int len;
+	size_t len;
 };
 
 struct index_mm_node {
@@ -657,7 +657,7 @@ static inline uint8_t read_char_mm(void **p)
 	return v;
 }
 
-static inline char *read_chars_mm(void **p, unsigned *rlen)
+static inline char *read_chars_mm(void **p, size_t *rlen)
 {
 	char *addr = *(char **)p;
 	size_t len = *rlen = strlen(addr);
@@ -680,7 +680,7 @@ static struct index_mm_node *index_mm_read_node(struct index_mm *idx, uint32_t o
 	p = (char *)p + (offset & INDEX_NODE_MASK);
 
 	if (offset & INDEX_NODE_PREFIX) {
-		unsigned len;
+		size_t len;
 		prefix = read_chars_mm(&p, &len);
 	} else
 		prefix = _idx_empty_str;

--- a/libkmod/libkmod-index.h
+++ b/libkmod/libkmod-index.h
@@ -10,7 +10,7 @@
 struct index_value {
 	struct index_value *next;
 	unsigned int priority;
-	unsigned int len;
+	size_t len;
 	char value[0];
 };
 


### PR DESCRIPTION
- Turn `unsigned int` lengths into `size_t` to stay in sync with latest strbuf changes
- Check strbuf function return values, because they might fail. If they fail, push and pop operations might run out of sync