### PR TITLE
Re-enable sanitizer on Fedora

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,6 @@ jobs:
           - name: 'debian:unstable'
             multilib: 'true'
           - name: 'fedora:latest'
-            meson_setup: '-D b_sanitize=none'
           - name: 'ubuntu:22.04'
             multilib: 'true'
           - name: 'ubuntu:24.04'

--- a/scripts/sanitizer-env.sh
+++ b/scripts/sanitizer-env.sh
@@ -7,9 +7,12 @@ if [[ ${CC-} == *gcc* ]]; then
 elif [[ ${CC-} == *clang* ]]; then
     OUR_PRELOAD=$("$CC" -print-file-name=libclang_rt.asan-x86_64.so)
 else
-    echo "Unknown compiler CC=\"${CC-}\" - gcc and clang are supported."
-    echo "Assuming \"gcc\", manually set the variable and retry if needed."
-    echo
+    cat <<- EOF
+
+    Unknown compiler CC="${CC-}" - gcc and clang are supported.
+    Assuming "gcc", manually set the variable and retry if needed.
+
+EOF
     OUR_PRELOAD=$(gcc -print-file-name=libasan.so)
 fi
 
@@ -23,7 +26,11 @@ if test -n "$OUR_PRELOAD"; then
 
     LD_PRELOAD=${LD_PRELOAD+${LD_PRELOAD}:}$OUR_PRELOAD
     export LD_PRELOAD
-    echo "LD_PRELOAD has been set to \"$LD_PRELOAD\"."
-    echo "The sanitizer might report issues with ANY process you execute."
+    cat <<- EOF
+
+    LD_PRELOAD has been set to "$LD_PRELOAD".
+    The sanitizer might report issues with ANY process you execute.
+
+EOF
 fi
 unset OUR_PRELOAD

--- a/scripts/sanitizer-env.sh
+++ b/scripts/sanitizer-env.sh
@@ -16,7 +16,7 @@ EOF
     OUR_PRELOAD=$(gcc -print-file-name=libasan.so)
 fi
 
-if test -n "$OUR_PRELOAD"; then
+if test -f "$OUR_PRELOAD"; then
     # In some cases, like in Fedora, the file is a script which cannot be
     # preloaded. Attempt to extract the details from within.
     if grep -q INPUT "$OUR_PRELOAD"; then
@@ -30,6 +30,17 @@ if test -n "$OUR_PRELOAD"; then
 
     LD_PRELOAD has been set to "$LD_PRELOAD".
     The sanitizer might report issues with ANY process you execute.
+
+EOF
+else
+    cat <<- EOF >&2
+
+    WARNING: compiler returned non-existing library name "$OUR_PRELOAD".
+
+    Make sure to install the relevant packages and ensure this script
+    references the correct library name.
+
+    LD_PRELOAD will NOT be set.
 
 EOF
 fi

--- a/scripts/sanitizer-env.sh
+++ b/scripts/sanitizer-env.sh
@@ -5,7 +5,11 @@
 if [[ ${CC-} == *gcc* ]]; then
     OUR_PRELOAD=$("$CC" -print-file-name=libasan.so)
 elif [[ ${CC-} == *clang* ]]; then
-    OUR_PRELOAD=$("$CC" -print-file-name=libclang_rt.asan-x86_64.so)
+    # With v19, the library lacks the CPU arch in its name
+    OUR_PRELOAD=$("$CC" -print-file-name=libclang_rt.asan.so)
+    if ! test -f "$OUR_PRELOAD"; then
+       OUR_PRELOAD=$("$CC" -print-file-name=libclang_rt.asan-x86_64.so)
+    fi
 else
     cat <<- EOF >&2
 

--- a/scripts/sanitizer-env.sh
+++ b/scripts/sanitizer-env.sh
@@ -7,9 +7,9 @@ if [[ ${CC-} == *gcc* ]]; then
 elif [[ ${CC-} == *clang* ]]; then
     OUR_PRELOAD=$("$CC" -print-file-name=libclang_rt.asan-x86_64.so)
 else
-    cat <<- EOF
+    cat <<- EOF >&2
 
-    Unknown compiler CC="${CC-}" - gcc and clang are supported.
+    WARNING: Unknown compiler CC="${CC-}" - gcc and clang are supported.
     Assuming "gcc", manually set the variable and retry if needed.
 
 EOF


### PR DESCRIPTION
Fedora 41 is out :partying_face: 

Being the first distro to ship clang 19, this time with actual sanitizer DSO for us to use :tada:. The filename has been changed and seemingly that went undocumented :facepalm:

With a tweak to the name + fallback for everyone else - things just work.

In before anyone asks: Why do we bother with checking for gcc vs clang, instead of just doing the `test -f` trick?

The `gcc` DSO usually lives within `$libdir`, thus is found, but not used, by `clang`. That may change in the future, plus there is no guarantee that the `clang` one won't be moved to `$libdir` at some point. 