### PR TITLE
Clang all the warnings

### DIFF
--- a/shared/array.c
+++ b/shared/array.c
@@ -69,10 +69,14 @@ int array_append(struct array *array, const void *element)
 int array_append_unique(struct array *array, const void *element)
 {
 	void **itr = array->array;
-	void **itr_end = itr + array->count;
-	for (; itr < itr_end; itr++)
-		if (*itr == element)
-			return -EEXIST;
+
+	if (array->count != 0) {
+		void **itr_end = itr + array->count;
+
+		for (; itr < itr_end; itr++)
+			if (*itr == element)
+				return -EEXIST;
+	}
 	return array_append(array, element);
 }
 

--- a/shared/hash.c
+++ b/shared/hash.c
@@ -58,7 +58,7 @@ void hash_free(struct hash *hash)
 	bucket = hash->buckets;
 	bucket_end = bucket + hash->n_buckets;
 	for (; bucket < bucket_end; bucket++) {
-		if (hash->free_value) {
+		if (hash->free_value && bucket->used != 0) {
 			struct hash_entry *entry, *entry_end;
 			entry = bucket->entries;
 			entry_end = entry + bucket->used;

--- a/tools/depmod.c
+++ b/tools/depmod.c
@@ -1944,6 +1944,9 @@ static int depmod_calculate_dependencies(struct depmod *depmod)
 		sorted[n_sorted] = src_idx;
 		n_sorted++;
 
+		if (src->deps.count == 0)
+			continue;
+
 		itr_dst = (const struct mod **)src->deps.array;
 		itr_dst_end = itr_dst + src->deps.count;
 		for (; itr_dst < itr_dst_end; itr_dst++) {


### PR DESCRIPTION
Split from https://github.com/kmod-project/kmod/pull/172

Bunch of fixes reported by clang
 - some corner-case arguments handling (insmod, rmmod)
 - implementation specific signed/unsigned promotion
 - undefined behaviour - incompatible function type, adding zero to a NULL