### PR TITLE
build: use cp instead of rsync

### DIFF
--- a/scripts/setup-modules.sh
+++ b/scripts/setup-modules.sh
@@ -8,7 +8,7 @@ MODULE_PLAYGROUND=$3
 
 # TODO: meson allows only out of tree builds
 if test "$SRCDIR" != "$BUILDDIR"; then
-    rsync --recursive --times "$SRCDIR/$MODULE_PLAYGROUND/" "$MODULE_PLAYGROUND/"
+    cp -a "$SRCDIR/$MODULE_PLAYGROUND/" "$MODULE_PLAYGROUND/"
 fi
 
 export MAKEFLAGS=${MAKEFLAGS-"-j$(nproc)"}


### PR DESCRIPTION
Having rsync as a build dependency is quite heavy.

@evelikov is there a strong reason to use rsync over cp here? I don't have it installed so running tests always involved modifying the script for me.