### PR TITLE
Add size_t overflow helpers and use them

### DIFF
--- a/libkmod/libkmod-elf.c
+++ b/libkmod/libkmod-elf.c
@@ -243,7 +243,7 @@ static inline int elf_get_section_info(const struct kmod_elf *elf, uint16_t idx,
 	}
 #undef READV
 
-	if (addu64_overflow(*offset, *size, &min_size) || min_size > elf->size) {
+	if (uadd64_overflow(*offset, *size, &min_size) || min_size > elf->size) {
 		ELFDBG(elf, "out-of-bounds: %" PRIu64 " >= %" PRIu64 " (ELF size)\n",
 		       min_size, elf->size);
 		return -EINVAL;
@@ -330,7 +330,7 @@ struct kmod_elf *kmod_elf_new(const void *memory, off_t size)
 		goto invalid;
 	}
 	shdrs_size = shdr_size * elf->header.section.count;
-	if (addu64_overflow(shdrs_size, elf->header.section.offset, &min_size) ||
+	if (uadd64_overflow(shdrs_size, elf->header.section.offset, &min_size) ||
 	    min_size > elf->size) {
 		ELFDBG(elf, "file is too short to hold sections\n");
 		goto invalid;

--- a/meson.build
+++ b/meson.build
@@ -52,6 +52,9 @@ _builtins = [
   ['__builtin_uadd_overflow', '0U, 0U, (void*)0', false],
   ['__builtin_uaddl_overflow', '0UL, 0UL, (void*)0', false],
   ['__builtin_uaddll_overflow', '0ULL, 0ULL, (void*)0', false],
+  ['__builtin_umul_overflow', '0U, 0U, (void*)0', false],
+  ['__builtin_umull_overflow', '0UL, 0UL, (void*)0', false],
+  ['__builtin_umulll_overflow', '0ULL, 0ULL, (void*)0', false],
 ]
 foreach tuple : _builtins
   builtin = tuple[0]

--- a/meson.build
+++ b/meson.build
@@ -49,6 +49,7 @@ endforeach
 _builtins = [
   ['__builtin_clz', '0', true],
   ['__builtin_types_compatible_p', 'int, int', true],
+  ['__builtin_uadd_overflow', '0U, 0U, (void*)0', false],
   ['__builtin_uaddl_overflow', '0UL, 0UL, (void*)0', false],
   ['__builtin_uaddll_overflow', '0ULL, 0ULL, (void*)0', false],
 ]

--- a/shared/util.h
+++ b/shared/util.h
@@ -92,6 +92,16 @@ static inline void freep(void *p)
 }
 #define _cleanup_free_ _cleanup_(freep)
 
+static inline bool uadd32_overflow(uint32_t a, uint32_t b, uint32_t *res)
+{
+#if (HAVE___BUILTIN_UADD_OVERFLOW && __SIZEOF_INT__ == 4)
+	return __builtin_uadd_overflow(a, b, res);
+#else
+	*res = a + b;
+	return UINT32_MAX - a < b;
+#endif
+}
+
 static inline bool uadd64_overflow(uint64_t a, uint64_t b, uint64_t *res)
 {
 #if (HAVE___BUILTIN_UADDL_OVERFLOW && __SIZEOF_LONG__ == 8)

--- a/shared/util.h
+++ b/shared/util.h
@@ -94,15 +94,12 @@ static inline void freep(void *p)
 
 static inline bool addu64_overflow(uint64_t a, uint64_t b, uint64_t *res)
 {
-#if (HAVE___BUILTIN_UADDL_OVERFLOW && HAVE___BUILTIN_UADDLL_OVERFLOW)
-#if __SIZEOF_LONG__ == 8
+#if (HAVE___BUILTIN_UADDL_OVERFLOW && __SIZEOF_LONG__ == 8)
 	return __builtin_uaddl_overflow(a, b, res);
-#elif __SIZEOF_LONG_LONG__ == 8
+#elif (HAVE___BUILTIN_UADDLL_OVERFLOW && __SIZEOF_LONG_LONG__ == 8)
 	return __builtin_uaddll_overflow(a, b, res);
 #else
-#error "sizeof(long long) != 8"
-#endif
-#endif
 	*res = a + b;
 	return UINT64_MAX - a < b;
+#endif
 }

--- a/shared/util.h
+++ b/shared/util.h
@@ -113,3 +113,25 @@ static inline bool uadd64_overflow(uint64_t a, uint64_t b, uint64_t *res)
 	return UINT64_MAX - a < b;
 #endif
 }
+
+static inline bool umul32_overflow(uint32_t a, uint32_t b, uint32_t *res)
+{
+#if (HAVE___BUILTIN_UMUL_OVERFLOW && __SIZEOF_INT__ == 4)
+	return __builtin_umul_overflow(a, b, res);
+#else
+	*res = a * b;
+	return UINT32_MAX / a < b;
+#endif
+}
+
+static inline bool umul64_overflow(uint64_t a, uint64_t b, uint64_t *res)
+{
+#if (HAVE___BUILTIN_UMULL_OVERFLOW && __SIZEOF_LONG__ == 8)
+	return __builtin_umull_overflow(a, b, res);
+#elif (HAVE___BUILTIN_UMULLL_OVERFLOW && __SIZEOF_LONG_LONG__ == 8)
+	return __builtin_umulll_overflow(a, b, res);
+#else
+	*res = a * b;
+	return UINT64_MAX / a < b;
+#endif
+}

--- a/shared/util.h
+++ b/shared/util.h
@@ -92,7 +92,7 @@ static inline void freep(void *p)
 }
 #define _cleanup_free_ _cleanup_(freep)
 
-static inline bool addu64_overflow(uint64_t a, uint64_t b, uint64_t *res)
+static inline bool uadd64_overflow(uint64_t a, uint64_t b, uint64_t *res)
 {
 #if (HAVE___BUILTIN_UADDL_OVERFLOW && __SIZEOF_LONG__ == 8)
 	return __builtin_uaddl_overflow(a, b, res);

--- a/shared/util.h
+++ b/shared/util.h
@@ -114,6 +114,17 @@ static inline bool uadd64_overflow(uint64_t a, uint64_t b, uint64_t *res)
 #endif
 }
 
+static inline bool uaddsz_overflow(size_t a, size_t b, size_t *res)
+{
+#if __SIZEOF_SIZE_T__ == 8
+	return uadd64_overflow(a, b, res);
+#elif __SIZEOF_SIZE_T__ == 4
+	return uadd32_overflow(a, b, res);
+#else
+#error "Unknown sizeof(size_t)"
+#endif
+}
+
 static inline bool umul32_overflow(uint32_t a, uint32_t b, uint32_t *res)
 {
 #if (HAVE___BUILTIN_UMUL_OVERFLOW && __SIZEOF_INT__ == 4)
@@ -133,5 +144,16 @@ static inline bool umul64_overflow(uint64_t a, uint64_t b, uint64_t *res)
 #else
 	*res = a * b;
 	return UINT64_MAX / a < b;
+#endif
+}
+
+static inline bool umulsz_overflow(size_t a, size_t b, size_t *res)
+{
+#if __SIZEOF_SIZE_T__ == 8
+	return umul64_overflow(a, b, res);
+#elif __SIZEOF_SIZE_T__ == 4
+	return umul32_overflow(a, b, res);
+#else
+#error "Unknown sizeof(size_t)"
 #endif
 }

--- a/testsuite/test-util.c
+++ b/testsuite/test-util.c
@@ -225,6 +225,40 @@ static int test_uadd64_overflow(const struct test *t)
 DEFINE_TEST(test_uadd64_overflow,
 	    .description = "check implementation of uadd64_overflow()")
 
+static int test_umul32_overflow(const struct test *t)
+{
+	uint32_t res;
+	bool overflow;
+
+	overflow = umul32_overflow(UINT32_MAX / 0x10, 0x10, &res);
+	assert_return(!overflow, EXIT_FAILURE);
+	assert_return(res == (UINT32_MAX & ~0xf), EXIT_FAILURE);
+
+	overflow = umul32_overflow(UINT32_MAX, 0x10, &res);
+	assert_return(overflow, EXIT_FAILURE);
+
+	return EXIT_SUCCESS;
+}
+DEFINE_TEST(test_umul32_overflow,
+	    .description = "check implementation of umul32_overflow()")
+
+static int test_umul64_overflow(const struct test *t)
+{
+	uint64_t res;
+	bool overflow;
+
+	overflow = umul64_overflow(UINT64_MAX / 0x10, 0x10, &res);
+	assert_return(!overflow, EXIT_FAILURE);
+	assert_return(res == (UINT64_MAX & ~0xf), EXIT_FAILURE);
+
+	overflow = umul64_overflow(UINT64_MAX, 0x10, &res);
+	assert_return(overflow, EXIT_FAILURE);
+
+	return EXIT_SUCCESS;
+}
+DEFINE_TEST(test_umul64_overflow,
+	    .description = "check implementation of umul64_overflow()")
+
 static int test_backoff_time(const struct test *t)
 {
 	unsigned long long delta = 0;

--- a/testsuite/test-util.c
+++ b/testsuite/test-util.c
@@ -191,6 +191,23 @@ DEFINE_TEST(test_write_str_safe,
 		},
 	});
 
+static int test_uadd32_overflow(const struct test *t)
+{
+	uint32_t res;
+	bool overflow;
+
+	overflow = uadd32_overflow(UINT32_MAX - 1, 1, &res);
+	assert_return(!overflow, EXIT_FAILURE);
+	assert_return(res == UINT32_MAX, EXIT_FAILURE);
+
+	overflow = uadd32_overflow(UINT32_MAX, 1, &res);
+	assert_return(overflow, EXIT_FAILURE);
+
+	return EXIT_SUCCESS;
+}
+DEFINE_TEST(test_uadd32_overflow,
+	    .description = "check implementation of uadd32_overflow()")
+
 static int test_uadd64_overflow(const struct test *t)
 {
 	uint64_t res;

--- a/testsuite/test-util.c
+++ b/testsuite/test-util.c
@@ -191,22 +191,22 @@ DEFINE_TEST(test_write_str_safe,
 		},
 	});
 
-static int test_addu64_overflow(const struct test *t)
+static int test_uadd64_overflow(const struct test *t)
 {
 	uint64_t res;
 	bool overflow;
 
-	overflow = addu64_overflow(UINT64_MAX - 1, 1, &res);
+	overflow = uadd64_overflow(UINT64_MAX - 1, 1, &res);
 	assert_return(!overflow, EXIT_FAILURE);
 	assert_return(res == UINT64_MAX, EXIT_FAILURE);
 
-	overflow = addu64_overflow(UINT64_MAX, 1, &res);
+	overflow = uadd64_overflow(UINT64_MAX, 1, &res);
 	assert_return(overflow, EXIT_FAILURE);
 
 	return EXIT_SUCCESS;
 }
-DEFINE_TEST(test_addu64_overflow,
-	    .description = "check implementation of addu4_overflow()")
+DEFINE_TEST(test_uadd64_overflow,
+	    .description = "check implementation of uadd64_overflow()")
 
 static int test_backoff_time(const struct test *t)
 {


### PR DESCRIPTION
This builds on the existing add_u64 helper, adding add_u32 and mul_{u32,u64} variants. Where those are used for the actual size_t ones.

Names are likely suboptimal, so any suggestions are highly appreciated. 

Note: the autotools build explicitly does not check for the extra built-ins since a) it's going away soon (tm) and b) serves as nice exercise that the fallback is correct.

Closes: https://github.com/kmod-project/kmod/issues/162