### PR TITLE
tools: Unify module options handling

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -174,6 +174,8 @@ tools_kmod_SOURCES = \
 	tools/lsmod.c \
 	tools/modinfo.c \
 	tools/modprobe.c \
+	tools/opt.c \
+	tools/opt.h \
 	tools/rmmod.c \
 	tools/static-nodes.c
 

--- a/meson.build
+++ b/meson.build
@@ -397,6 +397,8 @@ kmod_sources = files(
   'tools/lsmod.c',
   'tools/modinfo.c',
   'tools/modprobe.c',
+  'tools/opt.c',
+  'tools/opt.h',
   'tools/rmmod.c',
   'tools/static-nodes.c',
 )

--- a/tools/insmod.c
+++ b/tools/insmod.c
@@ -64,10 +64,9 @@ static int do_insmod(int argc, char *argv[])
 	struct kmod_module *mod;
 	const char *filename;
 	char *opts = NULL;
-	size_t optslen = 0;
 	int verbose = LOG_ERR;
 	int use_syslog = 0;
-	int i, c, r = 0;
+	int c, r = 0;
 	const char *null_config = NULL;
 	unsigned int flags = 0;
 
@@ -112,23 +111,9 @@ static int do_insmod(int argc, char *argv[])
 		goto end;
 	}
 
-	for (i = optind + 1; i < argc; i++) {
-		size_t len = strlen(argv[i]);
-		void *tmp = realloc(opts, optslen + len + 2);
-		if (tmp == NULL) {
-			ERR("out of memory\n");
-			r = EXIT_FAILURE;
-			goto end;
-		}
-		opts = tmp;
-		if (optslen > 0) {
-			opts[optslen] = ' ';
-			optslen++;
-		}
-		memcpy(opts + optslen, argv[i], len);
-		optslen += len;
-		opts[optslen] = '\0';
-	}
+	r = options_from_array(argv + optind + 1, argc - optind - 1, &opts);
+	if (r < 0)
+		goto end;
 
 	ctx = kmod_new(NULL, &null_config);
 	if (!ctx) {

--- a/tools/kmod.h
+++ b/tools/kmod.h
@@ -34,3 +34,4 @@ static inline void kmod_version(void)
 }
 
 #include "log.h"
+#include "opt.h"

--- a/tools/modprobe.c
+++ b/tools/modprobe.c
@@ -953,7 +953,7 @@ static int do_modprobe(int argc, char **orig_argv)
 		err = insmod_all(ctx, args, nargs);
 	else {
 		char *opts;
-		err = options_from_array(args, nargs, &opts);
+		err = options_from_array(args + 1, nargs - 1, &opts);
 		if (err == 0) {
 			err = insmod(ctx, args[0], opts);
 			free(opts);

--- a/tools/modprobe.c
+++ b/tools/modprobe.c
@@ -679,62 +679,6 @@ static void env_modprobe_options_append(const char *value)
 	free(env);
 }
 
-static int options_from_array(char **args, int nargs, char **output)
-{
-	char *opts = NULL;
-	size_t optslen = 0;
-	int i, err = 0;
-
-	for (i = 1; i < nargs; i++) {
-		size_t len = strlen(args[i]);
-		size_t qlen = 0;
-		const char *value;
-		void *tmp;
-
-		value = strchr(args[i], '=');
-		if (value) {
-			value++;
-			if (*value != '"' && *value != '\'') {
-				if (strchr(value, ' '))
-					qlen = 2;
-			}
-		}
-
-		tmp = realloc(opts, optslen + len + qlen + 2);
-		if (!tmp) {
-			err = -errno;
-			free(opts);
-			opts = NULL;
-			ERR("could not gather module options: out-of-memory\n");
-			break;
-		}
-		opts = tmp;
-		if (optslen > 0) {
-			opts[optslen] = ' ';
-			optslen++;
-		}
-		if (qlen == 0) {
-			memcpy(opts + optslen, args[i], len + 1);
-			optslen += len;
-		} else {
-			size_t keylen = value - args[i];
-			size_t valuelen = len - keylen;
-			memcpy(opts + optslen, args[i], keylen);
-			optslen += keylen;
-			opts[optslen] = '"';
-			optslen++;
-			memcpy(opts + optslen, value, valuelen);
-			optslen += valuelen;
-			opts[optslen] = '"';
-			optslen++;
-			opts[optslen] = '\0';
-		}
-	}
-
-	*output = opts;
-	return err;
-}
-
 static char **prepend_options_from_env(int *p_argc, char **orig_argv)
 {
 	const char *p, *env = getenv("MODPROBE_OPTIONS");

--- a/tools/opt.c
+++ b/tools/opt.c
@@ -15,7 +15,7 @@ int options_from_array(char **args, int nargs, char **output)
 	size_t optslen = 0;
 	int i, err = 0;
 
-	for (i = 1; i < nargs; i++) {
+	for (i = 0; i < nargs; i++) {
 		size_t len = strlen(args[i]);
 		size_t qlen = 0;
 		const char *value;

--- a/tools/opt.c
+++ b/tools/opt.c
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (C) 2011-2013  ProFUSION embedded systems
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "kmod.h"
+
+int options_from_array(char **args, int nargs, char **output)
+{
+	char *opts = NULL;
+	size_t optslen = 0;
+	int i, err = 0;
+
+	for (i = 1; i < nargs; i++) {
+		size_t len = strlen(args[i]);
+		size_t qlen = 0;
+		const char *value;
+		void *tmp;
+
+		value = strchr(args[i], '=');
+		if (value) {
+			value++;
+			if (*value != '"' && *value != '\'') {
+				if (strchr(value, ' '))
+					qlen = 2;
+			}
+		}
+
+		tmp = realloc(opts, optslen + len + qlen + 2);
+		if (!tmp) {
+			err = -errno;
+			free(opts);
+			opts = NULL;
+			ERR("could not gather module options: out-of-memory\n");
+			break;
+		}
+		opts = tmp;
+		if (optslen > 0) {
+			opts[optslen] = ' ';
+			optslen++;
+		}
+		if (qlen == 0) {
+			memcpy(opts + optslen, args[i], len + 1);
+			optslen += len;
+		} else {
+			size_t keylen = value - args[i];
+			size_t valuelen = len - keylen;
+			memcpy(opts + optslen, args[i], keylen);
+			optslen += keylen;
+			opts[optslen] = '"';
+			optslen++;
+			memcpy(opts + optslen, value, valuelen);
+			optslen += valuelen;
+			opts[optslen] = '"';
+			optslen++;
+			opts[optslen] = '\0';
+		}
+	}
+
+	*output = opts;
+	return err;
+}

--- a/tools/opt.h
+++ b/tools/opt.h
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (C) 2011-2013  ProFUSION embedded systems
+ */
+
+int options_from_array(char **args, int nargs, char **output);


### PR DESCRIPTION
The tools insmod and modprobe take optional module options on command line, but treat them differently. While modprobe quotes values which contain spaces, insmod does not. This in turn means that spaces in quoted command line arguments turn into multiple module options with insmod.

Fix this by using the modprobe approach. While at it, refactor the code to use strbuf instead of manually allocating memory for better readability.

Proof of Concept:

1. Inspect modprobe
```
$ modprobe -nv ntfs3 "key=value with blanks" justkey
insmod /lib/modules/6.11.5/kernel/fs/ntfs3/ntfs3.ko key="value with blanks" justkey
```

2. Inspect shown insmod
```
$ strace -e finit_module insmod /lib/modules/6.11.5/kernel/fs/ntfs3/ntfs3.ko key="value with blanks" justkey
finit_module(3, "key=value with blanks justkey", 0) = -1 EPERM (Operation not permitted)
insmod: ERROR: could not insert module /lib/modules/6.11.5/kernel/fs/ntfs3/ntfs3.ko: Operation not permitted
+++ exited with 1 +++
```

You can see that 4 module options are supplied to `finit_module`.