### PR TITLE
libkmod: Improve index dump performance

### DIFF
--- a/libkmod/libkmod-index.h
+++ b/libkmod/libkmod-index.h
@@ -19,7 +19,7 @@ struct index_file;
 struct index_file *index_file_open(const char *filename);
 void index_file_close(struct index_file *idx);
 char *index_search(struct index_file *idx, const char *key);
-void index_dump(struct index_file *in, int fd, bool alias_prefix);
+void index_dump(struct index_file *in, FILE *fp, bool alias_prefix);
 struct index_value *index_searchwild(struct index_file *idx, const char *key);
 
 void index_values_free(struct index_value *values);
@@ -31,4 +31,4 @@ int index_mm_open(const struct kmod_ctx *ctx, const char *filename,
 void index_mm_close(struct index_mm *index);
 char *index_mm_search(const struct index_mm *idx, const char *key);
 struct index_value *index_mm_searchwild(const struct index_mm *idx, const char *key);
-void index_mm_dump(const struct index_mm *idx, int fd, bool alias_prefix);
+void index_mm_dump(const struct index_mm *idx, FILE *fp, bool alias_prefix);

--- a/shared/util.c
+++ b/shared/util.c
@@ -237,32 +237,6 @@ ssize_t read_str_safe(int fd, char *buf, size_t buflen)
 	return done;
 }
 
-ssize_t write_str_safe(int fd, const char *buf, size_t buflen)
-{
-	size_t todo = buflen;
-	size_t done = 0;
-
-	assert_cc(EAGAIN == EWOULDBLOCK);
-
-	do {
-		ssize_t r = write(fd, buf + done, todo);
-
-		if (r == 0)
-			break;
-		else if (r > 0) {
-			todo -= r;
-			done += r;
-		} else {
-			if (errno == EAGAIN || errno == EINTR)
-				continue;
-			else
-				return -errno;
-		}
-	} while (todo > 0);
-
-	return done;
-}
-
 int read_str_long(int fd, long *value, int base)
 {
 	char buf[32], *end;

--- a/shared/util.h
+++ b/shared/util.h
@@ -37,7 +37,6 @@ _nonnull_all_ bool path_ends_with_kmod_ext(const char *path, size_t len);
 _must_check_ _nonnull_(2) ssize_t pread_str_safe(int fd, char *buf, size_t buflen,
 						 off_t off);
 _must_check_ _nonnull_(2) ssize_t read_str_safe(int fd, char *buf, size_t buflen);
-_nonnull_(2) ssize_t write_str_safe(int fd, const char *buf, size_t buflen);
 _must_check_ _nonnull_(2) int read_str_long(int fd, long *value, int base);
 _must_check_ _nonnull_(2) int read_str_ulong(int fd, unsigned long *value, int base);
 _nonnull_(1) char *freadline_wrapped(FILE *fp, unsigned int *linenum);

--- a/testsuite/test-util.c
+++ b/testsuite/test-util.c
@@ -162,35 +162,6 @@ static int test_path_ends_with_kmod_ext(const struct test *t)
 DEFINE_TEST(test_path_ends_with_kmod_ext,
 	    .description = "check implementation of path_ends_with_kmod_ext()")
 
-#define TEST_WRITE_STR_SAFE_FILE "/write-str-safe"
-#define TEST_WRITE_STR_SAFE_PATH TESTSUITE_ROOTFS "test-util2/" TEST_WRITE_STR_SAFE_FILE
-static int test_write_str_safe(const struct test *t)
-{
-	const char *s = "test";
-	int fd;
-
-	fd = open(TEST_WRITE_STR_SAFE_FILE ".txt", O_CREAT | O_TRUNC | O_WRONLY, 0644);
-	assert_return(fd >= 0, EXIT_FAILURE);
-
-	write_str_safe(fd, s, strlen(s));
-	close(fd);
-
-	return EXIT_SUCCESS;
-}
-DEFINE_TEST(test_write_str_safe,
-	.description = "check implementation of write_str_safe()",
-	.config = {
-		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-util2/",
-	},
-	.need_spawn = true,
-	.output = {
-		.files = (const struct keyval[]) {
-			{ TEST_WRITE_STR_SAFE_PATH ".txt",
-			  TEST_WRITE_STR_SAFE_PATH "-correct.txt" },
-			{ },
-		},
-	});
-
 static int test_uadd32_overflow(const struct test *t)
 {
 	uint32_t res;


### PR DESCRIPTION
Use FILE for output to reduce the amount of system calls. Removes the only use case of write_str_safe, which can be removed as well.

This has another advantage, beside faster execution: Having a FILE in `kmod_dump_index` allows us easier error detection in the future (by using `ferror` here instead of multiplying it into FILE-based and memory-mapped index functions).

Talking about execution times, these are collected from modules of an Arch Linux installation:

### current master

Uses 198497 write calls.
Takes around 224 ms on this system.

```
$ strace -c modprobe -c > output.txt
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
 99.98    0.224581           1    198497           write
  0.02    0.000045           7         6           munmap
  0.00    0.000000           0        13           read
  0.00    0.000000           0        17           close
  0.00    0.000000           0        18           fstat
  0.00    0.000000           0        30           mmap
  0.00    0.000000           0         7           mprotect
  0.00    0.000000           0         3           brk
  0.00    0.000000           0         2           pread64
  0.00    0.000000           0         1         1 access
  0.00    0.000000           0         1           execve
  0.00    0.000000           0         3           fcntl
  0.00    0.000000           0         1           arch_prctl
  0.00    0.000000           0         4           getdents64
  0.00    0.000000           0         1           set_tid_address
  0.00    0.000000           0        20         3 openat
  0.00    0.000000           0         9         5 newfstatat
  0.00    0.000000           0         1           set_robust_list
  0.00    0.000000           0         1           prlimit64
  0.00    0.000000           0         1           getrandom
  0.00    0.000000           0         1           rseq
------ ----------- ----------- --------- --------- ----------------
100.00    0.224626           1    198637         9 total
```

```
$ size tools/kmod libkmod/.libs/libkmod.so.2.5.0
   text    data     bss     dec     hex filename
 158343    5852     160  164355   28203 tools/kmod
  96173    2248       8   98429   1807d libkmod/.libs/libkmod.so.2.5.0
```

### new

Uses 573 write calls.
Takes around 7 ms.

Binary size shrinks by around 200 bytes, library size increases by around 60 bytes.
Speed increasement based on `strace`: around 30x
Speed increasement based on `time`: 4x to 10x (depending if you redirect to /dev/null or a real file)

```
$ strace -c modprobe -c > output.txt
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
 84.74    0.005751          10       573           write
  2.95    0.000200           6        30           mmap
  2.08    0.000141           7        20         3 openat
  1.93    0.000131           6        19           close
  1.66    0.000113           5        20           fstat
  1.31    0.000089          14         6           munmap
  1.21    0.000082           6        13           read
  0.96    0.000065           9         7           mprotect
  0.80    0.000054           6         9         5 newfstatat
  0.52    0.000035           5         6           fcntl
  0.50    0.000034           8         4           getdents64
  0.24    0.000016           5         3           brk
  0.22    0.000015           7         2           pread64
  0.18    0.000012           6         2           dup
  0.13    0.000009           9         1           set_tid_address
  0.12    0.000008           8         1           set_robust_list
  0.10    0.000007           7         1           arch_prctl
  0.10    0.000007           7         1           prlimit64
  0.10    0.000007           7         1           getrandom
  0.09    0.000006           6         1           rseq
  0.07    0.000005           5         1           lseek
  0.00    0.000000           0         1         1 access
  0.00    0.000000           0         1           execve
------ ----------- ----------- --------- --------- ----------------
100.00    0.006787           9       723         9 total
```

```
$ size tools/kmod libkmod/.libs/libkmod.so.2.5.0
   text    data     bss     dec     hex filename
 158143    5852     160  164155   2813b tools/kmod
  96208    2272       8   98488   180b8 libkmod/.libs/libkmod.so.2.5.0
```