### PR TITLE
modinfo: Avoid unneeded system call

### DIFF
--- a/tools/modinfo.c
+++ b/tools/modinfo.c
@@ -350,8 +350,8 @@ static bool is_module_filename(const char *name)
 {
 	struct stat st;
 
-	if (stat(name, &st) == 0 && S_ISREG(st.st_mode) &&
-	    path_ends_with_kmod_ext(name, strlen(name)))
+	if (path_ends_with_kmod_ext(name, strlen(name)) && stat(name, &st) == 0 &&
+	    S_ISREG(st.st_mode))
 		return true;
 
 	return false;


### PR DESCRIPTION
If a file name does not end with ".ko", there is no need to call fstat. Since common use cases are like "modinfo modname", the string check should come first to save a tiny amount of system time.

In fact, this would have saved me some time with strace analysis why a local file wasn't actually read. :)