### PR TITLE
libkmod: Some cleanups

### DIFF
--- a/libkmod/libkmod-elf.c
+++ b/libkmod/libkmod-elf.c
@@ -251,7 +251,6 @@ fail:
 struct kmod_elf *kmod_elf_new(const void *memory, off_t size)
 {
 	struct kmod_elf *elf;
-	uint64_t min_size;
 	size_t shdrs_size, shdr_size;
 	int err;
 	const char *name;
@@ -319,11 +318,8 @@ struct kmod_elf *kmod_elf_new(const void *memory, off_t size)
 		goto invalid;
 	}
 	shdrs_size = shdr_size * elf->header.section.count;
-	if (uadd64_overflow(shdrs_size, elf->header.section.offset, &min_size) ||
-	    min_size > elf->size) {
-		ELFDBG(elf, "file is too short to hold sections\n");
+	if (!elf_range_valid(elf, elf->header.section.offset, shdrs_size))
 		goto invalid;
-	}
 
 	if (elf_get_section_info(elf, elf->header.strings.section,
 				 &elf->header.strings.offset, &elf->header.strings.size,

--- a/libkmod/libkmod-internal.h
+++ b/libkmod/libkmod-internal.h
@@ -122,7 +122,7 @@ _nonnull_all_ const char * const *kmod_weakdep_get_weak(const struct kmod_list *
 
 /* libkmod-module.c */
 int kmod_module_new_from_alias(struct kmod_ctx *ctx, const char *alias, const char *name, struct kmod_module **mod);
-_nonnull_all_ int kmod_module_parse_depline(struct kmod_module *mod, char *line);
+_nonnull_all_ void kmod_module_parse_depline(struct kmod_module *mod, char *line);
 _nonnull_(1) void kmod_module_set_install_commands(struct kmod_module *mod, const char *cmd);
 _nonnull_(1) void kmod_module_set_remove_commands(struct kmod_module *mod, const char *cmd);
 _nonnull_(1)void kmod_module_set_visited(struct kmod_module *mod, bool visited);

--- a/libkmod/libkmod-module.c
+++ b/libkmod/libkmod-module.c
@@ -291,7 +291,6 @@ KMOD_EXPORT int kmod_module_new_from_name(struct kmod_ctx *ctx, const char *name
 int kmod_module_new_from_alias(struct kmod_ctx *ctx, const char *alias, const char *name,
 			       struct kmod_module **mod)
 {
-	int err;
 	char key[PATH_MAX];
 	size_t namelen = strlen(name);
 	size_t aliaslen = strlen(alias);
@@ -303,11 +302,7 @@ int kmod_module_new_from_alias(struct kmod_ctx *ctx, const char *alias, const ch
 	memcpy(key + namelen + 1, alias, aliaslen + 1);
 	key[namelen] = '\\';
 
-	err = kmod_module_new(ctx, key, name, namelen, alias, aliaslen, mod);
-	if (err < 0)
-		return err;
-
-	return 0;
+	return kmod_module_new(ctx, key, name, namelen, alias, aliaslen, mod);
 }
 
 KMOD_EXPORT int kmod_module_new_from_path(struct kmod_ctx *ctx, const char *path,

--- a/libkmod/libkmod-module.c
+++ b/libkmod/libkmod-module.c
@@ -146,6 +146,7 @@ void kmod_module_parse_depline(struct kmod_module *mod, char *line)
 	p++;
 	for (p = strtok_r(p, " \t", &saveptr); p != NULL;
 	     p = strtok_r(NULL, " \t", &saveptr)) {
+		struct kmod_list *l_new;
 		struct kmod_module *depmod = NULL;
 		const char *path;
 		int err;
@@ -164,7 +165,12 @@ void kmod_module_parse_depline(struct kmod_module *mod, char *line)
 
 		DBG(ctx, "add dep: %s\n", path);
 
-		list = kmod_list_prepend(list, depmod);
+		l_new = kmod_list_prepend(list, depmod);
+		if (l_new == NULL) {
+			ERR(ctx, "could not add dependency for %s\n", mod->name);
+			goto fail;
+		}
+		list = l_new;
 	}
 
 	DBG(ctx, "%zu dependencies for %s\n", n, mod->name);

--- a/libkmod/libkmod-module.c
+++ b/libkmod/libkmod-module.c
@@ -506,14 +506,14 @@ KMOD_EXPORT int kmod_module_get_filtered_blacklist(const struct kmod_ctx *ctx,
 	return kmod_module_apply_filter(ctx, KMOD_FILTER_BLACKLIST, input, output);
 }
 
-static void module_get_dependencies_noref(const struct kmod_module *mod)
+static void module_get_dependencies_noref(struct kmod_module *mod)
 {
 	if (!mod->init.dep) {
 		/* lazy init */
 		char *line = kmod_search_moddep(mod->ctx, mod->name);
 
 		if (line != NULL) {
-			kmod_module_parse_depline((struct kmod_module *)mod, line);
+			kmod_module_parse_depline(mod, line);
 			free(line);
 		}
 	}
@@ -526,7 +526,7 @@ KMOD_EXPORT struct kmod_list *kmod_module_get_dependencies(const struct kmod_mod
 	if (mod == NULL)
 		return NULL;
 
-	module_get_dependencies_noref(mod);
+	module_get_dependencies_noref((struct kmod_module *)mod);
 
 	kmod_list_foreach(l, mod->dep) {
 		l_new = kmod_list_append(list_new, kmod_module_ref(l->data));
@@ -575,7 +575,7 @@ KMOD_EXPORT const char *kmod_module_get_path(const struct kmod_module *mod)
 		return NULL;
 
 	/* lazy init */
-	module_get_dependencies_noref(mod);
+	module_get_dependencies_noref((struct kmod_module *)mod);
 
 	return mod->path;
 }

--- a/libkmod/libkmod-module.c
+++ b/libkmod/libkmod-module.c
@@ -573,8 +573,6 @@ KMOD_EXPORT const char *kmod_module_get_name(const struct kmod_module *mod)
 
 KMOD_EXPORT const char *kmod_module_get_path(const struct kmod_module *mod)
 {
-	char *line;
-
 	if (mod == NULL)
 		return NULL;
 
@@ -586,12 +584,7 @@ KMOD_EXPORT const char *kmod_module_get_path(const struct kmod_module *mod)
 		return NULL;
 
 	/* lazy init */
-	line = kmod_search_moddep(mod->ctx, mod->name);
-	if (line == NULL)
-		return NULL;
-
-	kmod_module_parse_depline((struct kmod_module *)mod, line);
-	free(line);
+	module_get_dependencies_noref(mod);
 
 	return mod->path;
 }

--- a/libkmod/libkmod.h
+++ b/libkmod/libkmod.h
@@ -641,7 +641,7 @@ int kmod_module_new_from_name(struct kmod_ctx *ctx, const char *name,
  * @mod: where to save the created struct kmod_module
  *
  * Create a new struct kmod_module using the module path. @path must be an
- * existent file with in the filesystem and must be accessible to libkmod.
+ * existent file within the filesystem and must be accessible to libkmod.
  *
  * The initial refcount is 1, and needs to be decremented to release the
  * resources of the kmod_module. Since libkmod keeps track of all


### PR DESCRIPTION
Collection of small cleanups gathered during the last weeks which did not properly fit into other PRs.

Mostly about code deduplication, removal of unused return values, and better error handling.