### PR TITLE
libkmod: Use pread where appropriate

### DIFF
--- a/libkmod/libkmod-file.c
+++ b/libkmod/libkmod-file.c
@@ -95,8 +95,7 @@ struct kmod_file *kmod_file_open(const struct kmod_ctx *ctx, const char *filenam
 		return NULL;
 	}
 
-	sz = read_str_safe(file->fd, buf, sizeof(buf));
-	lseek(file->fd, 0, SEEK_SET);
+	sz = pread_str_safe(file->fd, buf, sizeof(buf), 0);
 	if (sz != (sizeof(buf) - 1)) {
 		if (sz < 0)
 			errno = -sz;

--- a/shared/util.h
+++ b/shared/util.h
@@ -35,6 +35,8 @@ _nonnull_all_ bool path_ends_with_kmod_ext(const char *path, size_t len);
 
 /* read-like and fread-like functions                                       */
 /* ************************************************************************ */
+_must_check_ _nonnull_(2) ssize_t pread_str_safe(int fd, char *buf, size_t buflen,
+						 off_t off);
 _must_check_ _nonnull_(2) ssize_t read_str_safe(int fd, char *buf, size_t buflen);
 _nonnull_(2) ssize_t write_str_safe(int fd, const char *buf, size_t buflen);
 _must_check_ _nonnull_(2) int read_str_long(int fd, long *value, int base);


### PR DESCRIPTION
Since we do not want to modify the current position in file, use pread instead of read + lseek. Removes one lseek call per module, which for depmod on Arch Linux means 6143 calls.