### PR TITLE
libkmod: Refactor ELF parsing

### DIFF
--- a/libkmod/libkmod-elf.c
+++ b/libkmod/libkmod-elf.c
@@ -32,7 +32,7 @@ struct kmod_elf {
 	uint64_t size;
 	bool x32;
 	bool msb;
-	struct kmod_elf_header {
+	struct {
 		struct {
 			uint64_t offset;
 			uint16_t count;

--- a/libkmod/libkmod-elf.c
+++ b/libkmod/libkmod-elf.c
@@ -786,7 +786,7 @@ int kmod_elf_get_symbols(const struct kmod_elf *elf, struct kmod_modversion **ar
 	if (symtablen % symlen != 0) {
 		ELFDBG(elf,
 		       "unexpected .symtab of length %" PRIu64
-		       ", not multiple of %" PRIu64 " as expected.\n",
+		       ", not multiple of %zu as expected.\n",
 		       symtablen, symlen);
 		goto fallback;
 	}
@@ -812,8 +812,9 @@ int kmod_elf_get_symbols(const struct kmod_elf *elf, struct kmod_modversion **ar
 #undef READV
 		if (name_off >= strtablen) {
 			ELFDBG(elf,
-			       ".strtab is %" PRIu64 " bytes, but .symtab entry %" PRIu64
-			       " wants to access offset %" PRIu32 ".\n",
+			       ".strtab is %" PRIu64
+			       " bytes, but .symtab entry %zu wants to access offset %" PRIu32
+			       ".\n",
 			       strtablen, i, name_off);
 			goto fallback;
 		}
@@ -979,7 +980,7 @@ int kmod_elf_get_dependency_symbols(const struct kmod_elf *elf,
 	if (symtablen % symlen != 0) {
 		ELFDBG(elf,
 		       "unexpected .symtab of length %" PRIu64
-		       ", not multiple of %" PRIu64 " as expected.\n",
+		       ", not multiple of %zu as expected.\n",
 		       symtablen, symlen);
 		return -EINVAL;
 	}

--- a/libkmod/libkmod-elf.c
+++ b/libkmod/libkmod-elf.c
@@ -246,12 +246,6 @@ fail:
 	return -EINVAL;
 }
 
-static const char *elf_get_strings_section(const struct kmod_elf *elf, uint64_t *size)
-{
-	*size = elf->header.strings.size;
-	return elf_get_mem(elf, elf->header.strings.offset);
-}
-
 struct kmod_elf *kmod_elf_new(const void *memory, off_t size)
 {
 	struct kmod_elf *elf;
@@ -333,8 +327,8 @@ struct kmod_elf *kmod_elf_new(const void *memory, off_t size)
 		ELFDBG(elf, "could not get strings section\n");
 		goto invalid;
 	} else {
-		uint64_t slen;
-		const char *s = elf_get_strings_section(elf, &slen);
+		uint64_t slen = elf->header.strings.size;
+		const char *s = elf_get_mem(elf, elf->header.strings.offset);
 		if (slen == 0 || s[slen - 1] != '\0') {
 			ELFDBG(elf, "strings section does not end with \\0\n");
 			goto invalid;

--- a/libkmod/libkmod-elf.c
+++ b/libkmod/libkmod-elf.c
@@ -799,8 +799,8 @@ int kmod_elf_get_symbols(const struct kmod_elf *elf, struct kmod_modversion **ar
 	const void *strtab, *symtab;
 	struct kmod_modversion *a;
 	char *itr;
-	size_t slen, symlen;
-	int i, count, symcount, err;
+	size_t i, count, symcount, slen, symlen;
+	int err;
 
 	err = kmod_elf_get_section(elf, ".strtab", &strtab, &strtablen);
 	if (err < 0) {
@@ -848,9 +848,8 @@ int kmod_elf_get_symbols(const struct kmod_elf *elf, struct kmod_modversion **ar
 #undef READV
 		if (name_off >= strtablen) {
 			ELFDBG(elf,
-			       ".strtab is %" PRIu64
-			       " bytes, but .symtab entry %d wants to access offset %" PRIu32
-			       ".\n",
+			       ".strtab is %" PRIu64 " bytes, but .symtab entry %" PRIu64
+			       " wants to access offset %" PRIu32 ".\n",
 			       strtablen, i, name_off);
 			goto fallback;
 		}

--- a/libkmod/libkmod-elf.c
+++ b/libkmod/libkmod-elf.c
@@ -398,12 +398,10 @@ int kmod_elf_get_strings(const struct kmod_elf *elf, const char *section, char *
 	if (err < 0)
 		return err;
 
-	if (size == 0)
-		return 0;
 	strings = elf_get_mem(elf, off);
 
 	/* skip zero padding */
-	while (strings[0] == '\0' && size > 1) {
+	while (size > 1 && strings[0] == '\0') {
 		strings++;
 		size--;
 	}
@@ -567,12 +565,10 @@ static int elf_strip_vermagic(const struct kmod_elf *elf, uint8_t *changed)
 	err = kmod_elf_get_section(elf, ".modinfo", &sec_off, &size);
 	if (err < 0)
 		return err == -ENODATA ? 0 : err;
-	if (size == 0)
-		return 0;
 	strings = elf_get_mem(elf, sec_off);
 
 	/* skip zero padding */
-	while (strings[0] == '\0' && size > 1) {
+	while (size > 1 && strings[0] == '\0') {
 		strings++;
 		size--;
 	}
@@ -657,12 +653,10 @@ static int kmod_elf_get_symbols_symtab(const struct kmod_elf *elf,
 	err = kmod_elf_get_section(elf, "__ksymtab_strings", &off, &size);
 	if (err < 0)
 		return err;
-	if (size == 0)
-		return 0;
 	strings = elf_get_mem(elf, off);
 
 	/* skip zero padding */
-	while (strings[0] == '\0' && size > 1) {
+	while (size > 1 && strings[0] == '\0') {
 		strings++;
 		size--;
 	}

--- a/libkmod/libkmod-elf.c
+++ b/libkmod/libkmod-elf.c
@@ -450,7 +450,7 @@ int kmod_elf_get_strings(const struct kmod_elf *elf, const char *section, char *
 			continue;
 		}
 
-		while (strings[i] == '\0' && i < size)
+		while (i < size && s[i] == '\0')
 			i++;
 
 		a[j] = &s[i];

--- a/libkmod/libkmod-elf.c
+++ b/libkmod/libkmod-elf.c
@@ -212,6 +212,7 @@ static inline int elf_get_section_info(const struct kmod_elf *elf, uint16_t idx,
 
 	if (elf->x32) {
 		Elf32_Shdr *hdr;
+
 		if (!elf_range_valid(elf, off, sizeof(*hdr)))
 			goto fail;
 		*size = READV(sh_size);
@@ -219,6 +220,7 @@ static inline int elf_get_section_info(const struct kmod_elf *elf, uint16_t idx,
 		nameoff = READV(sh_name);
 	} else {
 		Elf64_Shdr *hdr;
+
 		if (!elf_range_valid(elf, off, sizeof(*hdr)))
 			goto fail;
 		*size = READV(sh_size);
@@ -289,12 +291,14 @@ struct kmod_elf *kmod_elf_new(const void *memory, off_t size)
 	elf->header.machine = READV(e_machine)
 	if (elf->x32) {
 		Elf32_Ehdr *hdr;
+
 		shdr_size = sizeof(Elf32_Shdr);
 		if (!elf_range_valid(elf, 0, shdr_size))
 			goto invalid;
 		LOAD_HEADER;
 	} else {
 		Elf64_Ehdr *hdr;
+
 		shdr_size = sizeof(Elf64_Shdr);
 		if (!elf_range_valid(elf, 0, shdr_size))
 			goto invalid;
@@ -804,9 +808,11 @@ int kmod_elf_get_symbols(const struct kmod_elf *elf, struct kmod_modversion **ar
 	elf_get_uint(elf, sym_off + offsetof(typeof(*s), field), sizeof(s->field))
 		if (elf->x32) {
 			Elf32_Sym *s;
+
 			name_off = READV(st_name);
 		} else {
 			Elf64_Sym *s;
+
 			name_off = READV(st_name);
 		}
 #undef READV
@@ -849,12 +855,14 @@ int kmod_elf_get_symbols(const struct kmod_elf *elf, struct kmod_modversion **ar
 	elf_get_uint(elf, sym_off + offsetof(typeof(*s), field), sizeof(s->field))
 		if (elf->x32) {
 			Elf32_Sym *s;
+
 			name_off = READV(st_name);
 			crc = READV(st_value);
 			info = READV(st_info);
 			shndx = READV(st_shndx);
 		} else {
 			Elf64_Sym *s;
+
 			name_off = READV(st_name);
 			crc = READV(st_value);
 			info = READV(st_info);
@@ -1022,11 +1030,13 @@ int kmod_elf_get_dependency_symbols(const struct kmod_elf *elf,
 	elf_get_uint(elf, sym_off + offsetof(typeof(*s), field), sizeof(s->field))
 		if (elf->x32) {
 			Elf32_Sym *s;
+
 			name_off = READV(st_name);
 			secidx = READV(st_shndx);
 			info = READV(st_info);
 		} else {
 			Elf64_Sym *s;
+
 			name_off = READV(st_name);
 			secidx = READV(st_shndx);
 			info = READV(st_info);
@@ -1119,11 +1129,13 @@ int kmod_elf_get_dependency_symbols(const struct kmod_elf *elf,
 	elf_get_uint(elf, sym_off + offsetof(typeof(*s), field), sizeof(s->field))
 		if (elf->x32) {
 			Elf32_Sym *s;
+
 			name_off = READV(st_name);
 			secidx = READV(st_shndx);
 			info = READV(st_info);
 		} else {
 			Elf64_Sym *s;
+
 			name_off = READV(st_name);
 			secidx = READV(st_shndx);
 			info = READV(st_info);

--- a/libkmod/libkmod-internal.h
+++ b/libkmod/libkmod-internal.h
@@ -161,7 +161,7 @@ _must_check_ _nonnull_all_ const void *kmod_elf_strip(const struct kmod_elf *elf
  * Debug mock lib need to find section ".gnu.linkonce.this_module" in order to
  * get modname
  */
-_must_check_ _nonnull_all_ int kmod_elf_get_section(const struct kmod_elf *elf, const char *section, const void **buf, uint64_t *buf_size);
+_must_check_ _nonnull_all_ int kmod_elf_get_section(const struct kmod_elf *elf, const char *section, uint64_t *sec_off, uint64_t *sec_size);
 
 /* libkmod-signature.c */
 struct kmod_signature_info {

--- a/testsuite/init_module.c
+++ b/testsuite/init_module.c
@@ -226,6 +226,7 @@ long init_module(void *mem, unsigned long len, const char *args)
 	struct kmod_elf *elf;
 	struct mod *mod;
 	const void *buf;
+	uint64_t off;
 	uint64_t bufsize;
 	int err;
 	uint8_t class;
@@ -237,7 +238,8 @@ long init_module(void *mem, unsigned long len, const char *args)
 	if (elf == NULL)
 		return 0;
 
-	err = kmod_elf_get_section(elf, ".gnu.linkonce.this_module", &buf, &bufsize);
+	err = kmod_elf_get_section(elf, ".gnu.linkonce.this_module", &off, &bufsize);
+	buf = (const char *)kmod_elf_get_memory(elf) + off;
 	kmod_elf_unref(elf);
 
 	/* We couldn't parse the ELF file. Just exit as if it was successful */


### PR DESCRIPTION
- Unify range checks in `elf_range_valid` and call it outside of loops or otherwise repeated calls to remove redundant runtime checks
- Perform better separations between offsets, pointers, and section index arithmetics.
This implies that no conversion from pointer to offset should be made, but from offset to pointer through `elf_get_mem`
- Handle section names directly as strings (do not just return offsets, which are converted to pointers, then strings)

Strips around 2-3 % (default settings, depending on arch and compiler) of binary and library sizes and has performance benefits of this margin as well. I keep this as side note since the refactoring for improved readability and easier auditing is more important.