### PR TITLE
Distro inspired patches

### DIFF
--- a/.github/actions/setup-alpine/action.yml
+++ b/.github/actions/setup-alpine/action.yml
@@ -17,6 +17,7 @@ runs:
           automake \
           bash \
           build-base \
+          coreutils \
           clang \
           git \
           gtk-doc \

--- a/Makefile.am
+++ b/Makefile.am
@@ -145,7 +145,8 @@ dist_zshcompletion_DATA = \
 install-exec-hook:
 if BUILD_TOOLS
 	for tool in insmod lsmod rmmod depmod modprobe modinfo; do \
-		$(LN_S) -f kmod $(DESTDIR)$(bindir)/$$tool; \
+		$(MKDIR_P) $(DESTDIR)$(sbindir); \
+		$(LN_S) --force --relative $(DESTDIR)$(bindir)/kmod $(DESTDIR)$(sbindir)/$$tool; \
 	done
 endif
 

--- a/man/meson.build
+++ b/man/meson.build
@@ -36,6 +36,7 @@ foreach tuple : _man_pages
 endforeach
 
 _man_aliases = [
+  ['5', 'modprobe.conf', 'modprobe.d.5'],
   ['5', 'modules.dep.bin', 'modules.dep.5'],
 ]
 

--- a/man/modprobe.conf.5
+++ b/man/modprobe.conf.5
@@ -1,0 +1,1 @@
+.so modprobe.d.5

--- a/meson.build
+++ b/meson.build
@@ -221,6 +221,11 @@ foreach tuple : _customdirs
   set_variable(dir_option, customdir)
 endforeach
 
+foreach confdir : [sysconfdir, distconfdir]
+  install_emptydir(confdir / 'depmod.d')
+  install_emptydir(confdir / 'modprobe.d')
+endforeach
+
 _completiondirs = [
   ['bash', 'bash-completion', 'bash-completion' / 'completions', '@0@'],
   ['fish', 'fish',            'fish' / 'vendor_functions.d',     '@0@.fish'],

--- a/meson.build
+++ b/meson.build
@@ -181,6 +181,7 @@ features = []
 prefixdir = get_option('prefix')
 sysconfdir = get_option('sysconfdir')
 bindir = prefixdir / get_option('bindir')
+sbindir = prefixdir / get_option('sbindir')
 includedir = prefixdir / get_option('includedir')
 libdir = prefixdir / get_option('libdir')
 datadir = prefixdir / get_option('datadir')
@@ -473,11 +474,15 @@ _tools = [
   'rmmod',
 ]
 
-foreach tool : _tools
-  if get_option('tools')
-    install_symlink(tool, pointing_to: 'kmod', install_dir: bindir)
-  endif
-endforeach
+if get_option('tools')
+  mkdir_p = 'mkdir -p "$DESTDIR@0@"'
+  meson.add_install_script('sh', '-c', mkdir_p.format(sbindir))
+
+  ln_s = 'ln --symbolic --force --relative "$DESTDIR@0@/kmod" "$DESTDIR@1@"'
+  foreach tool : _tools
+    meson.add_install_script('sh', '-c', ln_s.format(bindir, sbindir / tool))
+  endforeach
+endif
 
 internal_kmod_symlinks = []
 
@@ -522,6 +527,7 @@ summary({
   'prefix'      : prefixdir,
   'sysconfdir'  : sysconfdir,
   'bindir'      : bindir,
+  'sbindir'     : sbindir,
   'includedir'  : includedir,
   'libdir'      : libdir,
   'datadir'     : datadir,


### PR DESCRIPTION
The final batch of converting quirks that distros have been using into upstream material.

The first patch is potentially a bit controversial - install the symlinks into sbin. As the commit message says - this is a functional no-op* for merged `bin-sbin` (and `merged-usr`) but on split setups, this means we do 60% of the time what 100% of distros do (Gentoo has `lsmod` and `modinfo` symlinks in `{/usr,}/bin`, Debian only `lsmod`, Fedora has neither).

The other two commits are fairly trivial though :sweat_smile: 


[a] The meson `install_symlink` does not do `--relative` so we get the full path, even if the files are in the same directory. 

@eli-schwartz can I offer some virtual :cookie: in exchange of getting a flag "use-relative" like flag to meson' `install_symlink()`?