### PR TITLE
libkmod: Check child range in memory mapped index

### DIFF
--- a/libkmod/libkmod-index.c
+++ b/libkmod/libkmod-index.c
@@ -689,7 +689,7 @@ static struct index_mm_node *index_mm_read_node(struct index_mm *idx, uint32_t o
 		first = read_char_mm(&p);
 		last = read_char_mm(&p);
 
-		if (first > last)
+		if (first > last || first < 0 || last < 0)
 			return NULL;
 
 		child_count = last - first + 1;


### PR DESCRIPTION
If value of `first` is negative, then a broken index can trigger a stack based buffer overflow, because `child_count` could become larger than INDEX_CHILDMAX.

Proof of Concept:
1. Create broken index files
```
MYDIR=$(mktemp -d)
KDIR=$MYDIR/lib/modules/$(uname -r)
mkdir -p $KDIR
cat > $MYDIR/bin.xz.b64 << EOF
/Td6WFoAAATm1rRGBMAinAghARwAAAAAAAAAAOX2A/rgBBsAGl0AWAHahc6kB/nBvrJW9H1Nj78L
jsj0KxaUn0kAAAA4Anj08IzoigABPpwIAAAA/lBnLLHEZ/sCAAAAAARZWg==
EOF
base64 -d $MYDIR/bin.xz.b64 | xz -cd > $KDIR/modules.alias.bin
for i in builtin.alias builtin dep symbols
do
        ln -s modules.alias.bin $KDIR/modules.$i.bin
done
```
2. Run modprobe
```
modprobe -cd $MYDIR
```

On glibc based systems, you will most likely encounter a message like
```
*** stack smashing detected ***: terminated
```

Alternatively, compile with address sanitizer.