### PR TITLE
libkmod: Improve comment in libkmod-index.c

### DIFF
--- a/libkmod/libkmod-index.c
+++ b/libkmod/libkmod-index.c
@@ -25,10 +25,9 @@
  * Integers are stored as 32 bit unsigned in "network" order, i.e. MSB first.
  * All files start with a magic number.
  *
- * Magic spells "BOOTFAST". Second one used on newer versioned binary files.
- * #define INDEX_MAGIC_OLD 0xB007FA57
+ * Magic spells "BOOTFAST". Deprecated versions encoded it as 0xB007FA57.
  *
- * We use a version string to keep track of changes to the binary format
+ * We use a version string to keep track of changes to the binary format.
  * This is stored in the form: INDEX_MAJOR (hi) INDEX_MINOR (lo) just in
  * case we ever decide to have minor changes that are not incompatible.
  */

--- a/shared/missing.h
+++ b/shared/missing.h
@@ -6,7 +6,7 @@
 /*
  * Macros pulled from linux/module.h, to avoid pulling the header.
  *
- * In practise very few people have it installed and distros do not install the
+ * In practice, very few people have it installed and distros do not install the
  * relevant package during their build.
  *
  * Values are UAPI, so they cannot change.


### PR DESCRIPTION
The 0xB007FA57 (INDEX_MAGIC_OLD) magic is very old, since it was already old in kmod v1. Let's not talk about "newer binary files" when refering to 0xB007F457 (INDEX_MAGIC) anymore. Restructured the sentence to make it easier to understand after comments were moved from `libkmod-index.h` to `libkmod-index.c` (see [here](https://github.com/kmod-project/kmod/commit/c4cbdf8e175acdd0d907ae9e250fd2fe7acf9a00#diff-0f42cd27fb1b02778916c8172b6bc772d9dc1c5df403b4828d932d149299d85bL28) for an example how the sentence was more fitting back then).

While at it, added another commit which fixes a typo in another comment.

CC: @Maaxxs