### PR TITLE
Revert "libkmod: call fnmatch() only as needed"

### DIFF
--- a/libkmod/libkmod-index.c
+++ b/libkmod/libkmod-index.c
@@ -511,7 +511,7 @@ static void index_searchwild__all(struct index_node_f *node, int j, struct strbu
 		}
 	}
 
-	if (pushed && node->values) {
+	if (node->values) {
 		const char *s = strbuf_str(buf);
 
 		if (s != NULL && fnmatch(s, subkey, 0) == 0)
@@ -997,7 +997,7 @@ static void index_mm_searchwild_all(struct index_mm_node *node, int j, struct st
 		}
 	}
 
-	if (pushed && node->values.len > 0) {
+	if (node->values.len > 0) {
 		const char *s = strbuf_str(buf);
 
 		if (s != NULL && fnmatch(s, subkey, 0) == 0)


### PR DESCRIPTION
This reverts commit e79bba6b4af86216072b56382198da645a0906f4.

This broke alias resolution to more than one module. Example:

	kmod v33:
	$ modprobe -R char-major-116-1
	snd
	snd_seq

	e79bba6b4af86216072b56382198da645a0906f4:
	$ ./modprobe -R char-major-116-1
	snd

Closes: https://github.com/kmod-project/kmod/issues/207