### PR TITLE
libkmod: Do not set errno in libkmod-index

### DIFF
--- a/libkmod/libkmod-index.c
+++ b/libkmod/libkmod-index.c
@@ -167,24 +167,16 @@ static int add_value(struct index_value **values, const char *value, size_t len,
 	return 0;
 }
 
-static int read_char(FILE *in)
+static inline int read_char(FILE *in)
 {
-	int ch;
-
-	errno = 0;
-	ch = getc_unlocked(in);
-	if (ch == EOF)
-		errno = EINVAL;
-	return ch;
+	return getc_unlocked(in);
 }
 
 static bool read_u32s(FILE *in, uint32_t *l, size_t n)
 {
 	size_t i;
 
-	errno = 0;
 	if (fread_unlocked(l, sizeof(uint32_t), n, in) != n) {
-		errno = EINVAL;
 		return false;
 	}
 	for (i = 0; i < n; i++)
@@ -312,7 +304,6 @@ struct index_file *index_file_open(const char *filename)
 	file = fopen(filename, "re");
 	if (!file)
 		return NULL;
-	errno = EINVAL;
 
 	if (!read_u32(file, &magic) || magic != INDEX_MAGIC)
 		goto err;
@@ -332,7 +323,6 @@ struct index_file *index_file_open(const char *filename)
 	new->tmp = NULL;
 	new->tmp_size = 0;
 
-	errno = 0;
 	return new;
 err:
 	fclose(file);


### PR DESCRIPTION
There are two implementations for the index. The mmap index does not use errno at all. Which implementation is used, is based on the usage of kmod_load_resources and whether it succeeds or not. Therefore, callers using libkmod cannot rely on useful information in errno.

Part of the reason why we investigated this is the fact that an invalid magic value read by `index_file_open` leads to a NULL return value with errno set to `0`. This happens because `read_u32s` sets errno to `0` on success, while `index_file_open` initializes errno to `EINVAL` before performing any read operations.

No proof of concept because errno isn't checked 🙃

@stoeckmann 