### PR TITLE
Swap rsync for cp --archive for module sources copying

### DIFF
--- a/.github/actions/setup-alpine/action.yml
+++ b/.github/actions/setup-alpine/action.yml
@@ -23,7 +23,6 @@ runs:
           linux-edge-dev \
           meson \
           openssl-dev \
-          rsync \
           scdoc \
           tar \
           xz-dev \

--- a/.github/actions/setup-archlinux/action.yml
+++ b/.github/actions/setup-archlinux/action.yml
@@ -24,5 +24,4 @@ runs:
           gtk-doc \
           linux-headers \
           meson \
-          rsync \
           scdoc

--- a/.github/actions/setup-debian/action.yml
+++ b/.github/actions/setup-debian/action.yml
@@ -25,7 +25,6 @@ runs:
           libzstd-dev \
           linux-headers-generic \
           meson \
-          rsync \
           scdoc \
           zlib1g-dev \
           zstd

--- a/.github/actions/setup-fedora/action.yml
+++ b/.github/actions/setup-fedora/action.yml
@@ -29,7 +29,6 @@ runs:
           make \
           meson \
           openssl-devel \
-          rsync \
           scdoc \
           xz-devel \
           zlib-devel

--- a/.github/actions/setup-ubuntu/action.yml
+++ b/.github/actions/setup-ubuntu/action.yml
@@ -25,7 +25,6 @@ runs:
           libzstd-dev \
           linux-headers-generic \
           meson \
-          rsync \
           scdoc \
           zlib1g-dev \
           zstd

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ Compilation and installation
 In order to compile the source code you need the following software packages:
 - GCC/CLANG compiler
 - GNU C library / musl / uClibc
-- rsync
 
 Optional dependencies:
 - ZLIB library

--- a/scripts/setup-modules.sh
+++ b/scripts/setup-modules.sh
@@ -8,7 +8,8 @@ MODULE_PLAYGROUND=$3
 
 # TODO: meson allows only out of tree builds
 if test "$SRCDIR" != "$BUILDDIR"; then
-    rsync --recursive --times "$SRCDIR/$MODULE_PLAYGROUND/" "$MODULE_PLAYGROUND/"
+    mkdir -p "$MODULE_PLAYGROUND"
+    cp --archive "$SRCDIR/$MODULE_PLAYGROUND/"* "$MODULE_PLAYGROUND/"
 fi
 
 export MAKEFLAGS=${MAKEFLAGS-"-j$(nproc)"}

--- a/testsuite/meson.build
+++ b/testsuite/meson.build
@@ -10,9 +10,11 @@ build_module_playground = custom_target(
     meson.project_build_root(),
     'testsuite/module-playground', # do not prepend source/build root
   ],
+  # The command ensures we don't do extra work, so the missing output token file
+  # and the build_always_stale true are intentional.
   output : 'bb-rootfs',
   console : true,
-  build_always_stale : true, # TODO: only when the playground has changed
+  build_always_stale : true,
   build_by_default : false,
 )
 


### PR DESCRIPTION
As Tobias reported, rsync is a bit of heavyweight dependency. We introduced it, as a replacement for the rm/cp -r previously used.

The rsync was inspired since, unlike make, meson will build all the test binaries/artefacts even without calling "meson test".

We can go back to cp with --archive (--preserve=timestamps at least), which will ensure we don't get stale files. To ensure the second run doesn't copy the source folder as _subfolder_ of the dest we need to wildcard the copy... Plus we need a proper destination folder in the first place.

With this, we get a no-op second+ builds - be that with meson or make. Since the explicit always-dirty state is by design, drop the meson TODO and document the output variable.

Confirmed by comparing both the `make --debug` output and the execution times.

Reported-by: Tobias Stoeckmann <tobias@stoeckmann.org>