### PR TITLE
modinfo: Fix OOB access and signed integer overflow

### DIFF
--- a/tools/modinfo.c
+++ b/tools/modinfo.c
@@ -34,14 +34,19 @@ struct param {
 	int typelen;
 };
 
-static struct param *add_param(const char *name, int namelen, const char *param,
-			       int paramlen, const char *type, int typelen,
+static struct param *add_param(const char *name, size_t namelen, const char *param,
+			       size_t paramlen, const char *type, size_t typelen,
 			       struct param **list)
 {
 	struct param *it;
 
+	if (namelen > INT_MAX || paramlen > INT_MAX || typelen > INT_MAX) {
+		errno = EINVAL;
+		return NULL;
+	}
+
 	for (it = *list; it != NULL; it = it->next) {
-		if (it->namelen == namelen && memcmp(it->name, name, namelen) == 0)
+		if (it->namelen == (int)namelen && memcmp(it->name, name, namelen) == 0)
 			break;
 	}
 
@@ -75,7 +80,7 @@ static struct param *add_param(const char *name, int namelen, const char *param,
 static int process_parm(const char *key, const char *value, struct param **params)
 {
 	const char *name, *param, *type;
-	int namelen, paramlen, typelen;
+	size_t namelen, paramlen, typelen;
 	struct param *it;
 	const char *colon = strchr(value, ':');
 	if (colon == NULL) {
@@ -99,7 +104,7 @@ static int process_parm(const char *key, const char *value, struct param **param
 
 	it = add_param(name, namelen, param, paramlen, type, typelen, params);
 	if (it == NULL) {
-		ERR("Out of memory!\n");
+		ERR("Unable to add parameter: %m\n");
 		return -ENOMEM;
 	}
 

--- a/tools/modinfo.c
+++ b/tools/modinfo.c
@@ -201,7 +201,7 @@ static int modinfo_do(struct kmod_module *mod)
 	kmod_list_foreach(l, list) {
 		const char *key = kmod_module_info_get_key(l);
 		const char *value = kmod_module_info_get_value(l);
-		int keylen;
+		size_t keylen;
 
 		if (field != NULL) {
 			if (!streq(field, key))
@@ -224,7 +224,9 @@ static int modinfo_do(struct kmod_module *mod)
 		}
 
 		keylen = strlen(key);
-		printf("%s:%-*s%s%c", key, 15 - keylen, "", value, separator);
+		if (keylen > 15)
+			keylen = 15;
+		printf("%s:%-*s%s%c", key, 15 - (int)keylen, "", value, separator);
 	}
 
 	if (field != NULL)


### PR DESCRIPTION
It is possible to triger undefined behavior with modinfo and kernel modules with strings longer than INT_MAX.

Proof of Concept:

1. Create a kernel module with two identical parameter strings longer than INT_MAX
```
echo > poc.ko.zstd.b64 << EOF
KLUv/WQMACUDABJEDxiwqTEsiruIPi2K8lIhjb2jCJoqNBGye6f/TB1mYU1BDE5VVRidKvgRDbx+
z7nWdnfXipGZqRTiKSHJ8QQRIFDDLN0DQBC7N9CK2wH5OMI/9ESNlRPG764EZThEvvkU3Qg7Px9Z
EOF
base64 -d poc.ko.zstd.b64 | zstd -d > poc.ko
(echo -n "parm="; dd if=/dev/zero bs=4096 count=524288 | tr '\0' A; echo -en ":B\x00") >> poc.ko
(echo -n "parm="; dd if=/dev/zero bs=4096 count=524288 | tr '\0' A; echo -en ":B\x00") >> poc.ko
```
2. Run modinfo
```
modinfo -p poc.ko
```

Crashes on my system due to OOB access. Alternatively, compile with address sanitizer.

The second commit fixes signed integer overflow. You can trigger it by modifying the previous command and replace `parm=` with `parmx` or anything else which will turn the parameter key into an arbitrary key. Run modinfo without `-p` then. I recommend to compile with `-fsanitize=undefined` to see the issue.