### PR TITLE
testsuite: Fix test-weakdep with default autoconf settings

### DIFF
--- a/testsuite/README
+++ b/testsuite/README
@@ -50,9 +50,9 @@ pay attention when writing a test:
     expected not to be 0.
 
 7 - The rootfs is populated by copying the entire contents of rootfs-pristine
-    then running populate-modules.sh to copy generated modules from
-    module-playground. Update the latter script to include any modules your
-    test need.
+    through setup-rootfs.sh then running setup-modules.sh to copy generated
+    modules from module-playground. Update the latter script to include any
+    modules your test needs.
 
 8 - Tests can be run individually, outside of 'make check'. strace and gdb work
     too, as long as you tell them to operate on child process.

--- a/testsuite/test-weakdep.c
+++ b/testsuite/test-weakdep.c
@@ -19,7 +19,7 @@
 #define TEST_WEAKDEP_KERNEL_DIR TEST_WEAKDEP_ROOTFS MODULE_DIRECTORY "/4.4.4/"
 
 static const char *const test_weakdep_config_paths[] = {
-	TEST_WEAKDEP_ROOTFS "etc/modprobe.d",
+	TEST_WEAKDEP_ROOTFS SYSCONFDIR "/modprobe.d",
 	NULL,
 };
 


### PR DESCRIPTION
This breaks test-weakdep:

```
./configure
make
make check
```

The default should work, but it sets SYSCONFDIR to /usr/etc, which probably nobody really uses. Anyway, the test-suite should support configurations kmod allows.