### PR TITLE
scripts/kmod-symlink.sh: ignore prefix when provided absolute dir

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -186,6 +186,7 @@ features = []
 sysconfdir = get_option('sysconfdir')
 cdata.set_quoted('SYSCONFDIR', sysconfdir)
 
+bindir = join_paths(get_option('prefix'), get_option('bindir'))
 libdir = join_paths(get_option('prefix'), get_option('libdir'))
 
 distconfdir = get_option('distconfdir')
@@ -442,7 +443,7 @@ _tools = [
 kmod_symlink = find_program('scripts/kmod-symlink.sh')
 foreach tool : _tools
   if get_option('tools')
-    symlink = join_paths(get_option('bindir'), tool)
+    symlink = join_paths(bindir, tool)
     meson.add_install_script(kmod_symlink, symlink)
   endif
 endforeach
@@ -493,7 +494,7 @@ summary({
   'distconfdir' : distconfdir,
   'libdir'      : libdir,
   'includedir'  : join_paths(get_option('prefix'), get_option('includedir')),
-  'bindir'      : join_paths(get_option('prefix'), get_option('bindir')),
+  'bindir'      : bindir
 }, section : 'Directories')
 
 summary({

--- a/scripts/kmod-symlink.sh
+++ b/scripts/kmod-symlink.sh
@@ -7,4 +7,4 @@ set -euo pipefail
 #
 # For context read through https://github.com/mesonbuild/meson/issues/9
 
-ln -sf kmod "$MESON_INSTALL_DESTDIR_PREFIX/$1"
+ln -sf kmod "$DESTDIR/$1"


### PR DESCRIPTION
The end-user can provide either relative (to prefix) or an absolute directory for bindir. In case of the latter, we need to manually construct the path it seems.

---

Noticed this while trying to update the Gentoo ebuild. While they have migrated to merged /usr (+ bin/sbin) although split-usr is still an option. As the equivalent of `--prefix /usr --bindir /bin` is passed to meson.

In theory we could try and polish all environment variables so they don't add the prefix unless needed, although I'm inclined to deffer on as-needed basis. This includes the bindir listing on `meson setup`.