### PR TITLE
libkmod: Fix file error handling regression

### DIFF
--- a/libkmod/libkmod-file-zstd.c
+++ b/libkmod/libkmod-file-zstd.c
@@ -67,6 +67,7 @@ int kmod_file_load_zstd(struct kmod_file *file)
 	ret = ZSTD_decompress(dst_buf, dst_size, src_buf, src_size);
 	if (ZSTD_isError(ret)) {
 		ERR(file->ctx, "zstd: %s\n", ZSTD_getErrorName(ret));
+		ret = -EINVAL;
 		goto out;
 	}
 

--- a/libkmod/libkmod-file.c
+++ b/libkmod/libkmod-file.c
@@ -67,7 +67,7 @@ struct kmod_elf *kmod_file_get_elf(struct kmod_file *file)
 
 	err = kmod_file_load_contents(file);
 	if (err) {
-		errno = err;
+		errno = -err;
 		return NULL;
 	}
 


### PR DESCRIPTION
The propagation of errors from loading function through errno must make sure that errno is positive, otherwise errors are not correctly spotted.

Proof of Concept:

1. Create invalid module files of different file types
```
base64 -d <<< AAAAAAAAAA== > poc.ko
base64 -d <<< H4sAAAAAAA== > poc.ko.gz
base64 -d <<< /Td6WFoAAA== > poc.ko.xz
base64 -d <<< KLUv/QAAAA== > poc.ko.zst
```

2. Run modinfo and check exit code
```
for i in poc.ko*
do
        echo "$i:"
        modinfo $i
        echo $?
done
```

The regression occurs in kmod 33 already. Its output is:
```
poc.ko:
filename:       /tmp/poc.ko
modinfo: ERROR: could not get modinfo from 'poc': Exec format error
1
poc.ko.gz:
filename:       /tmp/poc.ko.gz
libkmod: kmod_file_load_zlib: gzip: <fd:4>: unknown compression method
0
poc.ko.xz:
filename:       /tmp/poc.ko.xz
libkmod: xz_uncompress_belch: xz: Unexpected end of input
0
poc.ko.zst:
filename:       /tmp/poc.ko.zst
modinfo: ERROR: could not get modinfo from 'poc': Exec format error
1
```

With current master, we see:
```
poc.ko:
filename:       /tmp/poc.ko
modinfo: ERROR: could not get modinfo from 'poc': Exec format error
1
poc.ko.gz:
filename:       /tmp/poc.ko.gz
libkmod: ERROR: kmod_file_load_zlib: gzip: <fd:4>: unknown compression method
0
poc.ko.xz:
filename:       /tmp/poc.ko.xz
libkmod: ERROR: xz_uncompress_belch: xz: Unexpected end of input
0
poc.ko.zst:
filename:       /tmp/poc.ko.zst
libkmod: ERROR: kmod_file_load_zstd: zstd: Failed to determine decompression size
0
```