### PR TITLE
libkmod: Avoid redundant kmod_pool_get_module call

### DIFF
--- a/libkmod/libkmod-module.c
+++ b/libkmod/libkmod-module.c
@@ -340,29 +340,21 @@ KMOD_EXPORT int kmod_module_new_from_path(struct kmod_ctx *ctx, const char *path
 		return -ENOENT;
 	}
 
-	m = kmod_pool_get_module(ctx, name);
-	if (m != NULL) {
-		if (m->path == NULL)
-			m->path = abspath;
-		else if (streq(m->path, abspath))
-			free(abspath);
-		else {
-			ERR(ctx,
-			    "kmod_module '%s' already exists with different path: new-path='%s' old-path='%s'\n",
-			    name, abspath, m->path);
-			free(abspath);
-			return -EEXIST;
-		}
-
-		kmod_module_ref(m);
-	} else {
-		err = kmod_module_new(ctx, name, name, namelen, NULL, 0, &m);
-		if (err < 0) {
-			free(abspath);
-			return err;
-		}
-
+	err = kmod_module_new(ctx, name, name, namelen, NULL, 0, &m);
+	if (err < 0) {
+		free(abspath);
+		return err;
+	}
+	if (m->path == NULL)
 		m->path = abspath;
+	else if (streq(m->path, abspath))
+		free(abspath);
+	else {
+		ERR(ctx,
+		    "kmod_module '%s' already exists with different path: new-path='%s' old-path='%s'\n",
+		    name, abspath, m->path);
+		free(abspath);
+		return -EEXIST;
 	}
 
 	m->builtin = KMOD_MODULE_BUILTIN_NO;


### PR DESCRIPTION
Before kmod_module_new_from_path creates a module with kmod_module_new, it checks with kmod_pool_get_module if a module with given name already exists.

This check can be removed, because kmod_module_new does the same. If the module already existed, the same checks are performed as in current code for the "if (m != NULL)" case. If it did not exist yet, m->path is NULL and the first if-block is entered.

And since kmod_module_new takes care of incrementing the reference counter, the explicit call of kmod_module_ref can be removed from kmod_module_new_from_path as well.