### PR TITLE
libkmod: Plug memory leak on error path

### DIFF
--- a/libkmod/libkmod-index.c
+++ b/libkmod/libkmod-index.c
@@ -338,8 +338,10 @@ struct index_file *index_file_open(const char *filename)
 		goto err;
 
 	new->file = file;
-	if (read_u32(new->file, &new->root_offset) < 0)
+	if (read_u32(new->file, &new->root_offset) < 0) {
+		free(new);
 		goto err;
+	}
 
 	errno = 0;
 	return new;


### PR DESCRIPTION
Fix memory leak on error path introduced with read_u32 error checks.

Leak introduced with: https://github.com/kmod-project/kmod/commit/9d965d3386b609e81155c55ade59fa35ae991edf