### PR TITLE
ci/codeql: use filter-sarif to filter meson-private

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -70,3 +70,19 @@ jobs:
         uses: github/codeql-action/analyze@4f3212b61783c3c68e8309a0f18a699764811cda # v3.27.1
         with:
           category: "/language:cpp"
+          upload: false
+          output: sarif-results
+
+      - name: Filter out meson-internal test files
+        uses: advanced-security/filter-sarif@f3b8118a9349d88f7b1c0c488476411145b6270d # v1.0.1
+        with:
+          patterns: |
+            -build/meson-private/**/testfile.c
+          input: sarif-results/cpp.sarif
+          output: sarif-results/cpp.sarif
+
+      - name: Upload CodeQL results to code scanning
+        uses: github/codeql-action/upload-sarif@4f3212b61783c3c68e8309a0f18a699764811cda # v3.27.1
+        with:
+          sarif_file: sarif-results/cpp.sarif
+          category: "/language:cpp"


### PR DESCRIPTION
There is a severe number of false-positive in code scanning caused by inspecting meson-internal test files like
'build/meson-private/tmpzb46osmq/testfile.c'.

As a workaround, use the 'filter-sarif' action to filter out these results before uploading the SARIF (Static Analysis Results Interchange Format).

This PR was inspired by https://github.com/rauc/rauc/pull/1346 and the example from https://github.com/advanced-security/filter-sarif.

---

At a glance this will remove ~35 or around half of the reports \o/

NOTE: there is a "path-ignore" option for the scanner itself, although it seems to be language specific - see their issue 1583