### PR TITLE
libkmod and depmod: Release memory on error paths

### DIFF
--- a/libkmod/libkmod-internal.h
+++ b/libkmod/libkmod-internal.h
@@ -58,7 +58,6 @@ _must_check_ _nonnull_(2) struct kmod_list *kmod_list_append(struct kmod_list *l
 _must_check_ _nonnull_(2) struct kmod_list *kmod_list_prepend(struct kmod_list *list, const void *data);
 _must_check_ struct kmod_list *kmod_list_remove(struct kmod_list *list);
 _must_check_ _nonnull_(2) struct kmod_list *kmod_list_remove_data(struct kmod_list *list, const void *data);
-_must_check_ struct kmod_list *kmod_list_remove_n_latest(struct kmod_list *list, unsigned int n);
 _nonnull_(2) struct kmod_list *kmod_list_insert_after(struct kmod_list *list, const void *data);
 _nonnull_(2) struct kmod_list *kmod_list_insert_before(struct kmod_list *list, const void *data);
 _must_check_ struct kmod_list *kmod_list_append_list(struct kmod_list *list1, struct kmod_list *list2);

--- a/libkmod/libkmod-internal.h
+++ b/libkmod/libkmod-internal.h
@@ -62,6 +62,11 @@ _must_check_ struct kmod_list *kmod_list_remove_n_latest(struct kmod_list *list,
 _nonnull_(2) struct kmod_list *kmod_list_insert_after(struct kmod_list *list, const void *data);
 _nonnull_(2) struct kmod_list *kmod_list_insert_before(struct kmod_list *list, const void *data);
 _must_check_ struct kmod_list *kmod_list_append_list(struct kmod_list *list1, struct kmod_list *list2);
+#define kmod_list_release(list, free_data)     \
+	while (list) {                         \
+		free_data((list)->data);       \
+		list = kmod_list_remove(list); \
+	}
 
 /* libkmod.c */
 _nonnull_all_ int kmod_lookup_alias_from_config(struct kmod_ctx *ctx, const char *name, struct kmod_list **list);

--- a/libkmod/libkmod-list.c
+++ b/libkmod/libkmod-list.c
@@ -198,23 +198,6 @@ struct kmod_list *kmod_list_remove_data(struct kmod_list *list, const void *data
 	return container_of(node, struct kmod_list, node);
 }
 
-/*
- * n must be greater to or equal the number of elements (we don't check the
- * condition)
- */
-struct kmod_list *kmod_list_remove_n_latest(struct kmod_list *list, unsigned int n)
-{
-	struct kmod_list *l = list;
-	unsigned int i;
-
-	for (i = 0; i < n; i++) {
-		l = kmod_list_last(l);
-		l = kmod_list_remove(l);
-	}
-
-	return l;
-}
-
 KMOD_EXPORT struct kmod_list *kmod_list_prev(const struct kmod_list *list,
 					     const struct kmod_list *curr)
 {

--- a/libkmod/libkmod-module.c
+++ b/libkmod/libkmod-module.c
@@ -495,8 +495,7 @@ KMOD_EXPORT int kmod_module_new_from_name_lookup(struct kmod_ctx *ctx,
 
 KMOD_EXPORT int kmod_module_unref_list(struct kmod_list *list)
 {
-	for (; list != NULL; list = kmod_list_remove(list))
-		kmod_module_unref(list->data);
+	kmod_list_release(list, kmod_module_unref);
 
 	return 0;
 }
@@ -1728,10 +1727,7 @@ KMOD_EXPORT unsigned long kmod_module_section_get_address(const struct kmod_list
 
 KMOD_EXPORT void kmod_module_section_free_list(struct kmod_list *list)
 {
-	while (list) {
-		kmod_module_section_free(list->data);
-		list = kmod_list_remove(list);
-	}
+	kmod_list_release(list, kmod_module_section_free);
 }
 
 static struct kmod_elf *kmod_module_get_elf(const struct kmod_module *mod)
@@ -1980,10 +1976,7 @@ KMOD_EXPORT const char *kmod_module_info_get_value(const struct kmod_list *entry
 
 KMOD_EXPORT void kmod_module_info_free_list(struct kmod_list *list)
 {
-	while (list) {
-		kmod_module_info_free(list->data);
-		list = kmod_list_remove(list);
-	}
+	kmod_list_release(list, kmod_module_info_free);
 }
 
 struct kmod_module_version {
@@ -2085,10 +2078,7 @@ KMOD_EXPORT uint64_t kmod_module_version_get_crc(const struct kmod_list *entry)
 
 KMOD_EXPORT void kmod_module_versions_free_list(struct kmod_list *list)
 {
-	while (list) {
-		kmod_module_version_free(list->data);
-		list = kmod_list_remove(list);
-	}
+	kmod_list_release(list, kmod_module_version_free);
 }
 
 struct kmod_module_symbol {
@@ -2189,10 +2179,7 @@ KMOD_EXPORT uint64_t kmod_module_symbol_get_crc(const struct kmod_list *entry)
 
 KMOD_EXPORT void kmod_module_symbols_free_list(struct kmod_list *list)
 {
-	while (list) {
-		kmod_module_symbol_free(list->data);
-		list = kmod_list_remove(list);
-	}
+	kmod_list_release(list, kmod_module_symbol_free);
 }
 
 struct kmod_module_dependency_symbol {
@@ -2312,8 +2299,5 @@ KMOD_EXPORT int kmod_module_dependency_symbol_get_bind(const struct kmod_list *e
 
 KMOD_EXPORT void kmod_module_dependency_symbols_free_list(struct kmod_list *list)
 {
-	while (list) {
-		kmod_module_dependency_symbol_free(list->data);
-		list = kmod_list_remove(list);
-	}
+	kmod_list_release(list, kmod_module_dependency_symbol_free);
 }

--- a/testsuite/test-list.c
+++ b/testsuite/test-list.c
@@ -76,33 +76,6 @@ static int test_list_prev(const struct test *t)
 }
 DEFINE_TEST(test_list_prev, .description = "test list prev");
 
-static int test_list_remove_n_latest(const struct test *t)
-{
-	struct kmod_list *list = NULL, *l;
-	int i;
-	const char *v[] = { "v1", "v2", "v3", "v4", "v5" };
-	const int N = ARRAY_SIZE(v), M = N / 2;
-
-	for (i = 0; i < N; i++)
-		list = kmod_list_append(list, v[i]);
-	assert_return(len(list) == N, EXIT_FAILURE);
-
-	list = kmod_list_remove_n_latest(list, M);
-	assert_return(len(list) == N - M, EXIT_FAILURE);
-
-	i = 0;
-	kmod_list_foreach(l, list) {
-		assert_return(l->data == v[i], EXIT_FAILURE);
-		i++;
-	}
-
-	kmod_list_remove_all(list);
-
-	return 0;
-}
-DEFINE_TEST(test_list_remove_n_latest,
-	    .description = "test list function to remove n latest elements");
-
 static int test_list_remove_data(const struct test *t)
 {
 	struct kmod_list *list = NULL, *l;

--- a/tools/depmod.c
+++ b/tools/depmod.c
@@ -1802,7 +1802,7 @@ static int depmod_report_one_cycle(struct depmod *depmod, struct vertex *vertex,
 	int i;
 	int n;
 	struct vertex *v;
-	int rc;
+	int rc = 0;
 
 	array_init(&reverse, 3);
 
@@ -1820,6 +1820,10 @@ static int depmod_report_one_cycle(struct depmod *depmod, struct vertex *vertex,
 	sz += vertex->mod->modnamesz - 1;
 
 	buf = malloc(sz + n * strlen(sep) + 1);
+	if (buf == NULL) {
+		rc = -ENOMEM;
+		goto out;
+	}
 
 	sz = 0;
 	for (i = reverse.count - 1; i >= 0; i--) {
@@ -1839,9 +1843,10 @@ static int depmod_report_one_cycle(struct depmod *depmod, struct vertex *vertex,
 	ERR("Cycle detected: %s\n", buf);
 
 	free(buf);
+out:
 	array_free_array(&reverse);
 
-	return 0;
+	return rc;
 }
 
 static int depmod_report_cycles_from_root(struct depmod *depmod, struct mod *root_mod,

--- a/tools/depmod.c
+++ b/tools/depmod.c
@@ -1930,12 +1930,7 @@ static int depmod_report_cycles_from_root(struct depmod *depmod, struct mod *roo
 	ret = 0;
 
 out:
-	while (free_list) {
-		v = free_list->data;
-		l = kmod_list_remove(free_list);
-		free_list = l;
-		free(v);
-	}
+	kmod_list_release(free_list, free);
 
 	return ret;
 }

--- a/tools/depmod.c
+++ b/tools/depmod.c
@@ -1867,6 +1867,7 @@ static int depmod_report_cycles_from_root(struct depmod *depmod, struct mod *roo
 	l = kmod_list_append(free_list, root);
 	if (l == NULL) {
 		ERR("No memory to report cycles\n");
+		free(root);
 		goto out;
 	}
 	free_list = l;
@@ -1922,6 +1923,7 @@ static int depmod_report_cycles_from_root(struct depmod *depmod, struct mod *roo
 			l = kmod_list_append(free_list, v);
 			if (l == NULL) {
 				ERR("No memory to report cycles\n");
+				free(v);
 				goto out;
 			}
 			free_list = l;


### PR DESCRIPTION
The libkmod library as well as depmod leaked memory on error paths related to kmod_lists:

1. On `kmod_list_append` failure (out of memory), the soon to be `list->data` was not freed
2. Not all modules were unreferenced in case of alias lookup failures

To make it a lot easier to review, I have added `kmod_list_release` which is a macro and abstracts the explicit while-loops from the code. I use it for case 2 to handle error cases more smoothly. This in turn made function `kmod_list_remove_n_latest` obsolete, so I removed it.

Proof of Concept (for case 2):

1. Either compile kmod with address sanitizer (for leak detection) or use valgrind for modprobe call later on

2. Create a modules config with an alias resolving to two modules (first one can be created in memory, second one is too long)
```
echo 'alias poc shortenough' > poc.conf
python -c 'print("alias poc " + 4096 * "A")' >> poc.conf
```

3. Try to insert modules through alias
```
modprobe -aC poc.conf poc
```

The option `-a` is important to not trigger a FATAL log, which would abort the modprobe call without trying to release all resources. Since the leak occurs in library code, it should be fixed so allocated memory can be freed when requested.