### PR TITLE
meson: undefine NDEBUG in the tests

### DIFF
--- a/testsuite/meson.build
+++ b/testsuite/meson.build
@@ -62,6 +62,7 @@ foreach mod : _test_override_mods
 endforeach
 
 testsuite_c_args = [
+  '-UNDEBUG',
   '-DTESTSUITE_ROOTFS="@0@/testsuite/rootfs/"'.format(meson.project_build_root()),
   '-DTOOLS_DIR="@0@/"'.format(meson.project_build_root()),
   '-DOVERRIDE_LIBDIR="@0@/testsuite/"'.format(meson.project_build_root()),


### PR DESCRIPTION
When using -D b_ndebug=true or inheriting CFLAGS="-DNDEBUG" from the environment, the asserts will be no-op thus the checks in the LD_PRELOADED libraries will be omitted.

Explicitly undefine the macro, so we don't accidentally shoot ourselves in the foot.

---

As an aside: our tests are fairly inconsistent, namely
 - explicit return/fail vs `assert_return(.... EXIT_FAILURE)`
 - close/free in error paths vs always leak
 - `return 0` vs `return EXIT_SUCCESS` vs `exit(EXIT_SUCCESS)`

Any objections if we get them on the same page, any preferences on the individual sub-topics?