### PR TITLE
meson: don't escape module_foo in kmod.pc

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -446,19 +446,25 @@ _kmod_variables = [
   'sysconfdir=' + sysconfdir,
   'distconfdir=' + distconfdir,
   'module_directory=' + moduledir,
+]
+
+# Don't (space) escape variables with space-separated lists, for consistency
+# with the autotools build.
+_kmod_unescaped_variables = [
   'module_signatures=' + module_signatures,
 ]
 
 # XXX: Support for empty variables was added in meson v1.4.0.
 # pkgconf behaves identically on missing and empty variable.
 if module_compressions != ''
-  _kmod_variables += ['module_compressions=' + module_compressions]
+  _kmod_unescaped_variables += ['module_compressions=' + module_compressions]
 endif
 
 pkg.generate(
   name : 'kmod',
   description : 'Tools to deal with kernel modules',
   install_dir : datadir / 'pkgconfig',
+  unescaped_variables : _kmod_unescaped_variables,
   variables : _kmod_variables,
 )
 


### PR DESCRIPTION
The kmod.pc file, contains module_signatures and module_compressions space-separated lists, indicating how kmod is built. For the meson generated file, any spaces are escaped where the autotools one does not do that.

Update the meson build to be consistent with the original autotools one and omit the escaping that we don't want.

Aside: seems like autotools does not escape the directory variables either, so if the path(s) have any spaces in them pkg-config (pkgconf at least) produces rubbish, quite rightfully IMHO.

Eg.
  $ cat .../autotools-file.pc
  prefix=/usr
  includedir=${prefix}/include bar
  Cflags: -I${includedir}
  ...
  $ pkg-config --cflags autotools-file.pc
  bar

  $ cat .../meson-file.pc
  prefix=/usr
  includedir=${prefix}/include\ bar
  Cflags: -I${includedir}
  ...
  $ pkg-config --cflags meson-file.pc
  -I/usr/include\ bar