### PR TITLE
libkmod: Improve FILE based index performance

### DIFF
--- a/libkmod/libkmod-index.c
+++ b/libkmod/libkmod-index.c
@@ -183,7 +183,7 @@ static bool read_u32s(FILE *in, uint32_t *l, size_t n)
 	size_t i;
 
 	errno = 0;
-	if (fread(l, sizeof(uint32_t), n, in) != n) {
+	if (fread_unlocked(l, sizeof(uint32_t), n, in) != n) {
 		errno = EINVAL;
 		return false;
 	}


### PR DESCRIPTION
As discussed in https://github.com/kmod-project/kmod/issues/161 there are some tweaks we can apply to FILE based index access which have been done with memory-mapped version.

In total, this increases performance of a FILE based `modprobe -c` by 8 %, measured on a Raspberry Pi 2.