### PR TITLE
meson: Fix installing without DESTDIR

### DIFF
--- a/scripts/kmod-symlink.sh
+++ b/scripts/kmod-symlink.sh
@@ -7,4 +7,6 @@ set -euo pipefail
 #
 # For context read through https://github.com/mesonbuild/meson/issues/9
 
+DESTDIR=${DESTDIR:-/}
+
 ln -sf kmod "$DESTDIR/$1"


### PR DESCRIPTION
Script fails because of `set -u`. Make sure DESTDIR is set to something

Reported-by: Sedat Dilek <sedat.dilek@gmail.com>