### PR TITLE
Silence gtk-doc warnings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,9 @@ is wired to `meson test` to catch accidental mistakes or omissions.
 
 If you're unfamiliar with `gtk-doc` here is a [quick primer].
 
+When adding new API, make sure to include the `Since:` token and add a new
+api-index section in `libkmod/docs/libkmod-docs.xml`.
+
 ## Tools manual pages
 
 Our manual pages are written in [scdoc] a simple [markdown-like syntax]. Please

--- a/libkmod/docs/libkmod-docs.xml
+++ b/libkmod/docs/libkmod-docs.xml
@@ -24,4 +24,36 @@
     <title>API Index</title>
     <xi:include href="xml/api-index-full.xml"><xi:fallback /></xi:include>
   </index>
+  <chapter id="api-index-v1" role="1">
+    <title>Index of new symbols in 1</title>
+    <xi:include href="xml/api-index-1.xml"></xi:include>
+  </chapter>
+  <chapter id="api-index-v2" role="2">
+    <title>Index of new symbols in 2</title>
+    <xi:include href="xml/api-index-2.xml"></xi:include>
+  </chapter>
+  <chapter id="api-index-v3" role="3">
+    <title>Index of new symbols in 3</title>
+    <xi:include href="xml/api-index-3.xml"></xi:include>
+  </chapter>
+  <chapter id="api-index-v4" role="4">
+    <title>Index of new symbols in 4</title>
+    <xi:include href="xml/api-index-4.xml"></xi:include>
+  </chapter>
+  <chapter id="api-index-v6" role="6">
+    <title>Index of new symbols in 6</title>
+    <xi:include href="xml/api-index-6.xml"></xi:include>
+  </chapter>
+  <chapter id="api-index-v22" role="22">
+    <title>Index of new symbols in 22</title>
+    <xi:include href="xml/api-index-22.xml"></xi:include>
+  </chapter>
+  <chapter id="api-index-v30" role="30">
+    <title>Index of new symbols in 30</title>
+    <xi:include href="xml/api-index-30.xml"></xi:include>
+  </chapter>
+  <chapter id="api-index-v33" role="33">
+    <title>Index of new symbols in 33</title>
+    <xi:include href="xml/api-index-33.xml"></xi:include>
+  </chapter>
 </book>

--- a/libkmod/docs/libkmod-docs.xml
+++ b/libkmod/docs/libkmod-docs.xml
@@ -24,6 +24,10 @@
     <title>API Index</title>
     <xi:include href="xml/api-index-full.xml"><xi:fallback /></xi:include>
   </index>
+  <chapter id="deprecated-api-index" role="deprecated">
+    <title>Index of deprecated symbols</title>
+    <xi:include href="xml/api-index-deprecated.xml"></xi:include>
+  </chapter>
   <chapter id="api-index-v1" role="1">
     <title>Index of new symbols in 1</title>
     <xi:include href="xml/api-index-1.xml"></xi:include>

--- a/libkmod/libkmod.h
+++ b/libkmod/libkmod.h
@@ -946,6 +946,7 @@ int kmod_module_apply_filter(const struct kmod_ctx *ctx, enum kmod_filter filter
  * list.
  *
  * Since: 1
+ * Deprecated: 6: Use #kmod_module_apply_filter instead.
  */
 int kmod_module_get_filtered_blacklist(const struct kmod_ctx *ctx,
 				       const struct kmod_list *input,


### PR DESCRIPTION
This adds designated entries to the per-version indexes at the top-level html, alongside one for the deprecated symbol which is properly annotated.

The latter introduces a warning, since gtk-doc expects for deprecated symbols to be within an `#ifdef` guard. In hindsight that would have been good, but the ship has sailed.

Closes: https://github.com/kmod-project/kmod/issues/199

