### PR TITLE
depmod: Write index in pre-order

### DIFF
--- a/tools/depmod.c
+++ b/tools/depmod.c
@@ -384,7 +384,7 @@ static uint32_t index_calculate_size(struct index_node *node)
 static uint32_t index_write__node(const struct index_node *node, FILE *out,
 				  uint32_t offset)
 {
-	uint32_t *child_offs = NULL;
+	uint32_t child_offs[INDEX_CHILDMAX] = {};
 	int child_count = 0;
 
 	/* Calculate children offsets */
@@ -393,9 +393,6 @@ static uint32_t index_write__node(const struct index_node *node, FILE *out,
 		size_t sizes = 0;
 
 		child_count = node->last - node->first + 1;
-		child_offs = malloc(child_count * sizeof(uint32_t));
-		if (child_offs == NULL)
-			fatal_oom();
 
 		for (i = 0; i < child_count; i++) {
 			struct index_node *child;
@@ -423,8 +420,6 @@ static uint32_t index_write__node(const struct index_node *node, FILE *out,
 		fputc(node->last, out);
 		fwrite(child_offs, sizeof(uint32_t), child_count, out);
 	}
-
-	free(child_offs);
 
 	if (node->values) {
 		const struct index_value *v;


### PR DESCRIPTION
Index files in pre-order have a significant performance improvement for libkmod users.

On Arch Linux system, dumping configuration takes 296 read calls in pre-order, compared to 4080 in post-order. Tests on a Raspberry Pi 2 test system have shown an improvement by 9 %.

Even writing is faster now. This happens because we must know in advance how many bytes index nodes will consume in the resulting file. Although this code calculates it on the fly and caches the results, saving lseek system calls has a significant positive effect which compensates this extra overhead.

On Arch Linux system, writing index takes 6143 lseek calls now, compared to previous 83701, leading to a performance gain of 13 %.