### PR TITLE
libkmod: Improve memory-mapped index performance

### DIFF
--- a/libkmod/libkmod-index.c
+++ b/libkmod/libkmod-index.c
@@ -642,29 +642,29 @@ struct index_mm_node {
 	uint32_t children[];
 };
 
-static inline uint32_t read_u32_mm(void **p)
+static inline uint32_t read_u32_mm(const void **p)
 {
-	uint8_t *addr = *(uint8_t **)p;
+	const uint8_t *addr = *(const uint8_t **)p;
 	uint32_t v;
 
 	/* addr may be unalined to uint32_t */
-	v = get_unaligned((uint32_t *)addr);
+	v = get_unaligned((const uint32_t *)addr);
 
 	*p = addr + sizeof(uint32_t);
 	return ntohl(v);
 }
 
-static inline uint8_t read_char_mm(void **p)
+static inline uint8_t read_char_mm(const void **p)
 {
-	uint8_t *addr = *(uint8_t **)p;
+	const uint8_t *addr = *(const uint8_t **)p;
 	uint8_t v = *addr;
 	*p = addr + sizeof(uint8_t);
 	return v;
 }
 
-static inline char *read_chars_mm(void **p, size_t *rlen)
+static inline const char *read_chars_mm(const void **p, size_t *rlen)
 {
-	char *addr = *(char **)p;
+	const char *addr = *(const char **)p;
 	size_t len = *rlen = strlen(addr);
 	*p = addr + len + 1;
 	return addr;
@@ -672,7 +672,7 @@ static inline char *read_chars_mm(void **p, size_t *rlen)
 
 static struct index_mm_node *index_mm_read_node(struct index_mm *idx, uint32_t offset)
 {
-	void *p = idx->mm;
+	const void *p = idx->mm;
 	struct index_mm_node *node;
 	const char *prefix;
 	int i, child_count, value_count, children_padding;
@@ -682,7 +682,7 @@ static struct index_mm_node *index_mm_read_node(struct index_mm *idx, uint32_t o
 	if ((offset & INDEX_NODE_MASK) == 0 || (offset & INDEX_NODE_MASK) >= idx->size)
 		return NULL;
 
-	p = (char *)p + (offset & INDEX_NODE_MASK);
+	p = (const char *)p + (offset & INDEX_NODE_MASK);
 
 	if (offset & INDEX_NODE_PREFIX) {
 		size_t len;
@@ -761,7 +761,7 @@ int index_mm_open(const struct kmod_ctx *ctx, const char *filename,
 		uint32_t version;
 		uint32_t root_offset;
 	} hdr;
-	void *p;
+	const void *p;
 
 	assert(pidx != NULL);
 

--- a/libkmod/libkmod-index.c
+++ b/libkmod/libkmod-index.c
@@ -635,7 +635,7 @@ struct index_mm_value_array {
 
 struct index_mm_node {
 	struct index_mm *idx;
-	const char *prefix; /* mmape'd value */
+	const char *prefix; /* mmap'ed value */
 	struct index_mm_value_array values;
 	unsigned char first;
 	unsigned char last;
@@ -647,7 +647,7 @@ static inline uint32_t read_u32_mm(const void **p)
 	const uint8_t *addr = *(const uint8_t **)p;
 	uint32_t v;
 
-	/* addr may be unalined to uint32_t */
+	/* addr may be unaligned to uint32_t */
 	v = get_unaligned((const uint32_t *)addr);
 
 	*p = addr + sizeof(uint32_t);
@@ -945,7 +945,7 @@ static char *index_mm_search_node(struct index_mm_node *node, const char *key, i
  *
  * Returns the value of the first match
  *
- * The recursive functions free their node argument (using index_close).
+ * The recursive functions free their node argument (using index_mm_free_node).
  */
 char *index_mm_search(struct index_mm *idx, const char *key)
 {


### PR DESCRIPTION
Nodes (their child offsets and values) are copied from memory-mapped area into newly allocated heap memory. We can just store pointers into memory-mapped area in a struct. With such a fixed size struct, it's possible to keep it in stack, entirely removing the need to call malloc/free for each node.

This implies that values and child offsets must be parsed on the fly. This makes sense for search operations, because most likely, only one child offset will be followed. And most of the times, only the first value is of interest.

With such a reduced workload, `modprobe -c` is 3-4 % faster (measured on Raspberry Pi 3 and old x86_64 laptop).

A bit more details:

### master on x86_64:

- clang 19.1.2
```
   text    data     bss     dec     hex filename
 151511    5620     104  157235   26633 tools/kmod
  89249    1992       8   91249   16471 libkmod/.libs/libkmod.so.2.5.0
```

- gcc 14.2.0
```
   text    data     bss     dec     hex filename
 159530    5780     160  165470   2865e tools/kmod
  96212    2176       8   98396   1805c libkmod/.libs/libkmod.so.2.5.0
```

- Arch Linux with ~6000 modules: valgrind modprobe -c
```
HEAP SUMMARY:
    in use at exit: 0 bytes in 0 blocks
  total heap usage: 69,494 allocs, 69,494 frees, 5,125,499 bytes allocated
```

### branch on x86_64:

- clang 19.1.2
```
   text    data     bss     dec     hex filename
 152903    5620     104  158627   26ba3 tools/kmod
  90641    1992       8   92641   169e1 libkmod/.libs/libkmod.so.2.5.0
```

- gcc 14.2.0
```
   text    data     bss     dec     hex filename
 159450    5780     160  165390   2860e tools/kmod
  96132    2176       8   98316   1800c libkmod/.libs/libkmod.so.2.5.0
```

- Arch Linux with ~6000 modules: valgrind modprobe -c
```
HEAP SUMMARY:
    in use at exit: 0 bytes in 0 blocks
  total heap usage: 375 allocs, 375 frees, 156,459 bytes allocated
```

### Notes

The allocations do not scale with index entries anymore. On Arch Linux, this means that ~69,000 allocations have been removed. This mostly explains the 3-4 % performance gain.

You can see that the binary and library compiled with clang become larger. On investigation, I noticed that clang starts inlining `index_mm_read_node` now. It seems that, for whatever reason, this is supposed to be faster. If compiled with `-Os` it reduces the sizes from master to branch as expected.