### PR TITLE
libkmod: Prevent OOB with specially crafted /proc/modules

### DIFF
--- a/libkmod/libkmod-module.c
+++ b/libkmod/libkmod-module.c
@@ -1382,7 +1382,7 @@ KMOD_EXPORT int kmod_module_new_from_loaded(struct kmod_ctx *ctx, struct kmod_li
 			kmod_module_unref(m);
 		}
 eat_line:
-		while (line[len - 1] != '\n' && fgets(line, sizeof(line), fp))
+		while (len > 0 && line[len - 1] != '\n' && fgets(line, sizeof(line), fp))
 			len = strlen(line);
 	}
 


### PR DESCRIPTION
Do not access memory out of bounds if the first character read by fgets is NUL. Treat such a character as EOL instead. This is a purely defensive measure since /proc/modules should normaly not contain such characters.

Proof of Concept:

1. Compile kmod with address sanitizer

2. Create a tool which chroots to read custom /proc/modules
```
cat > poc.c << EOF
#include <err.h>
#include <libkmod.h>
#include <stdio.h>
#include <unistd.h>

int
main(int argc, char *argv[])
{
        struct kmod_ctx *ctx;
        struct kmod_list *list = NULL;
        const char *null_config = NULL;

        if (argc != 2)
                errx(1, "usage: poc chrootdir");

        ctx = kmod_new(NULL, &null_config);
        if (ctx == NULL)
                errx(1, "kmod_new");

        if (chroot(argv[1]) || chdir("/"))
                err(1, "chroot");

        if (kmod_module_new_from_loaded(ctx, &list) < 0)
                err(1, "kmod_mdule_new_from_loaded");

        kmod_unref(ctx);

        return 0;
}
EOF
cc -fsanitize=address -lkmod -o poc poc.c
```

3. Create a /proc/modules which starts with a NUL character
```
TMPDIR=$(mktemp -d)
mkdir -p $TMPDIR/proc
echo -e "\x00" > $TMPDIR/proc/modules
```

4. Run tool
```
sudo ./poc $TMPDIR
```

You can see the following line:
```
SUMMARY: AddressSanitizer: stack-buffer-overflow (/usr/lib/libkmod.so.2+0xac1e8)
```