### PR TITLE
tools: getopt-log polish

### DIFF
--- a/tools/insmod.c
+++ b/tools/insmod.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #include <shared/util.h>
 
@@ -66,15 +67,11 @@ static int do_insmod(int argc, char *argv[])
 	size_t optslen = 0;
 	int verbose = LOG_ERR;
 	int use_syslog = 0;
-	int i, r = 0;
+	int i, c, r = 0;
 	const char *null_config = NULL;
 	unsigned int flags = 0;
 
-	for (;;) {
-		int c, idx = 0;
-		c = getopt_long(argc, argv, cmdopts_s, cmdopts, &idx);
-		if (c == -1)
-			break;
+	while ((c = getopt_long(argc, argv, cmdopts_s, cmdopts, NULL)) != -1) {
 		switch (c) {
 		case 'f':
 			flags |= KMOD_PROBE_FORCE_MODVERSION;

--- a/tools/lsmod.c
+++ b/tools/lsmod.c
@@ -45,13 +45,9 @@ static int do_lsmod(int argc, char *argv[])
 	struct kmod_list *list, *itr;
 	int verbose = LOG_ERR;
 	int use_syslog = 0;
-	int err, r = 0;
+	int err, c, r = 0;
 
-	for (;;) {
-		int c, idx = 0;
-		c = getopt_long(argc, argv, cmdopts_s, cmdopts, &idx);
-		if (c == -1)
-			break;
+	while ((c = getopt_long(argc, argv, cmdopts_s, cmdopts, NULL)) != -1) {
 		switch (c) {
 		case 's':
 			use_syslog = 1;

--- a/tools/rmmod.c
+++ b/tools/rmmod.c
@@ -96,13 +96,9 @@ static int do_rmmod(int argc, char *argv[])
 	int verbose = LOG_ERR;
 	int use_syslog = 0;
 	int flags = 0;
-	int i, r = 0;
+	int i, c, r = 0;
 
-	for (;;) {
-		int c, idx = 0;
-		c = getopt_long(argc, argv, cmdopts_s, cmdopts, &idx);
-		if (c == -1)
-			break;
+	while ((c = getopt_long(argc, argv, cmdopts_s, cmdopts, NULL)) != -1) {
 		switch (c) {
 		case 'f':
 			flags |= KMOD_REMOVE_FORCE;


### PR DESCRIPTION
Adjust the loop to follow the in-documentation example.

Namely, we don't need the unused idx and removing the seemingly
infinite loop helps static analysers better reason about the code flow.

---

Only insmod, lsmod and rmmod for now. The others will come at later date as I do through and document/deprecation/update the existing option handling.