### PR TITLE
libkmod: Fail if ELF cannot be stripped

### DIFF
--- a/libkmod/libkmod-elf.c
+++ b/libkmod/libkmod-elf.c
@@ -573,7 +573,7 @@ static int elf_strip_versions_section(const struct kmod_elf *elf, uint8_t *chang
 	uint64_t val;
 
 	if (idx < 0)
-		return idx;
+		return idx == -ENODATA ? 0 : idx;
 
 	buf = elf_get_section_header(elf, idx);
 	off = (const uint8_t *)buf - elf->memory;
@@ -601,7 +601,7 @@ static int elf_strip_vermagic(const struct kmod_elf *elf, uint8_t *changed)
 
 	err = kmod_elf_get_section(elf, ".modinfo", &buf, &size);
 	if (err < 0)
-		return err;
+		return err == -ENODATA ? 0 : err;
 	strings = buf;
 	if (strings == NULL || size == 0)
 		return 0;
@@ -658,14 +658,18 @@ const void *kmod_elf_strip(const struct kmod_elf *elf, unsigned int flags)
 
 	if (flags & KMOD_INSERT_FORCE_MODVERSION) {
 		err = elf_strip_versions_section(elf, changed);
-		if (err < 0)
+		if (err < 0) {
+			errno = -err;
 			goto fail;
+		}
 	}
 
 	if (flags & KMOD_INSERT_FORCE_VERMAGIC) {
 		err = elf_strip_vermagic(elf, changed);
-		if (err < 0)
+		if (err < 0) {
+			errno = -err;
 			goto fail;
+		}
 	}
 
 	return changed;

--- a/libkmod/libkmod-module.c
+++ b/libkmod/libkmod-module.c
@@ -673,12 +673,11 @@ static int do_init_module(struct kmod_module *mod, unsigned int flags, const cha
 
 		stripped = kmod_elf_strip(elf, flags);
 		if (stripped == NULL) {
-			INFO(mod->ctx, "Failed to strip version information: %s\n",
-			     strerror(errno));
-			mem = kmod_elf_get_memory(elf);
-		} else {
-			mem = stripped;
+			ERR(mod->ctx, "Failed to strip version information: %s\n",
+			    strerror(errno));
+			return -errno;
 		}
+		mem = stripped;
 	} else {
 		err = kmod_file_load_contents(mod->file);
 		if (err)


### PR DESCRIPTION
Do not fall back to regular module operations.