### PR TITLE
Index bugfix and papercuts

### DIFF
--- a/libkmod/libkmod-index.c
+++ b/libkmod/libkmod-index.c
@@ -613,7 +613,7 @@ struct index_mm_value {
 };
 
 struct index_mm_node {
-	struct index_mm *idx;
+	const struct index_mm *idx;
 	const char *prefix; /* mmap'ed value */
 	unsigned char first;
 	unsigned char last;
@@ -657,7 +657,8 @@ static inline void read_value_mm(const void **p, struct index_mm_value *v)
 }
 
 /* reads node into given node struct and returns its address on success or NULL on error. */
-static struct index_mm_node *index_mm_read_node(struct index_mm *idx, uint32_t offset,
+static struct index_mm_node *index_mm_read_node(const struct index_mm *idx,
+						uint32_t offset,
 						struct index_mm_node *node)
 {
 	const void *p;
@@ -797,7 +798,7 @@ void index_mm_close(struct index_mm *idx)
 	free(idx);
 }
 
-static struct index_mm_node *index_mm_readroot(struct index_mm *idx,
+static struct index_mm_node *index_mm_readroot(const struct index_mm *idx,
 					       struct index_mm_node *root)
 {
 	return index_mm_read_node(idx, idx->root_offset, root);
@@ -854,7 +855,7 @@ static void index_mm_dump_node(struct index_mm_node *node, struct strbuf *buf, i
 	strbuf_popchars(buf, pushed);
 }
 
-void index_mm_dump(struct index_mm *idx, int fd, bool alias_prefix)
+void index_mm_dump(const struct index_mm *idx, int fd, bool alias_prefix)
 {
 	struct index_mm_node nbuf, *root;
 	struct strbuf buf;
@@ -911,7 +912,7 @@ static char *index_mm_search_node(struct index_mm_node *node, const char *key)
  *
  * Returns the value of the first match
  */
-char *index_mm_search(struct index_mm *idx, const char *key)
+char *index_mm_search(const struct index_mm *idx, const char *key)
 {
 	// FIXME: return value by reference instead of strdup
 	struct index_mm_node nbuf, *root;
@@ -1035,7 +1036,7 @@ static void index_mm_searchwild_node(struct index_mm_node *node, struct strbuf *
  *
  * Returns a list of all the values of matching keys.
  */
-struct index_value *index_mm_searchwild(struct index_mm *idx, const char *key)
+struct index_value *index_mm_searchwild(const struct index_mm *idx, const char *key)
 {
 	struct index_mm_node nbuf, *root;
 	struct strbuf buf;

--- a/libkmod/libkmod-index.c
+++ b/libkmod/libkmod-index.c
@@ -599,8 +599,6 @@ struct index_value *index_searchwild(struct index_file *in, const char *key)
 #include <sys/stat.h>
 #include <unistd.h>
 
-static const char _idx_empty_str[] = "";
-
 struct index_mm {
 	const struct kmod_ctx *ctx;
 	void *mm;
@@ -673,7 +671,7 @@ static struct index_mm_node *index_mm_read_node(struct index_mm *idx, uint32_t o
 		size_t len;
 		node->prefix = read_chars_mm(&p, &len);
 	} else {
-		node->prefix = _idx_empty_str;
+		node->prefix = "";
 	}
 
 	if (offset & INDEX_NODE_CHILDS) {

--- a/libkmod/libkmod-index.c
+++ b/libkmod/libkmod-index.c
@@ -391,7 +391,7 @@ static void index_dump_node(struct index_node_f *node, struct strbuf *buf, int f
 	index_close(node);
 }
 
-void index_dump(struct index_file *in, int fd, const char *prefix)
+void index_dump(struct index_file *in, int fd, bool alias_prefix)
 {
 	struct index_node_f *root;
 	struct strbuf buf;
@@ -401,7 +401,7 @@ void index_dump(struct index_file *in, int fd, const char *prefix)
 		return;
 
 	strbuf_init(&buf);
-	if (prefix[0] == '\0' || strbuf_pushchars(&buf, prefix))
+	if (!alias_prefix || strbuf_pushchars(&buf, "alias "))
 		index_dump_node(root, &buf, fd);
 	strbuf_release(&buf);
 }
@@ -856,7 +856,7 @@ static void index_mm_dump_node(struct index_mm_node *node, struct strbuf *buf, i
 	strbuf_popchars(buf, pushed);
 }
 
-void index_mm_dump(struct index_mm *idx, int fd, const char *prefix)
+void index_mm_dump(struct index_mm *idx, int fd, bool alias_prefix)
 {
 	struct index_mm_node nbuf, *root;
 	struct strbuf buf;
@@ -866,7 +866,7 @@ void index_mm_dump(struct index_mm *idx, int fd, const char *prefix)
 		return;
 
 	strbuf_init(&buf);
-	if (prefix[0] == '\0' || strbuf_pushchars(&buf, prefix))
+	if (!alias_prefix || strbuf_pushchars(&buf, "alias "))
 		index_mm_dump_node(root, &buf, fd);
 	strbuf_release(&buf);
 }

--- a/libkmod/libkmod-index.c
+++ b/libkmod/libkmod-index.c
@@ -401,7 +401,7 @@ void index_dump(struct index_file *in, int fd, const char *prefix)
 		return;
 
 	strbuf_init(&buf);
-	if (strbuf_pushchars(&buf, prefix))
+	if (prefix[0] == '\0' || strbuf_pushchars(&buf, prefix))
 		index_dump_node(root, &buf, fd);
 	strbuf_release(&buf);
 }
@@ -866,7 +866,7 @@ void index_mm_dump(struct index_mm *idx, int fd, const char *prefix)
 		return;
 
 	strbuf_init(&buf);
-	if (strbuf_pushchars(&buf, prefix))
+	if (prefix[0] == '\0' || strbuf_pushchars(&buf, prefix))
 		index_mm_dump_node(root, &buf, fd);
 	strbuf_release(&buf);
 }

--- a/libkmod/libkmod-index.c
+++ b/libkmod/libkmod-index.c
@@ -146,7 +146,7 @@ void index_values_free(struct index_value *values)
 }
 
 static int add_value(struct index_value **values, const char *value, size_t len,
-		     unsigned int priority)
+		     uint32_t priority)
 {
 	struct index_value *v;
 
@@ -270,7 +270,7 @@ static struct index_node_f *index_read(struct index_file *idx, uint32_t offset)
 	node->values = NULL;
 	if (offset & INDEX_NODE_VALUES) {
 		uint32_t value_count;
-		unsigned int priority;
+		uint32_t priority;
 
 		if (!read_u32(fp, &value_count))
 			goto err;
@@ -609,7 +609,7 @@ struct index_mm {
 };
 
 struct index_mm_value {
-	unsigned int priority;
+	uint32_t priority;
 	size_t len;
 	const char *value;
 };

--- a/libkmod/libkmod-index.h
+++ b/libkmod/libkmod-index.h
@@ -29,6 +29,6 @@ struct index_mm;
 int index_mm_open(const struct kmod_ctx *ctx, const char *filename,
 		  unsigned long long *stamp, struct index_mm **pidx);
 void index_mm_close(struct index_mm *index);
-char *index_mm_search(struct index_mm *idx, const char *key);
-struct index_value *index_mm_searchwild(struct index_mm *idx, const char *key);
-void index_mm_dump(struct index_mm *idx, int fd, bool alias_prefix);
+char *index_mm_search(const struct index_mm *idx, const char *key);
+struct index_value *index_mm_searchwild(const struct index_mm *idx, const char *key);
+void index_mm_dump(const struct index_mm *idx, int fd, bool alias_prefix);

--- a/libkmod/libkmod-index.h
+++ b/libkmod/libkmod-index.h
@@ -9,7 +9,7 @@
 
 struct index_value {
 	struct index_value *next;
-	unsigned int priority;
+	uint32_t priority;
 	size_t len;
 	char value[0];
 };

--- a/libkmod/libkmod-index.h
+++ b/libkmod/libkmod-index.h
@@ -19,7 +19,7 @@ struct index_file;
 struct index_file *index_file_open(const char *filename);
 void index_file_close(struct index_file *idx);
 char *index_search(struct index_file *idx, const char *key);
-void index_dump(struct index_file *in, int fd, const char *prefix);
+void index_dump(struct index_file *in, int fd, bool alias_prefix);
 struct index_value *index_searchwild(struct index_file *idx, const char *key);
 
 void index_values_free(struct index_value *values);
@@ -31,4 +31,4 @@ int index_mm_open(const struct kmod_ctx *ctx, const char *filename,
 void index_mm_close(struct index_mm *index);
 char *index_mm_search(struct index_mm *idx, const char *key);
 struct index_value *index_mm_searchwild(struct index_mm *idx, const char *key);
-void index_mm_dump(struct index_mm *idx, int fd, const char *prefix);
+void index_mm_dump(struct index_mm *idx, int fd, bool alias_prefix);

--- a/libkmod/libkmod.c
+++ b/libkmod/libkmod.c
@@ -30,14 +30,14 @@
 
 static const struct {
 	const char *fn;
-	const char *prefix;
+	bool alias_prefix;
 } index_files[] = {
 	// clang-format off
-	[KMOD_INDEX_MODULES_DEP] = { .fn = "modules.dep", .prefix = "" },
-	[KMOD_INDEX_MODULES_ALIAS] = { .fn = "modules.alias", .prefix = "alias " },
-	[KMOD_INDEX_MODULES_SYMBOL] = { .fn = "modules.symbols", .prefix = "alias " },
-	[KMOD_INDEX_MODULES_BUILTIN_ALIAS] = { .fn = "modules.builtin.alias", .prefix = "" },
-	[KMOD_INDEX_MODULES_BUILTIN] = { .fn = "modules.builtin", .prefix = "" },
+	[KMOD_INDEX_MODULES_DEP] = { .fn = "modules.dep" },
+	[KMOD_INDEX_MODULES_ALIAS] = { .fn = "modules.alias", .alias_prefix = true },
+	[KMOD_INDEX_MODULES_SYMBOL] = { .fn = "modules.symbols", .alias_prefix = true },
+	[KMOD_INDEX_MODULES_BUILTIN_ALIAS] = { .fn = "modules.builtin.alias" },
+	[KMOD_INDEX_MODULES_BUILTIN] = { .fn = "modules.builtin" },
 	// clang-format on
 };
 
@@ -813,7 +813,7 @@ KMOD_EXPORT int kmod_dump_index(struct kmod_ctx *ctx, enum kmod_index type, int 
 
 	if (ctx->indexes[type] != NULL) {
 		DBG(ctx, "use mmapped index '%s'\n", index_files[type].fn);
-		index_mm_dump(ctx->indexes[type], fd, index_files[type].prefix);
+		index_mm_dump(ctx->indexes[type], fd, index_files[type].alias_prefix);
 	} else {
 		char fn[PATH_MAX];
 		struct index_file *idx;
@@ -826,7 +826,7 @@ KMOD_EXPORT int kmod_dump_index(struct kmod_ctx *ctx, enum kmod_index type, int 
 		if (idx == NULL)
 			return -ENOSYS;
 
-		index_dump(idx, fd, index_files[type].prefix);
+		index_dump(idx, fd, index_files[type].alias_prefix);
 		index_file_close(idx);
 	}
 


### PR DESCRIPTION
While looking at how to make the index API properly handle error conditions, I noticed that we completely broke the API.

The first commit fixes that + reintroduces earlier proposal of mine. The initial counter argument had a good point but was a bit absolute (aka thinking of a extreme case, that isn't applicable to us).

The rest are bunch of paper cuts, that I've accumulated as part of the initial goal.

/cc @stoeckmann can you check the first commit? can I offer some :cookie: for adding an in-tree test?

Random notes:
 - there is only one external user (AFAICT) of the regressed API :sweat_smile: 
 - a "test-needed" label to tag PRs (merged or not) would be awesome
   - cannot create labels or I would have done it already :cry:  
 - `index_value::priority` is ignored when dumping... unlike the `depmod` equivalent
 - de-duplicating and dog-fooding the dumping API across libkmod and depmod
   - introduce new one and deprecate the old?