### PR TITLE
depmod: Minor performance improvements

### DIFF
--- a/tools/depmod.c
+++ b/tools/depmod.c
@@ -1484,7 +1484,7 @@ static void depmod_modules_sort(struct depmod *depmod)
 		}
 		line[len - 1] = '\0';
 		mod = hash_find(depmod->modules_by_uncrelpath, line);
-		if (mod == NULL)
+		if (mod == NULL || mod->sort_idx < 0)
 			continue;
 		mod->sort_idx = i++;
 	}

--- a/tools/depmod.c
+++ b/tools/depmod.c
@@ -2661,7 +2661,7 @@ static int depmod_output(struct depmod *depmod, FILE *out)
 
 static void depmod_add_fake_syms(struct depmod *depmod)
 {
-	/* __this_module is magic inserted by kernel loader. */
+	/* __this_module is magically inserted by kernel loader. */
 	depmod_symbol_add(depmod, "__this_module", true, 0, NULL);
 	/* On S390, this is faked up too */
 	depmod_symbol_add(depmod, "_GLOBAL_OFFSET_TABLE_", true, 0, NULL);

--- a/tools/depmod.c
+++ b/tools/depmod.c
@@ -265,10 +265,9 @@ static int index_insert(struct index_node *node, const char *key, const char *va
 				struct index_node *n;
 
 				/* New child is copy of node with prefix[j+1..N] */
-				n = calloc(1, sizeof(struct index_node));
+				n = memdup(node, sizeof(struct index_node));
 				if (n == NULL)
 					fatal_oom();
-				memcpy(n, node, sizeof(struct index_node));
 				n->prefix = strdup(&prefix[j + 1]);
 				if (n->prefix == NULL)
 					fatal_oom();

--- a/tools/depmod.c
+++ b/tools/depmod.c
@@ -1066,6 +1066,11 @@ static int depmod_module_add(struct depmod *depmod, struct kmod_module *kmod)
 		size_t uncrelpathlen = lastslash - mod->relpath + modnamesz +
 				       strlen(KMOD_EXTENSION_UNCOMPRESSED);
 		mod->uncrelpath = memdup(mod->relpath, uncrelpathlen + 1);
+		if (mod->uncrelpath == NULL) {
+			err = -ENOMEM;
+			hash_del(depmod->modules_by_name, mod->modname);
+			goto fail;
+		}
 		mod->uncrelpath[uncrelpathlen] = '\0';
 		err = hash_add_unique(depmod->modules_by_uncrelpath, mod->uncrelpath, mod);
 		if (err < 0) {

--- a/tools/depmod.c
+++ b/tools/depmod.c
@@ -1428,6 +1428,8 @@ static int depmod_modules_build_array(struct depmod *depmod)
 		if (err < 0)
 			return err;
 	}
+	if (depmod->modules.count >= UINT16_MAX)
+		return -ERANGE;
 
 	return 0;
 }


### PR DESCRIPTION
- We can skip a `calloc` and turn it into a `malloc` because newly allocated memory is directly overwritten
- The `modules.order` file can be interated just once
- Minor cleanups (fixed typo and added a missing NULL check)