### PR TITLE
Fixup code coverage, add to CI

### DIFF
--- a/.github/actions/setup-debian/action.yml
+++ b/.github/actions/setup-debian/action.yml
@@ -11,6 +11,8 @@ runs:
     - name: Install dependencies
       shell: bash
       run: |
+        export DEBIAN_FRONTEND=noninteractive
+        export TZ=Etc/UTC
         apt-get update
         apt-get install --yes \
           autoconf \

--- a/.github/actions/setup-ubuntu/action.yml
+++ b/.github/actions/setup-ubuntu/action.yml
@@ -20,6 +20,7 @@ runs:
           build-essential \
           clang \
           gcc-multilib \
+          gcovr \
           git \
           gtk-doc-tools \
           liblzma-dev \

--- a/.github/actions/setup-ubuntu/action.yml
+++ b/.github/actions/setup-ubuntu/action.yml
@@ -11,6 +11,8 @@ runs:
     - name: Install dependencies
       shell: bash
       run: |
+        export DEBIAN_FRONTEND=noninteractive
+        export TZ=Etc/UTC
         apt-get update
         apt-get install --yes \
           autoconf \

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,8 +28,8 @@ jobs:
       fail-fast: false
       matrix:
         container:
-          - name: 'ubuntu:22.04'
-            meson_setup: '-D manpages=false -D docs=false'
+          - name: 'ubuntu:24.04'
+            meson_setup: '-D b_sanitize=none -D build-tests=false'
 
     container:
       image: ${{ matrix.container.name }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: 2024 Emil Velikov <emil.l.velikov@gmail.com>
+# SPDX-FileCopyrightText: 2024 Lucas De Marchi <lucas.de.marchi@gmail.com>
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+name: Code Coverage
+
+on:
+  push:
+    branches: [master, ci-test]
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: "30 2 * * 0"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        container:
+          - name: 'ubuntu:24.04'
+            meson_setup: '-D b_sanitize=none -D b_coverage=true'
+
+    container:
+      image: ${{ matrix.container.name }}
+
+    steps:
+      - name: Sparse checkout the local actions
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          sparse-checkout: .github
+
+      - uses: ./.github/actions/setup-ubuntu
+        if: ${{ startsWith(matrix.container.name, 'ubuntu') }}
+
+      - name: Checkout the whole project
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Set the environment
+        run: |
+          # The second checkout above claims to set safe.directory, yet it
+          # doesn't quite work. Perhaps our double/sparse checkout is to blame?
+          git config --global --add safe.directory '*'
+
+          .github/print-kdir.sh >> "$GITHUB_ENV"
+
+      - name: Build
+        run: |
+          mkdir build && cd build
+          meson setup --native-file ../build-dev.ini ${{ matrix.container.meson_setup }} . ..
+          meson compile
+          meson test
+          ninja coverage-xml
+
+      - name: Upload Coverage
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: build/meson-logs/coverage.xml

--- a/Makefile.am
+++ b/Makefile.am
@@ -255,6 +255,8 @@ EXTRA_DIST += \
 check_LTLIBRARIES = $(TESTSUITE_OVERRIDE_LIBS)
 
 testsuite_uname_la_LDFLAGS = $(TESTSUITE_OVERRIDE_LIBS_LDFLAGS)
+testsuite_path_la_CPPFLAGS = $(AM_CPPFLAGS) \
+	-DABS_TOP_BUILDDIR=\"$(abs_top_builddir)\"
 testsuite_path_la_LDFLAGS = $(TESTSUITE_OVERRIDE_LIBS_LDFLAGS)
 
 testsuite_delete_module_la_LDFLAGS = $(TESTSUITE_OVERRIDE_LIBS_LDFLAGS)

--- a/shared/util.h
+++ b/shared/util.h
@@ -16,7 +16,6 @@
 /* ************************************************************************ */
 #define streq(a, b) (strcmp((a), (b)) == 0)
 #define strstartswith(a, b) (strncmp(a, b, strlen(b)) == 0)
-#define strnstartswith(a, b, n) (strncmp(a, b, n) == 0)
 char *strchr_replace(char *s, char c, char r);
 _nonnull_all_ void *memdup(const void *p, size_t n);
 

--- a/testsuite/meson.build
+++ b/testsuite/meson.build
@@ -51,6 +51,7 @@ foreach mod : _test_override_mods
     mod,
     files('@0@.c'.format(mod)),
     include_directories : top_include,
+    c_args : '-DABS_TOP_BUILDDIR="@0@"'.format(meson.project_build_root()),
     dependencies : libdl,
     link_with : [libshared, libkmod_internal],
     gnu_symbol_visibility : 'hidden',

--- a/testsuite/path.c
+++ b/testsuite/path.c
@@ -32,8 +32,16 @@ static size_t rootpathlen;
 
 static inline bool need_trap(const char *path)
 {
-	return path != NULL && path[0] == '/' &&
-	       !strnstartswith(path, rootpath, rootpathlen);
+	/*
+	 * Always consider the ABS_TOP_BUILDDIR as the base root of anything we do.
+	 *
+	 * Changing this to rootpath is tempting but incorrect, since it won't consider
+	 * any third-party files managed through this LD_PRELOAD library, eg coverage.
+	 *
+	 * In other words: if using rootpath, the coverage gcna files will end up created
+	 * in the wrong location eg. $rootpath/$ABS_TOP_BUILDDIR.
+	 */
+	return path != NULL && path[0] == '/' && !strstartswith(path, ABS_TOP_BUILDDIR);
 }
 
 static const char *trap_path(const char *path, char buf[PATH_MAX * 2])


### PR DESCRIPTION
This PR starts off with a trivial annoyance fix the last day or so - removing the tests, use Ubuntu 24 for CodeQL.

Then an earlier commit of mine is reverted which broke the code coverage and finally a CI action is added. For the last piece a CodeCov account is needed + trivial setup for the `CODECOV_TOKEN`.

Edit: here is an illustrative link to the CodeCov web UI https://app.codecov.io/github/evelikov/kmod