### PR TITLE
libkmod: unref in  kmod_module_new_from_path() error path

### DIFF
--- a/libkmod/libkmod-module.c
+++ b/libkmod/libkmod-module.c
@@ -350,6 +350,7 @@ KMOD_EXPORT int kmod_module_new_from_path(struct kmod_ctx *ctx, const char *path
 	else if (streq(m->path, abspath))
 		free(abspath);
 	else {
+		kmod_module_unref(m);
 		ERR(ctx,
 		    "kmod_module '%s' already exists with different path: new-path='%s' old-path='%s'\n",
 		    name, abspath, m->path);


### PR DESCRIPTION
Preserve the original behaviour, where the module refcount stays the same, if the function fails.

Fixes: e19338da ("libkmod: Avoid redundant kmod_pool_get_module call")

---

Follow-up to https://github.com/kmod-project/kmod/pull/168 ... not sure how I missed it :sweat_smile: 