### PR TITLE
Fix GCC sanitizer load ordering

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: test (meson)
         if: ${{ matrix.build == 'meson' }}
-        run: cd build && meson test
+        run: cd build && meson test || meson test --verbose
 
       - name: test (autotools)
         if: ${{ matrix.build == 'autotools' }}
@@ -123,4 +123,4 @@ jobs:
 
       - name: test (32bit) (meson)
         if: ${{ matrix.build == 'meson' && matrix.container.multilib == 'true' }}
-        run: cd build32 && meson test
+        run: cd build32 && meson test || meson test --verbose

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,6 @@ jobs:
           git config --global --add safe.directory '*'
 
           .github/print-kdir.sh >> "$GITHUB_ENV"
-          echo "ASAN_OPTIONS=verify_asan_link_order=0:halt_on_error=1:abort_on_error=1:print_summary=1" >> "$GITHUB_ENV"
 
       - name: configure (meson)
         if: ${{ matrix.build == 'meson' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,6 @@ jobs:
         build: ['meson', 'autotools']
         container:
           - name: 'ubuntu:22.04'
-            meson_setup: '-D b_sanitize=address,undefined'
             multilib: 'true'
           - name: 'ubuntu:24.04'
             meson_setup: '-D b_sanitize=address,undefined'

--- a/Makefile.am
+++ b/Makefile.am
@@ -24,6 +24,7 @@ EXTRA_DIST += \
 	testsuite/meson.build \
 	scripts/build-scdoc.sh \
 	scripts/test-gtkdoc.sh \
+	scripts/test-wrapper.sh \
 	scripts/kmod-symlink.sh
 
 AM_CPPFLAGS = \

--- a/meson.build
+++ b/meson.build
@@ -65,12 +65,6 @@ foreach tuple : _builtins
   cdata.set10('HAVE_@0@'.format(builtin.to_upper()), have)
 endforeach
 
-# Check for __GLIBC__ as short-cut for the LFS64 wrappers
-glibc = cc.has_header_symbol('features.h', '__GLIBC__')
-# XXX: once meson only, rename the define to something more sensible ...
-# NEED_64_WRAPPERS perhaps?
-cdata.set10('HAVE_DECL___GLIBC__', glibc)
-
 # dietlibc doesn't have st.st_mtim struct member
 # XXX: we use both st_mtim and st_mtime ... unify and test
 foreach tuple : [['struct stat', 'st_mtim', '#include <sys/stat.h>']]

--- a/meson.build
+++ b/meson.build
@@ -451,6 +451,7 @@ if get_option('build-tests')
   setup_modules = find_program('scripts/setup-modules.sh')
   setup_rootfs = find_program('scripts/setup-rootfs.sh')
   top_include = include_directories('.')
+  test_wrapper = find_program('scripts/test-wrapper.sh')
   subdir('testsuite')
 endif
 

--- a/scripts/test-wrapper.sh
+++ b/scripts/test-wrapper.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [[ ${ASAN_OPTIONS-} || ${UBSAN_OPTIONS-} || ${MSAN_OPTIONS-} ]]; then
+    ASAN_OPTIONS=verify_asan_link_order=0:halt_on_error=1:abort_on_error=1:print_summary=1
+    export ASAN_OPTIONS
+fi
+
+exec "$@"

--- a/scripts/test-wrapper.sh
+++ b/scripts/test-wrapper.sh
@@ -3,8 +3,14 @@
 set -euo pipefail
 
 if [[ ${ASAN_OPTIONS-} || ${UBSAN_OPTIONS-} || ${MSAN_OPTIONS-} ]]; then
-    ASAN_OPTIONS=verify_asan_link_order=0:halt_on_error=1:abort_on_error=1:print_summary=1
-    export ASAN_OPTIONS
+    LD_PRELOAD=$(gcc -print-file-name=libasan.so)
+    # In some cases, like in Fedora, the file is a script which cannot be
+    # preloaded. Attempt to extract the details from within.
+    if grep -q INPUT "$LD_PRELOAD"; then
+        input=$(sed -r -n "s/INPUT \( (.*) \)/\1/p" "$LD_PRELOAD")
+        test -f "$input" && LD_PRELOAD="$input"
+    fi
+    export LD_PRELOAD
 fi
 
 exec "$@"

--- a/testsuite/meson.build
+++ b/testsuite/meson.build
@@ -97,7 +97,8 @@ _testsuite = [
 foreach input : _testsuite
   test(
     input,
-    executable(
+    test_wrapper,
+    args : executable(
       input,
       files('@0@.c'.format(input)),
       include_directories : top_include,

--- a/testsuite/test-testsuite.c
+++ b/testsuite/test-testsuite.c
@@ -30,7 +30,7 @@ static noreturn int testsuite_uname(const struct test *t)
 		exit(EXIT_FAILURE);
 
 	if (!streq(u.release, TEST_UNAME)) {
-		char *ldpreload = getenv("LD_PRELOAD");
+		const char *ldpreload = getenv("LD_PRELOAD");
 		ERR("u.release=%s should be %s\n", u.release, TEST_UNAME);
 		ERR("LD_PRELOAD=%s\n", ldpreload);
 		exit(EXIT_FAILURE);

--- a/testsuite/testsuite.c
+++ b/testsuite/testsuite.c
@@ -161,8 +161,6 @@ static void test_export_environ(const struct test *t)
 	size_t i;
 	const struct keyval *env;
 
-	unsetenv("LD_PRELOAD");
-
 	for (i = 0; i < _TC_LAST; i++) {
 		const char *ldpreload;
 		size_t ldpreloadlen;
@@ -189,8 +187,27 @@ static void test_export_environ(const struct test *t)
 		preload[preloadlen] = '\0';
 	}
 
-	if (preload != NULL)
+	if (preload != NULL) {
+		const char *existing_preload = getenv("LD_PRELOAD");
+		if (existing_preload) {
+			char *tmp;
+			size_t len = strlen(existing_preload);
+
+			tmp = malloc(preloadlen + 2 + len);
+			if (tmp == NULL) {
+				ERR("oom: test_export_environ()\n");
+				return;
+			}
+			memcpy(tmp, existing_preload, len);
+			tmp[len++] = ' ';
+			memcpy(tmp + len, preload, preloadlen);
+			preloadlen += len;
+			tmp[preloadlen] = '\0';
+			free(preload);
+			preload = tmp;
+		}
 		setenv("LD_PRELOAD", preload, 1);
+	}
 
 	free(preload);
 


### PR DESCRIPTION
Split from https://github.com/kmod-project/kmod/pull/172

Adjust the testsuite to properly preserve LD_PRELOAD and swap the ASAN_OPTIONS workaround, with LD_PRELOAD based wrapper.

Thus devs can use the sanitizers locally with zero setup. This exact same approach will be reused for clang based sanitizers.