### PR TITLE
depmod: Use shared/ more often

### DIFF
--- a/tools/depmod.c
+++ b/tools/depmod.c
@@ -1494,10 +1494,12 @@ static void depmod_modules_sort(struct depmod *depmod)
 		mod->sort_idx = i++;
 	}
 
-	array_sort(&depmod->modules, mod_cmp);
-	for (idx = 0; idx < depmod->modules.count; idx++) {
-		struct mod *m = depmod->modules.array[idx];
-		m->idx = idx;
+	if (depmod->modules.count > 1) {
+		array_sort(&depmod->modules, mod_cmp);
+		for (idx = 0; idx < depmod->modules.count; idx++) {
+			struct mod *m = depmod->modules.array[idx];
+			m->idx = idx;
+		}
 	}
 
 corrupted:


### PR DESCRIPTION
The dependency output code basically contained its own version of shared/array and shared/strbuf.

Use these implementations for easier code, smaller binary size and slightly faster runtime due to reusage of memory.