### PR TITLE
meson: align default distconfdir with autotools

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -199,9 +199,9 @@ zshcompletiondir = get_option('zshcompletiondir')
 cdata.set_quoted('SYSCONFDIR', sysconfdir)
 
 _customdirs = [
-  ['distconfdir', libdir,         'DISTCONFDIR'],
-  # The default moduledir is hard-coded due to historical reasons
-  ['moduledir',   '/lib/modules', 'MODULE_DIRECTORY'],
+  # The defaults are hard-coded due to historical reasons
+  ['distconfdir', prefixdir / 'lib',  'DISTCONFDIR'],
+  ['moduledir',   '/lib/modules',     'MODULE_DIRECTORY'],
 ]
 
 foreach tuple : _customdirs


### PR DESCRIPTION
Autotools uses $prefix/lib as the default for distconfdir, while meson $libdir - which is not guaranteed to be the same.

In particular: Debian and derivatives use /usr/lib/$target-triplet as a $libdir, while still keep the configuration directory as /usr/lib.

Fixes: 370141c1 ("meson: introduce meson, covering libkmod.so")
Reported-by: Marco d'Itri <md@linux.it>