### PR TITLE
shared: Use unsigned char in hash calculation

### DIFF
--- a/shared/hash.c
+++ b/shared/hash.c
@@ -94,7 +94,7 @@ static inline unsigned int hash_superfast(const char *key, unsigned int len)
 	case 3:
 		hash += get_unaligned((uint16_t *)key);
 		hash ^= hash << 16;
-		hash ^= key[2] << 18;
+		hash ^= ((uint8_t)key[2]) << 18;
 		hash += hash >> 11;
 		break;
 


### PR DESCRIPTION
Spotted these while investigating https://github.com/kmod-project/kmod/issues/26.

- Use hash_superfast as intended (UBSAN gave a warning and yes, this modifies the hash result)
- Improve handling of out of memory conditions
- Add yet another fgets check (copy & paste code, last time I have just seen one of them)
- Use proper format specifiers

Since these don't fix the issue but would basically lead all to a single PR, I've grouped them in a single one instead.