### PR TITLE
libkmod: Assist compiler in ELF parser optimization

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -86,7 +86,6 @@ AttributeMacros:
   - _nonnull_
   - _nonnull_all_
   - _printf_format_
-  - _unused_
   - noreturn
 
 IncludeBlocks: Preserve

--- a/libkmod/libkmod-elf.c
+++ b/libkmod/libkmod-elf.c
@@ -223,12 +223,12 @@ static inline int elf_get_section_info(const struct kmod_elf *elf, uint16_t idx,
 	elf_get_uint(elf, off + offsetof(typeof(*hdr), field), sizeof(hdr->field))
 
 	if (elf->class & KMOD_ELF_32) {
-		const Elf32_Shdr *hdr _unused_ = (const Elf32_Shdr *)p;
+		Elf32_Shdr *hdr;
 		*size = READV(sh_size);
 		*offset = READV(sh_offset);
 		*nameoff = READV(sh_name);
 	} else {
-		const Elf64_Shdr *hdr _unused_ = (const Elf64_Shdr *)p;
+		Elf64_Shdr *hdr;
 		*size = READV(sh_size);
 		*offset = READV(sh_offset);
 		*nameoff = READV(sh_name);
@@ -296,11 +296,11 @@ struct kmod_elf *kmod_elf_new(const void *memory, off_t size)
 	elf->header.strings.section = READV(e_shstrndx);     \
 	elf->header.machine = READV(e_machine)
 	if (elf->class & KMOD_ELF_32) {
-		const Elf32_Ehdr *hdr _unused_ = elf_get_mem(elf, 0);
+		Elf32_Ehdr *hdr;
 		LOAD_HEADER;
 		shdr_size = sizeof(Elf32_Shdr);
 	} else {
-		const Elf64_Ehdr *hdr _unused_ = elf_get_mem(elf, 0);
+		Elf64_Ehdr *hdr;
 		LOAD_HEADER;
 		shdr_size = sizeof(Elf64_Shdr);
 	}

--- a/shared/macro.h
+++ b/shared/macro.h
@@ -42,7 +42,6 @@
 
 #define _must_check_ __attribute__((warn_unused_result))
 #define _printf_format_(a, b) __attribute__((format(printf, a, b)))
-#define _unused_ __attribute__((unused))
 #define _always_inline_ __inline__ __attribute__((always_inline))
 #define _cleanup_(x) __attribute__((cleanup(x)))
 #define _nonnull_(...) __attribute__((nonnull(__VA_ARGS__)))


### PR DESCRIPTION
I have checked the resulting code of libkmod-elf.c on aarch64 and x86_64. Interestingly enough, the compilers clang and gcc  optimize rather poorly:

- On these little endian systems, `elf_get_uint` actually runs a for-loop instead of copying memory content
- Checking the content of `elf->class` is done with mask operation, which takes two instructions. Granted, clang is a bit better here

At least both compilers remove unused variable assignments in relation to `READV` macro usage. Let's remove them in code because they made it even harder for me at first reading to figure out what they are supposed to do.

There's much more we can do (see https://github.com/stoeckmann/kmod/tree/elf_performance for more details, which reduces runtime of `depmod` on a Raspberry Pi 3 by 2.5 % and library/binary sizes by same amount), but let's get this in step by step to not introduce any regressions.