### PR TITLE
ci: add meson setup -D {distconf,module}dir=relative/ checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,6 +70,19 @@ jobs:
 
           .github/print-kdir.sh >> "$GITHUB_ENV"
 
+      - name: configure checks (meson)
+        if: ${{ matrix.build == 'meson' }}
+        run: |
+          should_fail() {
+            if meson setup "$@" build/; then
+              echo Command was expected to fail, but was successful
+              return 1
+            fi
+          }
+          should_fail -D distconfdir=relative/
+          should_fail -D moduledir=relative/
+          rm -rf build/
+
       - name: configure (meson)
         if: ${{ matrix.build == 'meson' }}
         run: mkdir build && cd build && meson setup --native-file ../build-dev.ini ${{ matrix.container.meson_setup }} . ..


### PR DESCRIPTION
Based on the autotools build, meson does not support relative directories for distconfig and moduledir. We fixed that recently, but never added a check so we don't regress.