### PR TITLE
Avoid copying elf symbol names, cache elf_get_section_info results

### DIFF
--- a/libkmod/libkmod-elf.c
+++ b/libkmod/libkmod-elf.c
@@ -383,7 +383,7 @@ int kmod_elf_get_section(const struct kmod_elf *elf, const char *section,
 }
 
 /* array will be allocated with strings in a single malloc, just free *array */
-int kmod_elf_get_strings(const struct kmod_elf *elf, const char *section, char ***array)
+int kmod_elf_get_modinfo_strings(const struct kmod_elf *elf, char ***array)
 {
 	size_t i, j, count;
 	size_t tmp_size, vec_size, total_size;
@@ -394,7 +394,7 @@ int kmod_elf_get_strings(const struct kmod_elf *elf, const char *section, char *
 
 	*array = NULL;
 
-	err = kmod_elf_get_section(elf, section, &off, &size);
+	err = kmod_elf_get_section(elf, ".modinfo", &off, &size);
 	if (err < 0)
 		return err;
 

--- a/libkmod/libkmod-internal.h
+++ b/libkmod/libkmod-internal.h
@@ -145,7 +145,7 @@ struct kmod_elf;
 struct kmod_modversion {
 	uint64_t crc;
 	enum kmod_symbol_bind bind;
-	char *symbol;
+	const char *symbol;
 };
 
 struct kmod_elf *kmod_elf_new(const void *memory, off_t size);

--- a/libkmod/libkmod-internal.h
+++ b/libkmod/libkmod-internal.h
@@ -151,7 +151,7 @@ struct kmod_modversion {
 struct kmod_elf *kmod_elf_new(const void *memory, off_t size);
 _nonnull_all_ void kmod_elf_unref(struct kmod_elf *elf);
 _must_check_ _nonnull_all_ const void *kmod_elf_get_memory(const struct kmod_elf *elf);
-_must_check_ _nonnull_all_ int kmod_elf_get_strings(const struct kmod_elf *elf, const char *section, char ***array);
+_must_check_ _nonnull_all_ int kmod_elf_get_modinfo_strings(const struct kmod_elf *elf, char ***array);
 _must_check_ _nonnull_all_ int kmod_elf_get_modversions(const struct kmod_elf *elf, struct kmod_modversion **array);
 _must_check_ _nonnull_all_ int kmod_elf_get_symbols(const struct kmod_elf *elf, struct kmod_modversion **array);
 _must_check_ _nonnull_all_ int kmod_elf_get_dependency_symbols(const struct kmod_elf *elf, struct kmod_modversion **array);

--- a/libkmod/libkmod-module.c
+++ b/libkmod/libkmod-module.c
@@ -1875,7 +1875,7 @@ KMOD_EXPORT int kmod_module_get_info(const struct kmod_module *mod,
 		if (elf == NULL)
 			return -errno;
 
-		count = kmod_elf_get_strings(elf, ".modinfo", &strings);
+		count = kmod_elf_get_modinfo_strings(elf, &strings);
 		if (count < 0)
 			return count;
 	}


### PR DESCRIPTION
Couple of tiny tweaks, which shave a ~4MB of memory and ~5% CPU cycles off a depmod run, although the actual perf difference is within the noise margin.

Grab whichever commit make sense.

OOC: any ideas when all `.strtab` started getting only `__crc_` symbols? Going back to ~2011 and it seems to have always been the case.