### PR TITLE
depmod: Actually use scratch buffer memory

### DIFF
--- a/tools/depmod.c
+++ b/tools/depmod.c
@@ -2333,6 +2333,7 @@ static int output_symbols_bin(struct depmod *depmod, FILE *out)
 		int duplicate;
 		const struct symbol *sym = v;
 		size_t len;
+		char *s;
 
 		if (sym->owner == NULL)
 			continue;
@@ -2343,12 +2344,12 @@ static int output_symbols_bin(struct depmod *depmod, FILE *out)
 			ret = -ENOMEM;
 			goto err_scratchbuf;
 		}
-		memcpy(scratchbuf_str(&salias) + baselen, sym->name, len + 1);
-		duplicate =
-			index_insert(idx, alias, sym->owner->modname, sym->owner->idx);
+		s = scratchbuf_str(&salias);
+		memcpy(s + baselen, sym->name, len + 1);
+		duplicate = index_insert(idx, s, sym->owner->modname, sym->owner->idx);
 
 		if (duplicate && depmod->cfg->warn_dups)
-			WRN("duplicate module syms:\n%s %s\n", alias, sym->owner->modname);
+			WRN("duplicate module syms:\n%s %s\n", s, sym->owner->modname);
 	}
 
 	index_write(idx, out);

--- a/tools/depmod.c
+++ b/tools/depmod.c
@@ -2310,10 +2310,10 @@ static int output_symbols(struct depmod *depmod, FILE *out)
 static int output_symbols_bin(struct depmod *depmod, FILE *out)
 {
 	struct index_node *idx;
-	char alias[1024];
+	char aliasbuf[1024] = "symbol:";
 	_cleanup_(scratchbuf_release) struct scratchbuf salias =
-		SCRATCHBUF_INITIALIZER(alias);
-	size_t baselen = sizeof("symbol:") - 1;
+		SCRATCHBUF_INITIALIZER(aliasbuf);
+	const size_t baselen = sizeof("symbol:") - 1;
 	struct hash_iter iter;
 	const void *v;
 	int ret = 0;
@@ -2324,8 +2324,6 @@ static int output_symbols_bin(struct depmod *depmod, FILE *out)
 	idx = index_create();
 	if (idx == NULL)
 		return -ENOMEM;
-
-	memcpy(alias, "symbol:", baselen);
 
 	hash_iter_init(depmod->symbols, &iter);
 


### PR DESCRIPTION
Accessing the backing "alias" char buffer directly works only as long as all symbols are smaller than 1024, because otherwise the scratch buffer allocates memory and the addresses do not match anymore.

Proof of Concept:
1. Create a temporary modules directory containing a module with two symbols, `aa` and `1025*A` (i.e. longer than 1024 characters)
```
MYDIR=$(mktemp -d)
KDIR=$MYDIR/lib/modules/$(uname -r)
mkdir -p $KDIR/kernel/sub
cat > $MYDIR/mod.ko.xz.b64 << EOF
/Td6WFoAAATm1rRGBMBvmQohARwAAAAAAAAAAMNcVP3gBRgAZ10AP5FFhGhEVEmcAlZtZy+BVw2o
524UVW19oueqRkgFvigdxpHbOYyTU7Kx/hlefDfD+r/tFCQlBcHuPRCbnxuRTPRldwa2DYFC2g0c
DdY1yxHvF6tv9kbWqc8xpwpQ8YWKVB8MXvUAAAAAPR9nVoEFabMAAYsBmQoAAI4ynUexxGf7AgAA
AAAEWVo=
EOF
base64 -d $MYDIR/mod.ko.xz.b64 | xz -cd > $KDIR/kernel/sub/mod.ko
```
2. Run depmod with warnings enabled
```
depmod -b $MYDIR -o $MYDIR/out -w
```

You can see, among other warnings, this one:
```
depmod: WARNING: duplicate module syms:
symbol:aa mod
```

Since the `1025*A` symbol name triggered an allocation within the scratch buffer, the first symbol name `aa` has been added twice. The `1025*A` symbol name can be seen in written `modules.symbols` file, but not in `modules.symbols.bin` (because the scratch buffer issue is triggered in second output).