### PR TITLE
libkmod: Remove elf->changed

### DIFF
--- a/libkmod/libkmod-elf.c
+++ b/libkmod/libkmod-elf.c
@@ -564,12 +564,11 @@ int kmod_elf_get_modversions(const struct kmod_elf *elf, struct kmod_modversion 
 	return count;
 }
 
-static int elf_strip_section(const struct kmod_elf *elf, const char *section,
-			     uint8_t *changed)
+static int elf_strip_versions_section(const struct kmod_elf *elf, uint8_t *changed)
 {
 	uint64_t off, size;
 	const void *buf;
-	int idx = elf_find_section(elf, section);
+	int idx = elf_find_section(elf, "__versions");
 	uint64_t val;
 
 	if (idx < 0)
@@ -657,7 +656,7 @@ const void *kmod_elf_strip(const struct kmod_elf *elf, unsigned int flags)
 	ELFDBG(elf, "copied memory to allow writing.\n");
 
 	if (flags & KMOD_INSERT_FORCE_MODVERSION) {
-		err = elf_strip_section(elf, "__versions", changed);
+		err = elf_strip_versions_section(elf, changed);
 		if (err < 0)
 			goto fail;
 	}

--- a/libkmod/libkmod-internal.h
+++ b/libkmod/libkmod-internal.h
@@ -169,8 +169,7 @@ _must_check_ _nonnull_all_ int kmod_elf_get_strings(const struct kmod_elf *elf, 
 _must_check_ _nonnull_all_ int kmod_elf_get_modversions(const struct kmod_elf *elf, struct kmod_modversion **array);
 _must_check_ _nonnull_all_ int kmod_elf_get_symbols(const struct kmod_elf *elf, struct kmod_modversion **array);
 _must_check_ _nonnull_all_ int kmod_elf_get_dependency_symbols(const struct kmod_elf *elf, struct kmod_modversion **array);
-_must_check_ _nonnull_all_ int kmod_elf_strip_section(struct kmod_elf *elf, const char *section);
-_must_check_ _nonnull_all_ int kmod_elf_strip_vermagic(struct kmod_elf *elf);
+_must_check_ _nonnull_all_ const void *kmod_elf_strip(const struct kmod_elf *elf, unsigned int flags);
 
 /*
  * Debug mock lib need to find section ".gnu.linkonce.this_module" in order to


### PR DESCRIPTION
Keep changed ELF data only around as long as necessary. Otherwise it can happen that subsequent module operations lead to unintuitive results.

I've prepared a program which does the following:
1. Forcefully load a given module file
2. Try to load it without force if forcefully loading failed
3. Print version information

```
#include <err.h>
#include <libkmod.h>
#include <stdio.h>
#include <string.h>
#include <unistd.h>

int main(int argc, char *argv[])
{
        struct kmod_ctx *ctx;
        struct kmod_module *mod;
        struct kmod_list *l, *list;
        const char *null_config;
        int flags, res;

        if (argc != 2)
                errx(1, "usage: poc modfile");

        ctx = kmod_new(NULL, &null_config);
        if (ctx == NULL)
                err(1, "kmod_new");

        res = kmod_module_new_from_path(ctx, argv[1], &mod);
        if (res < 0)
                err(1, "kmod_module_new_from_path");

        puts("forcefully load");
        flags = 0;
        flags |= KMOD_PROBE_FORCE_MODVERSION;
        flags |= KMOD_PROBE_FORCE_VERMAGIC;
        res = kmod_module_insert_module(mod, flags, NULL);
        if (res < 0) {
                puts("try without force");
                flags = 0;
                res = kmod_module_insert_module(mod, flags, NULL);
                if (res < 0)
                        fputs("loading module failed\n", stderr);
        }

        res = kmod_module_get_info(mod, &list);
        if (err < 0)
                err(1, "kmod_module_get_info");

        kmod_list_foreach(l, list) {
                const char *key = kmod_module_info_get_key(l);
                const char *value = kmod_module_info_get_value(l);

                if (strcmp(key, "vermagic") == 0)
                        printf("%s=%s\n", key, value);
        }

        kmod_module_unref(mod);
        kmod_unref(ctx);
        return 0;
}
```

I have compiled a kernel with module versioning support, i.e. `CONFIG_MODVERSIONS=y` which can be found in main menu config under `Enable loadable module support` during kernel configuration. My kernel has no module compression, but libkmod is compiled with xz support. Also, forced module loading is disabled, i.e. `CONFIG_MODULE_FORCE_LOAD=n`.

After all that, I have copied the module ntfs3.ko (anyone works, as long as they have version information) to a temporary directory, and created a compressed version of it as well which my kernel does not understand.
```
MYDIR=$(mktemp -d)
cd $MYDIR
cp /lib/modules/$(uname -r)/kernel/fs/ntfs3/ntfs3.ko .
xz --keep ntfs3.ko
```

As an unprivileged user, I have run the following commands:
```
$ ./poc ntfs3.ko
forcefully load
try without force
loading module failed
vermagic=6.11.3 SMP preempt mod_unload modversions
$ ./poc ntfs3.ko.xz
forcefully load
try without force
loading module failed
```

As you can see, it makes a difference how this module file is processed. If it is native or compressed in a form which the kernel understands, the ELF memory content is never modified. If it is modified, it is never turned back to normal, i.e. the version information is lost no matter what's done afterwards.

You can see this impact when the program is run as root user:
```
# ./poc ntfs3.ko.xz
forcefully load
try without force
# rmmod ntfs3
# ./poc ntfs3.ko
forcefully load
try without force
vermagic=6.11.3 SMP preempt mod_unload modversions
```

In fact, both versions lead to a loaded module with version information, but only the latter keeps the information in its module. The former one overwrites the ELF content, even though ELF data with version information is loaded into kernel. How? Without force, it calls `kmod_file_get_contents` which is the unchanged ELF data, but later modinfo calls access `kmod_file_get_elf` which is modified.

TLDR: It's very unintuitive what happens in these scenarios, so properly drop modified memory after requiring it.