### PR TITLE
Fix and rework logging

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -203,6 +203,8 @@ AC_ARG_ENABLE([logging],
 	[], enable_logging=yes)
 AS_IF([test "x$enable_logging" = "xyes"], [
 	AC_DEFINE(ENABLE_LOGGING, [1], [System logging.])
+], [
+	AC_DEFINE(ENABLE_LOGGING, [0], [System logging.])
 ])
 
 AC_ARG_ENABLE([debug],

--- a/configure.ac
+++ b/configure.ac
@@ -215,6 +215,7 @@ AS_IF([test "x$enable_debug" = "xyes"], [
 ], [
 	AC_DEFINE(ENABLE_DEBUG, [0], [Debug messages.])
 ])
+AC_DEFINE(ENABLE_ELFDBG, [0], [Debug elf parsing messages.])
 
 AC_ARG_ENABLE([coverage],
 	AS_HELP_STRING([--enable-coverage], [enable test coverage @<:@default=disabled@:>@]),

--- a/configure.ac
+++ b/configure.ac
@@ -212,6 +212,8 @@ AC_ARG_ENABLE([debug],
 	[], [enable_debug=no])
 AS_IF([test "x$enable_debug" = "xyes"], [
 	AC_DEFINE(ENABLE_DEBUG, [1], [Debug messages.])
+], [
+	AC_DEFINE(ENABLE_DEBUG, [0], [Debug messages.])
 ])
 
 AC_ARG_ENABLE([coverage],

--- a/libkmod/libkmod-elf.c
+++ b/libkmod/libkmod-elf.c
@@ -56,7 +56,7 @@ struct kmod_elf {
 
 //#define ENABLE_ELFDBG 1
 
-#if defined(ENABLE_LOGGING) && defined(ENABLE_ELFDBG)
+#if (ENABLE_LOGGING == 1) && defined(ENABLE_ELFDBG)
 #define ELFDBG(elf, ...) _elf_dbg(elf, __FILE__, __LINE__, __func__, __VA_ARGS__);
 
 static inline void _elf_dbg(const struct kmod_elf *elf, const char *fname, unsigned line,

--- a/libkmod/libkmod-elf.c
+++ b/libkmod/libkmod-elf.c
@@ -54,10 +54,14 @@ struct kmod_elf {
 	} header;
 };
 
+//#undef ENABLE_ELFDBG
 //#define ENABLE_ELFDBG 1
 
-#if (ENABLE_LOGGING == 1) && defined(ENABLE_ELFDBG)
-#define ELFDBG(elf, ...) _elf_dbg(elf, __FILE__, __LINE__, __func__, __VA_ARGS__);
+#define ELFDBG(elf, ...)                                                          \
+	do {                                                                      \
+		if (ENABLE_LOGGING == 1 && ENABLE_ELFDBG == 1)                    \
+			_elf_dbg(elf, __FILE__, __LINE__, __func__, __VA_ARGS__); \
+	} while (0);
 
 static inline void _elf_dbg(const struct kmod_elf *elf, const char *fname, unsigned line,
 			    const char *func, const char *fmt, ...)
@@ -70,9 +74,6 @@ static inline void _elf_dbg(const struct kmod_elf *elf, const char *fname, unsig
 	vfprintf(stderr, fmt, args);
 	va_end(args);
 }
-#else
-#define ELFDBG(elf, ...)
-#endif
 
 static int elf_identify(const void *memory, uint64_t size)
 {

--- a/libkmod/libkmod-internal.h
+++ b/libkmod/libkmod-internal.h
@@ -10,22 +10,15 @@
 
 #include "libkmod.h"
 
-static _always_inline_ _printf_format_(2, 3) void kmod_log_null(const struct kmod_ctx *ctx,
-								const char *format, ...)
-{
-}
-
-#define kmod_log_cond(ctx, prio, arg...)                                          \
-	do {                                                                      \
-		if (ENABLE_LOGGING == 1 && kmod_get_log_priority(ctx) >= prio)    \
-			kmod_log(ctx, prio, __FILE__, __LINE__, __func__, ##arg); \
+#define kmod_log_cond(ctx, prio, arg...)                                           \
+	do {                                                                       \
+		if (ENABLE_LOGGING == 1 &&                                         \
+		    (ENABLE_DEBUG == 1 || (!ENABLE_DEBUG && prio != LOG_DEBUG)) && \
+		    kmod_get_log_priority(ctx) >= prio)                            \
+			kmod_log(ctx, prio, __FILE__, __LINE__, __func__, ##arg);  \
 	} while (0)
 
-#ifdef ENABLE_DEBUG
 #define DBG(ctx, arg...) kmod_log_cond(ctx, LOG_DEBUG, ##arg)
-#else
-#define DBG(ctx, arg...) kmod_log_null(ctx, ##arg)
-#endif
 #define NOTICE(ctx, arg...) kmod_log_cond(ctx, LOG_NOTICE, ##arg)
 #define INFO(ctx, arg...) kmod_log_cond(ctx, LOG_INFO, ##arg)
 #define ERR(ctx, arg...) kmod_log_cond(ctx, LOG_ERR, ##arg)

--- a/libkmod/libkmod-internal.h
+++ b/libkmod/libkmod-internal.h
@@ -17,11 +17,10 @@ static _always_inline_ _printf_format_(2, 3) void kmod_log_null(const struct kmo
 
 #define kmod_log_cond(ctx, prio, arg...)                                          \
 	do {                                                                      \
-		if (kmod_get_log_priority(ctx) >= prio)                           \
+		if (ENABLE_LOGGING == 1 && kmod_get_log_priority(ctx) >= prio)    \
 			kmod_log(ctx, prio, __FILE__, __LINE__, __func__, ##arg); \
 	} while (0)
 
-#ifdef ENABLE_LOGGING
 #ifdef ENABLE_DEBUG
 #define DBG(ctx, arg...) kmod_log_cond(ctx, LOG_DEBUG, ##arg)
 #else
@@ -30,12 +29,6 @@ static _always_inline_ _printf_format_(2, 3) void kmod_log_null(const struct kmo
 #define NOTICE(ctx, arg...) kmod_log_cond(ctx, LOG_NOTICE, ##arg)
 #define INFO(ctx, arg...) kmod_log_cond(ctx, LOG_INFO, ##arg)
 #define ERR(ctx, arg...) kmod_log_cond(ctx, LOG_ERR, ##arg)
-#else
-#define DBG(ctx, arg...) kmod_log_null(ctx, ##arg)
-#define NOTICE(ctx, arg...) kmod_log_null(ctx, ##arg)
-#define INFO(ctx, arg...) kmod_log_null(ctx, ##arg)
-#define ERR(ctx, arg...) kmod_log_null(ctx, ##arg)
-#endif
 
 #define KMOD_EXPORT __attribute__((visibility("default")))
 

--- a/libkmod/libkmod.c
+++ b/libkmod/libkmod.c
@@ -116,11 +116,10 @@ _printf_format_(6, 0) static void log_filep(void *data, int priority, const char
 		snprintf(buf, sizeof(buf), "L:%d", priority);
 		priname = buf;
 	}
-#ifdef ENABLE_DEBUG
-	fprintf(fp, "libkmod: %s %s:%d %s: ", priname, file, line, fn);
-#else
-	fprintf(fp, "libkmod: %s: %s: ", priname, fn);
-#endif
+	if (ENABLE_DEBUG == 1)
+		fprintf(fp, "libkmod: %s %s:%d %s: ", priname, file, line, fn);
+	else
+		fprintf(fp, "libkmod: %s: %s: ", priname, fn);
 	vfprintf(fp, format, args);
 }
 

--- a/libkmod/libkmod.c
+++ b/libkmod/libkmod.c
@@ -85,7 +85,6 @@ _printf_format_(6, 0) static void log_filep(void *data, int priority, const char
 					    va_list args)
 {
 	FILE *fp = data;
-#ifdef ENABLE_DEBUG
 	char buf[16];
 	const char *priname;
 	switch (priority) {
@@ -117,9 +116,10 @@ _printf_format_(6, 0) static void log_filep(void *data, int priority, const char
 		snprintf(buf, sizeof(buf), "L:%d", priority);
 		priname = buf;
 	}
+#ifdef ENABLE_DEBUG
 	fprintf(fp, "libkmod: %s %s:%d %s: ", priname, file, line, fn);
 #else
-	fprintf(fp, "libkmod: %s: ", fn);
+	fprintf(fp, "libkmod: %s: %s: ", priname, fn);
 #endif
 	vfprintf(fp, format, args);
 }

--- a/meson.build
+++ b/meson.build
@@ -19,9 +19,7 @@ cdata.set_quoted('PACKAGE', meson.project_name())
 cdata.set_quoted('VERSION', meson.project_version())
 
 cdata.set10('ENABLE_LOGGING', get_option('logging'))
-if get_option('debug-messages')
-  cdata.set('ENABLE_DEBUG', true)
-endif
+cdata.set10('ENABLE_DEBUG', get_option('debug-messages'))
 
 pkg = import('pkgconfig')
 cc = meson.get_compiler('c')

--- a/meson.build
+++ b/meson.build
@@ -20,6 +20,7 @@ cdata.set_quoted('VERSION', meson.project_version())
 
 cdata.set10('ENABLE_LOGGING', get_option('logging'))
 cdata.set10('ENABLE_DEBUG', get_option('debug-messages'))
+cdata.set10('ENABLE_ELFDBG', false)
 
 pkg = import('pkgconfig')
 cc = meson.get_compiler('c')

--- a/meson.build
+++ b/meson.build
@@ -18,9 +18,7 @@ cdata = configuration_data()
 cdata.set_quoted('PACKAGE', meson.project_name())
 cdata.set_quoted('VERSION', meson.project_version())
 
-if get_option('logging')
-  cdata.set('ENABLE_LOGGING', true)
-endif
+cdata.set10('ENABLE_LOGGING', get_option('logging'))
 if get_option('debug-messages')
   cdata.set('ENABLE_DEBUG', true)
 endif

--- a/tools/log.c
+++ b/tools/log.c
@@ -62,19 +62,19 @@ _printf_format_(6, 0) static void log_kmod(void *data, int priority, const char 
 		return;
 
 	if (log_use_syslog) {
-#ifdef ENABLE_DEBUG
-		syslog(priority, "%s: %s:%d %s() %s", prioname, file, line, fn, str);
-#else
-		syslog(priority, "%s: %s", prioname, str);
-#endif
+		if (ENABLE_DEBUG == 1)
+			syslog(priority, "%s: %s:%d %s() %s", prioname, file, line, fn,
+			       str);
+		else
+			syslog(priority, "%s: %s", prioname, str);
 	} else {
-#ifdef ENABLE_DEBUG
-		fprintf(stderr, "%s: %s: %s:%d %s() %s", program_invocation_short_name,
-			prioname, file, line, fn, str);
-#else
-		fprintf(stderr, "%s: %s: %s", program_invocation_short_name, prioname,
-			str);
-#endif
+		if (ENABLE_DEBUG == 1)
+			fprintf(stderr, "%s: %s: %s:%d %s() %s",
+				program_invocation_short_name, prioname, file, line, fn,
+				str);
+		else
+			fprintf(stderr, "%s: %s: %s", program_invocation_short_name,
+				prioname, str);
 	}
 
 	free(str);


### PR DESCRIPTION
While looking at the ENABLE_ELFDBG I noticed that the meson build is a little broken wrt logging/debug. The first commit fixes that, while the others rework things to be a bit more sane IMHO.

Since the changes are somewhat opinionated, I left them separate. If we decide to have them, we should all together drop the first commit, since it's effectively undone with latter ones.

Still not 100% on board with the last one `ENABLE_ELFDBG`, but I'm adding it as a food for thought ... It cannot land as-is, hence the XXX.
 
---

Closes: https://github.com/kmod-project/kmod/issues/163 ... maybe