### PR TITLE
RFC: Consolidate test rootfs in single place

### DIFF
--- a/testsuite/test-blacklist.c
+++ b/testsuite/test-blacklist.c
@@ -83,7 +83,7 @@ fail_lookup:
 
 DEFINE_TEST(blacklist_1, .description = "check if modules are correctly blacklisted",
 	    .config = {
-		    [TC_ROOTFS] = TESTSUITE_ROOTFS "test-blacklist/",
+		    [TC_ROOTFS] = "test-blacklist/",
 	    });
 
 TESTSUITE_MAIN();

--- a/testsuite/test-dependencies.c
+++ b/testsuite/test-dependencies.c
@@ -70,7 +70,7 @@ DEFINE_TEST(test_dependencies,
 	    .description = "test if kmod_module_get_dependencies works",
 	    .config = {
 		    [TC_UNAME_R] = TEST_UNAME,
-		    [TC_ROOTFS] = TESTSUITE_ROOTFS "test-dependencies/",
+		    [TC_ROOTFS] = "test-dependencies/",
 	    });
 
 TESTSUITE_MAIN();

--- a/testsuite/test-depmod.c
+++ b/testsuite/test-depmod.c
@@ -18,9 +18,6 @@
 	test_spawn_prog(TOOLS_DIR "/depmod", \
 			(const char *[]){ TOOLS_DIR "/depmod", ##__VA_ARGS__, NULL })
 
-#define MODULES_UNAME "4.4.4"
-#define MODULES_ORDER_ROOTFS "test-depmod/modules-order-compressed"
-#define MODULES_ORDER_LIB_MODULES MODULES_ORDER_ROOTFS MODULE_DIRECTORY "/" MODULES_UNAME
 static noreturn int depmod_modules_order_for_compressed(const struct test *t)
 {
 	EXEC_DEPMOD();
@@ -29,22 +26,18 @@ static noreturn int depmod_modules_order_for_compressed(const struct test *t)
 DEFINE_TEST(depmod_modules_order_for_compressed,
 	.description = "check if depmod let aliases in right order when using compressed modules",
 	.config = {
-		[TC_UNAME_R] = MODULES_UNAME,
-		[TC_ROOTFS] = MODULES_ORDER_ROOTFS,
+		[TC_UNAME_R] = "4.4.4",
+		[TC_ROOTFS] = "test-depmod/modules-order-compressed",
 	},
 	.output = {
 		.files = (const struct keyval[]) {
-			{ MODULES_ORDER_LIB_MODULES "/correct-modules.alias",
-			  MODULES_ORDER_LIB_MODULES "/modules.alias" },
+			{ "correct-modules.alias", "modules.alias" },
 			{ },
 		},
 	});
 
-#define MODULES_OUTDIR_ROOTFS "test-depmod/modules-outdir"
 #define MODULES_OUTDIR_LIB_MODULES_OUTPUT \
-	MODULES_OUTDIR_ROOTFS "/outdir" MODULE_DIRECTORY "/" MODULES_UNAME
-#define MODULES_OUTDIR_LIB_MODULES_INPUT \
-	MODULES_OUTDIR_ROOTFS MODULE_DIRECTORY "/" MODULES_UNAME
+	MODULES_OUTDIR_ROOTFS "/outdir" MODULE_DIRECTORY "/" "4.4.4"
 static noreturn int depmod_modules_outdir(const struct test *t)
 {
 	EXEC_DEPMOD("--outdir", "/outdir/");
@@ -53,8 +46,8 @@ static noreturn int depmod_modules_outdir(const struct test *t)
 DEFINE_TEST(depmod_modules_outdir,
 	.description = "check if depmod honours the outdir option",
 	.config = {
-		[TC_UNAME_R] = MODULES_UNAME,
-		[TC_ROOTFS] = MODULES_OUTDIR_ROOTFS,
+		[TC_UNAME_R] = "4.4.4",
+		[TC_ROOTFS] = "test-depmod/modules-outdir",
 	},
 	.output = {
 		.files = (const struct keyval[]) {
@@ -66,9 +59,6 @@ DEFINE_TEST(depmod_modules_outdir,
 		},
 	});
 
-#define SEARCH_ORDER_SIMPLE_ROOTFS "test-depmod/search-order-simple"
-#define SEARCH_ORDER_SIMPLE_LIB_MODULES \
-	SEARCH_ORDER_SIMPLE_ROOTFS MODULE_DIRECTORY "/" MODULES_UNAME
 static noreturn int depmod_search_order_simple(const struct test *t)
 {
 	EXEC_DEPMOD();
@@ -77,13 +67,12 @@ static noreturn int depmod_search_order_simple(const struct test *t)
 DEFINE_TEST(depmod_search_order_simple,
 	.description = "check if depmod honor search order in config",
 	.config = {
-		[TC_UNAME_R] = MODULES_UNAME,
-		[TC_ROOTFS] = SEARCH_ORDER_SIMPLE_ROOTFS,
+		[TC_UNAME_R] = "4.4.4",
+		[TC_ROOTFS] = "test-depmod/search-order-simple"
 	},
 	.output = {
 		.files = (const struct keyval[]) {
-			{ SEARCH_ORDER_SIMPLE_LIB_MODULES "/correct-modules.dep",
-			  SEARCH_ORDER_SIMPLE_LIB_MODULES "/modules.dep" },
+			{ "correct-modules.dep", "modules.dep" },
 			{ },
 		},
 	});
@@ -104,33 +93,30 @@ static noreturn int depmod_another_moddir_relative(const struct test *t)
 DEFINE_TEST(depmod_another_moddir,
 	.description = "check depmod -m flag",
 	.config = {
-		[TC_UNAME_R] = MODULES_UNAME,
+		[TC_UNAME_R] = "4.4.4",
 		[TC_ROOTFS] = MODULES_ANOTHER_MODDIR_ROOTFS,
 	},
 	.output = {
 		.files = (const struct keyval[]) {
 			{ MODULES_ANOTHER_MODDIR_ROOTFS "/correct-modules.dep",
-			  MODULES_ANOTHER_MODDIR_ROOTFS ANOTHER_MODDIR "/" MODULES_UNAME "/modules.dep" },
+			  MODULES_ANOTHER_MODDIR_ROOTFS ANOTHER_MODDIR "/" "4.4.4" "/modules.dep" },
 			{ },
 		},
 	});
 DEFINE_TEST(depmod_another_moddir_relative,
 	.description = "check depmod -m flag with relative dir",
 	.config = {
-		[TC_UNAME_R] = MODULES_UNAME,
+		[TC_UNAME_R] = "4.4.4",
 		[TC_ROOTFS] = MODULES_ANOTHER_MODDIR_ROOTFS,
 	},
 	.output = {
 		.files = (const struct keyval[]) {
 			{ MODULES_ANOTHER_MODDIR_ROOTFS "/correct-modules.dep",
-			  MODULES_ANOTHER_MODDIR_ROOTFS "/" RELATIVE_MODDIR "/" MODULES_UNAME "/modules.dep" },
+			  MODULES_ANOTHER_MODDIR_ROOTFS "/" RELATIVE_MODDIR "/" "4.4.4" "/modules.dep" },
 			{ },
 		},
 	});
 
-#define SEARCH_ORDER_SAME_PREFIX_ROOTFS "test-depmod/search-order-same-prefix"
-#define SEARCH_ORDER_SAME_PREFIX_LIB_MODULES \
-	SEARCH_ORDER_SAME_PREFIX_ROOTFS MODULE_DIRECTORY "/" MODULES_UNAME
 static noreturn int depmod_search_order_same_prefix(const struct test *t)
 {
 	EXEC_DEPMOD();
@@ -139,13 +125,12 @@ static noreturn int depmod_search_order_same_prefix(const struct test *t)
 DEFINE_TEST(depmod_search_order_same_prefix,
 	.description = "check if depmod honor search order in config with same prefix",
 	.config = {
-		[TC_UNAME_R] = MODULES_UNAME,
-		[TC_ROOTFS] = SEARCH_ORDER_SAME_PREFIX_ROOTFS,
+		[TC_UNAME_R] = "4.4.4",
+		[TC_ROOTFS] = "test-depmod/search-order-same-prefix",
 	},
 	.output = {
 		.files = (const struct keyval[]) {
-			{ SEARCH_ORDER_SAME_PREFIX_LIB_MODULES "/correct-modules.dep",
-			  SEARCH_ORDER_SAME_PREFIX_LIB_MODULES "/modules.dep" },
+			{ "correct-modules.dep", "modules.dep" },
 			{ },
 		},
 	});
@@ -159,7 +144,7 @@ static noreturn int depmod_detect_loop(const struct test *t)
 DEFINE_TEST(depmod_detect_loop,
 	.description = "check if depmod detects module loops correctly",
 	.config = {
-		[TC_UNAME_R] = MODULES_UNAME,
+		[TC_UNAME_R] = "4.4.4",
 		[TC_ROOTFS] = DETECT_LOOP_ROOTFS,
 	},
 	.expected_fail = true,
@@ -169,7 +154,7 @@ DEFINE_TEST(depmod_detect_loop,
 
 #define SEARCH_ORDER_EXTERNAL_FIRST_ROOTFS "test-depmod/search-order-external-first"
 #define SEARCH_ORDER_EXTERNAL_FIRST_LIB_MODULES \
-	SEARCH_ORDER_EXTERNAL_FIRST_ROOTFS MODULE_DIRECTORY "/" MODULES_UNAME
+	SEARCH_ORDER_EXTERNAL_FIRST_ROOTFS MODULE_DIRECTORY "/" "4.4.4"
 static noreturn int depmod_search_order_external_first(const struct test *t)
 {
 	EXEC_DEPMOD();
@@ -178,7 +163,7 @@ static noreturn int depmod_search_order_external_first(const struct test *t)
 DEFINE_TEST(depmod_search_order_external_first,
 	.description = "check if depmod honor external keyword with higher priority",
 	.config = {
-		[TC_UNAME_R] = MODULES_UNAME,
+		[TC_UNAME_R] = "4.4.4",
 		[TC_ROOTFS] = SEARCH_ORDER_EXTERNAL_FIRST_ROOTFS,
 	},
 	.output = {
@@ -191,7 +176,7 @@ DEFINE_TEST(depmod_search_order_external_first,
 
 #define SEARCH_ORDER_EXTERNAL_LAST_ROOTFS "test-depmod/search-order-external-last"
 #define SEARCH_ORDER_EXTERNAL_LAST_LIB_MODULES \
-	SEARCH_ORDER_EXTERNAL_LAST_ROOTFS MODULE_DIRECTORY "/" MODULES_UNAME
+	SEARCH_ORDER_EXTERNAL_LAST_ROOTFS MODULE_DIRECTORY "/" "4.4.4"
 static noreturn int depmod_search_order_external_last(const struct test *t)
 {
 	EXEC_DEPMOD();
@@ -200,7 +185,7 @@ static noreturn int depmod_search_order_external_last(const struct test *t)
 DEFINE_TEST(depmod_search_order_external_last,
 	.description = "check if depmod honor external keyword with lower priority",
 	.config = {
-		[TC_UNAME_R] = MODULES_UNAME,
+		[TC_UNAME_R] = "4.4.4",
 		[TC_ROOTFS] = SEARCH_ORDER_EXTERNAL_LAST_ROOTFS,
 	},
 	.output = {
@@ -213,7 +198,7 @@ DEFINE_TEST(depmod_search_order_external_last,
 
 #define SEARCH_ORDER_OVERRIDE_ROOTFS "test-depmod/search-order-override"
 #define SEARCH_ORDER_OVERRIDE_LIB_MODULES \
-	SEARCH_ORDER_OVERRIDE_ROOTFS MODULE_DIRECTORY "/" MODULES_UNAME
+	SEARCH_ORDER_OVERRIDE_ROOTFS MODULE_DIRECTORY "/" "4.4.4"
 static noreturn int depmod_search_order_override(const struct test *t)
 {
 	EXEC_DEPMOD();
@@ -222,7 +207,7 @@ static noreturn int depmod_search_order_override(const struct test *t)
 DEFINE_TEST(depmod_search_order_override,
 	.description = "check if depmod honor override keyword",
 	.config = {
-		[TC_UNAME_R] = MODULES_UNAME,
+		[TC_UNAME_R] = "4.4.4",
 		[TC_ROOTFS] = SEARCH_ORDER_OVERRIDE_ROOTFS,
 	},
 	.output = {
@@ -233,8 +218,7 @@ DEFINE_TEST(depmod_search_order_override,
 		},
 	});
 
-#define CHECK_WEAKDEP_ROOTFS "test-depmod/check-weakdep"
-#define CHECK_WEAKDEP_LIB_MODULES CHECK_WEAKDEP_ROOTFS MODULE_DIRECTORY "/" MODULES_UNAME
+#define CHECK_WEAKDEP_LIB_MODULES CHECK_WEAKDEP_ROOTFS MODULE_DIRECTORY "/" "4.4.4"
 static noreturn int depmod_check_weakdep(const struct test *t)
 {
 	EXEC_DEPMOD();
@@ -243,13 +227,12 @@ static noreturn int depmod_check_weakdep(const struct test *t)
 DEFINE_TEST(depmod_check_weakdep,
 	.description = "check weakdep output",
 	.config = {
-		[TC_UNAME_R] = MODULES_UNAME,
-		[TC_ROOTFS] = CHECK_WEAKDEP_ROOTFS,
+		[TC_UNAME_R] = "4.4.4",
+		[TC_ROOTFS] = "test-depmod/check-weakdep",
 	},
 	.output = {
 		.files = (const struct keyval[]) {
-			{ CHECK_WEAKDEP_LIB_MODULES "/correct-modules.weakdep",
-			  CHECK_WEAKDEP_LIB_MODULES "/modules.weakdep" },
+			{ "correct-modules.weakdep", "modules.weakdep" },
 			{ },
 		},
 	});

--- a/testsuite/test-depmod.c
+++ b/testsuite/test-depmod.c
@@ -19,7 +19,7 @@
 			(const char *[]){ TOOLS_DIR "/depmod", ##__VA_ARGS__, NULL })
 
 #define MODULES_UNAME "4.4.4"
-#define MODULES_ORDER_ROOTFS TESTSUITE_ROOTFS "test-depmod/modules-order-compressed"
+#define MODULES_ORDER_ROOTFS "test-depmod/modules-order-compressed"
 #define MODULES_ORDER_LIB_MODULES MODULES_ORDER_ROOTFS MODULE_DIRECTORY "/" MODULES_UNAME
 static noreturn int depmod_modules_order_for_compressed(const struct test *t)
 {
@@ -40,7 +40,7 @@ DEFINE_TEST(depmod_modules_order_for_compressed,
 		},
 	});
 
-#define MODULES_OUTDIR_ROOTFS TESTSUITE_ROOTFS "test-depmod/modules-outdir"
+#define MODULES_OUTDIR_ROOTFS "test-depmod/modules-outdir"
 #define MODULES_OUTDIR_LIB_MODULES_OUTPUT \
 	MODULES_OUTDIR_ROOTFS "/outdir" MODULE_DIRECTORY "/" MODULES_UNAME
 #define MODULES_OUTDIR_LIB_MODULES_INPUT \
@@ -66,7 +66,7 @@ DEFINE_TEST(depmod_modules_outdir,
 		},
 	});
 
-#define SEARCH_ORDER_SIMPLE_ROOTFS TESTSUITE_ROOTFS "test-depmod/search-order-simple"
+#define SEARCH_ORDER_SIMPLE_ROOTFS "test-depmod/search-order-simple"
 #define SEARCH_ORDER_SIMPLE_LIB_MODULES \
 	SEARCH_ORDER_SIMPLE_ROOTFS MODULE_DIRECTORY "/" MODULES_UNAME
 static noreturn int depmod_search_order_simple(const struct test *t)
@@ -90,7 +90,7 @@ DEFINE_TEST(depmod_search_order_simple,
 
 #define ANOTHER_MODDIR "/foobar"
 #define RELATIVE_MODDIR "foobar2"
-#define MODULES_ANOTHER_MODDIR_ROOTFS TESTSUITE_ROOTFS "test-depmod/another-moddir"
+#define MODULES_ANOTHER_MODDIR_ROOTFS "test-depmod/another-moddir"
 static noreturn int depmod_another_moddir(const struct test *t)
 {
 	EXEC_DEPMOD("-m", ANOTHER_MODDIR);
@@ -128,8 +128,7 @@ DEFINE_TEST(depmod_another_moddir_relative,
 		},
 	});
 
-#define SEARCH_ORDER_SAME_PREFIX_ROOTFS \
-	TESTSUITE_ROOTFS "test-depmod/search-order-same-prefix"
+#define SEARCH_ORDER_SAME_PREFIX_ROOTFS "test-depmod/search-order-same-prefix"
 #define SEARCH_ORDER_SAME_PREFIX_LIB_MODULES \
 	SEARCH_ORDER_SAME_PREFIX_ROOTFS MODULE_DIRECTORY "/" MODULES_UNAME
 static noreturn int depmod_search_order_same_prefix(const struct test *t)
@@ -151,7 +150,7 @@ DEFINE_TEST(depmod_search_order_same_prefix,
 		},
 	});
 
-#define DETECT_LOOP_ROOTFS TESTSUITE_ROOTFS "test-depmod/detect-loop"
+#define DETECT_LOOP_ROOTFS "test-depmod/detect-loop"
 static noreturn int depmod_detect_loop(const struct test *t)
 {
 	EXEC_DEPMOD();
@@ -168,8 +167,7 @@ DEFINE_TEST(depmod_detect_loop,
 		.err = DETECT_LOOP_ROOTFS "/correct.txt",
 	});
 
-#define SEARCH_ORDER_EXTERNAL_FIRST_ROOTFS \
-	TESTSUITE_ROOTFS "test-depmod/search-order-external-first"
+#define SEARCH_ORDER_EXTERNAL_FIRST_ROOTFS "test-depmod/search-order-external-first"
 #define SEARCH_ORDER_EXTERNAL_FIRST_LIB_MODULES \
 	SEARCH_ORDER_EXTERNAL_FIRST_ROOTFS MODULE_DIRECTORY "/" MODULES_UNAME
 static noreturn int depmod_search_order_external_first(const struct test *t)
@@ -191,8 +189,7 @@ DEFINE_TEST(depmod_search_order_external_first,
 		},
 	});
 
-#define SEARCH_ORDER_EXTERNAL_LAST_ROOTFS \
-	TESTSUITE_ROOTFS "test-depmod/search-order-external-last"
+#define SEARCH_ORDER_EXTERNAL_LAST_ROOTFS "test-depmod/search-order-external-last"
 #define SEARCH_ORDER_EXTERNAL_LAST_LIB_MODULES \
 	SEARCH_ORDER_EXTERNAL_LAST_ROOTFS MODULE_DIRECTORY "/" MODULES_UNAME
 static noreturn int depmod_search_order_external_last(const struct test *t)
@@ -214,7 +211,7 @@ DEFINE_TEST(depmod_search_order_external_last,
 		},
 	});
 
-#define SEARCH_ORDER_OVERRIDE_ROOTFS TESTSUITE_ROOTFS "test-depmod/search-order-override"
+#define SEARCH_ORDER_OVERRIDE_ROOTFS "test-depmod/search-order-override"
 #define SEARCH_ORDER_OVERRIDE_LIB_MODULES \
 	SEARCH_ORDER_OVERRIDE_ROOTFS MODULE_DIRECTORY "/" MODULES_UNAME
 static noreturn int depmod_search_order_override(const struct test *t)
@@ -236,7 +233,7 @@ DEFINE_TEST(depmod_search_order_override,
 		},
 	});
 
-#define CHECK_WEAKDEP_ROOTFS TESTSUITE_ROOTFS "test-depmod/check-weakdep"
+#define CHECK_WEAKDEP_ROOTFS "test-depmod/check-weakdep"
 #define CHECK_WEAKDEP_LIB_MODULES CHECK_WEAKDEP_ROOTFS MODULE_DIRECTORY "/" MODULES_UNAME
 static noreturn int depmod_check_weakdep(const struct test *t)
 {

--- a/testsuite/test-init.c
+++ b/testsuite/test-init.c
@@ -44,7 +44,7 @@ DEFINE_TEST_WITH_FUNC(
 	.description =
 		"test if kmod_load_resources works (recent modprobe on kernel without modules.builtin.modinfo)",
 	.config = {
-		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-init-load-resources/",
+		[TC_ROOTFS] = "test-init-load-resources/",
 		[TC_UNAME_R] = "5.6.0",
 	});
 
@@ -53,8 +53,7 @@ DEFINE_TEST_WITH_FUNC(
 	.description =
 		"test if kmod_load_resources works with empty modules.builtin.aliases.bin (recent depmod on kernel without modules.builtin.modinfo)",
 	.config = {
-		[TC_ROOTFS] = TESTSUITE_ROOTFS
-		"test-init-load-resources-empty-builtin-aliases-bin/",
+		[TC_ROOTFS] = "test-init-load-resources-empty-builtin-aliases-bin/",
 		[TC_UNAME_R] = "5.6.0",
 	});
 
@@ -102,7 +101,7 @@ static noreturn int test_insert(const struct test *t)
 DEFINE_TEST(test_insert,
 	.description = "test if libkmod's insert_module returns ok",
 	.config = {
-		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-init/",
+		[TC_ROOTFS] = "test-init/",
 		[TC_INIT_MODULE_RETCODES] = "bla:1:20",
 	},
 	.modules_loaded = "mod_simple");
@@ -149,7 +148,7 @@ static noreturn int test_remove(const struct test *t)
 DEFINE_TEST(
 	test_remove, .description = "test if libkmod's remove_module returns ok",
 	.config = {
-		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-remove/",
+		[TC_ROOTFS] = "test-remove/",
 		[TC_DELETE_MODULE_RETCODES] = "mod-simple:0:0:bla:-1:" STRINGIFY(ENOENT),
 	});
 

--- a/testsuite/test-initstate.c
+++ b/testsuite/test-initstate.c
@@ -62,7 +62,7 @@ DEFINE_TEST(
 	.description =
 		"test if libkmod return correct initstate for builtin module from lookup",
 	.config = {
-		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-initstate",
+		[TC_ROOTFS] = "test-initstate",
 		[TC_UNAME_R] = "4.4.4",
 	});
 
@@ -104,7 +104,7 @@ DEFINE_TEST(test_initstate_from_name,
 	    .description =
 		    "test if libkmod return correct initstate for builtin module from name",
 	    .config = {
-		    [TC_ROOTFS] = TESTSUITE_ROOTFS "test-initstate",
+		    [TC_ROOTFS] = "test-initstate",
 		    [TC_UNAME_R] = "4.4.4",
 	    });
 

--- a/testsuite/test-loaded.c
+++ b/testsuite/test-loaded.c
@@ -69,10 +69,10 @@ static int loaded_1(const struct test *t)
 DEFINE_TEST(loaded_1,
 	.description = "check if list of module is created",
 	.config = {
-		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-loaded/",
+		[TC_ROOTFS] = "test-loaded/",
 	},
 	.output = {
-		.out = TESTSUITE_ROOTFS "test-loaded/correct.txt",
+		.out = "test-loaded/correct.txt",
 	});
 
 TESTSUITE_MAIN();

--- a/testsuite/test-modinfo.c
+++ b/testsuite/test-modinfo.c
@@ -27,10 +27,10 @@ static const char *progname = TOOLS_DIR "/modinfo";
 	DEFINE_TEST(test_modinfo_##_field, \
 	.description = "check " #_field " output of modinfo for different architectures", \
 	.config = { \
-		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-modinfo/", \
+		[TC_ROOTFS] = "test-modinfo/", \
 	}, \
 	.output = { \
-		.out = TESTSUITE_ROOTFS "test-modinfo/correct-" #_field #_flavor ".txt", \
+		.out = "test-modinfo/correct-" #_field #_flavor ".txt", \
 	})
 
 /* TODO: add cross-compiled modules to the test */
@@ -72,10 +72,10 @@ static noreturn int test_modinfo_signature(const struct test *t)
 DEFINE_TEST(test_modinfo_signature,
 	.description = "check signatures are correct for modinfo is correct for i686, ppc64, s390x and x86_64",
 	.config = {
-		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-modinfo/",
+		[TC_ROOTFS] = "test-modinfo/",
 	},
 	.output = {
-		.out = TESTSUITE_ROOTFS "test-modinfo/correct.txt",
+		.out = "test-modinfo/correct.txt",
 	});
 #endif
 
@@ -95,11 +95,11 @@ static noreturn int test_modinfo_external(const struct test *t)
 DEFINE_TEST(test_modinfo_external,
 	.description = "check if modinfo finds external module",
 	.config = {
-		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-modinfo/external",
+		[TC_ROOTFS] = "test-modinfo/external",
 		[TC_UNAME_R] = "4.4.4",
 	},
 	.output = {
-		.out = TESTSUITE_ROOTFS "test-modinfo/correct-external.txt",
+		.out = "test-modinfo/correct-external.txt",
 	})
 
 static noreturn int test_modinfo_builtin(const struct test *t)
@@ -117,11 +117,11 @@ static noreturn int test_modinfo_builtin(const struct test *t)
 DEFINE_TEST(test_modinfo_builtin,
 	.description = "check if modinfo finds builtin module",
 	.config = {
-		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-modinfo/builtin",
+		[TC_ROOTFS] = "test-modinfo/builtin",
 		[TC_UNAME_R] = "6.11.0",
 	},
 	.output = {
-		.out = TESTSUITE_ROOTFS "test-modinfo/correct-builtin.txt",
+		.out = "test-modinfo/correct-builtin.txt",
 	})
 
 TESTSUITE_MAIN();

--- a/testsuite/test-modprobe.c
+++ b/testsuite/test-modprobe.c
@@ -27,10 +27,10 @@ DEFINE_TEST(modprobe_show_depends,
 	.description = "check if output for modprobe --show-depends is correct for loaded modules",
 	.config = {
 		[TC_UNAME_R] = "4.4.4",
-		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-modprobe/show-depends",
+		[TC_ROOTFS] = "test-modprobe/show-depends",
 	},
 	.output = {
-		.out = TESTSUITE_ROOTFS "test-modprobe/show-depends/correct.txt",
+		.out = "test-modprobe/show-depends/correct.txt",
 	});
 
 static noreturn int modprobe_show_depends2(const struct test *t)
@@ -42,16 +42,16 @@ DEFINE_TEST(modprobe_show_depends2,
 	.description = "check if output for modprobe --show-depends is correct",
 	.config = {
 		[TC_UNAME_R] = "4.4.4",
-		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-modprobe/show-depends",
+		[TC_ROOTFS] = "test-modprobe/show-depends",
 	},
 	.output = {
-		.out = TESTSUITE_ROOTFS "test-modprobe/show-depends/correct-mod-simple.txt",
+		.out = "test-modprobe/show-depends/correct-mod-simple.txt",
 	});
 DEFINE_TEST_WITH_FUNC(modprobe_show_depends_no_load, modprobe_show_depends2,
 	.description = "check that --show-depends doesn't load any module",
 	.config = {
 		[TC_UNAME_R] = "4.4.4",
-		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-modprobe/show-depends",
+		[TC_ROOTFS] = "test-modprobe/show-depends",
 	},
 	.modules_loaded = "",
 	);
@@ -65,10 +65,10 @@ DEFINE_TEST(modprobe_show_alias_to_none,
 	.description = "check if modprobe --show-depends doesn't explode with an alias to nothing",
 	.config = {
 		[TC_UNAME_R] = "4.4.4",
-		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-modprobe/alias-to-none",
+		[TC_ROOTFS] = "test-modprobe/alias-to-none",
 	},
 	.output = {
-		.out = TESTSUITE_ROOTFS "test-modprobe/alias-to-none/correct.txt",
+		.out = "test-modprobe/alias-to-none/correct.txt",
 	},
 	.modules_loaded = "",
 	);
@@ -81,10 +81,10 @@ static noreturn int modprobe_show_exports(const struct test *t)
 DEFINE_TEST(modprobe_show_exports,
 	.description = "check if modprobe --show-depends doesn't explode with an alias to nothing",
 	.config = {
-		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-modprobe/show-exports",
+		[TC_ROOTFS] = "test-modprobe/show-exports",
 	},
 	.output = {
-		.out = TESTSUITE_ROOTFS "test-modprobe/show-exports/correct.txt",
+		.out = "test-modprobe/show-exports/correct.txt",
 		.regex = true,
 	});
 
@@ -96,7 +96,7 @@ static noreturn int modprobe_builtin(const struct test *t)
 DEFINE_TEST(modprobe_builtin, .description = "check if modprobe return 0 for builtin",
 	    .config = {
 		    [TC_UNAME_R] = "4.4.4",
-		    [TC_ROOTFS] = TESTSUITE_ROOTFS "test-modprobe/builtin",
+		    [TC_ROOTFS] = "test-modprobe/builtin",
 	    });
 
 static noreturn int modprobe_builtin_lookup_only(const struct test *t)
@@ -108,10 +108,10 @@ DEFINE_TEST(modprobe_builtin_lookup_only,
 	.description = "check if modprobe -R correctly returns the builtin module",
 	.config = {
 		[TC_UNAME_R] = "4.4.4",
-		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-modprobe/builtin",
+		[TC_ROOTFS] = "test-modprobe/builtin",
 	},
 	.output = {
-		.out = TESTSUITE_ROOTFS "test-modprobe/builtin/correct.txt",
+		.out = "test-modprobe/builtin/correct.txt",
 	});
 
 static noreturn int modprobe_softdep_loop(const struct test *t)
@@ -123,7 +123,7 @@ DEFINE_TEST(modprobe_softdep_loop,
 	.description = "check if modprobe breaks softdep loop",
 	.config = {
 		[TC_UNAME_R] = "4.4.4",
-		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-modprobe/softdep-loop",
+		[TC_ROOTFS] = "test-modprobe/softdep-loop",
 		[TC_INIT_MODULE_RETCODES] = "",
 	},
 	.modules_loaded = "mod-loop-a,mod-loop-b",
@@ -138,7 +138,7 @@ DEFINE_TEST(modprobe_weakdep_loop,
 	.description = "check if modprobe breaks weakdep loop",
 	.config = {
 		[TC_UNAME_R] = "4.4.4",
-		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-modprobe/weakdep-loop",
+		[TC_ROOTFS] = "test-modprobe/weakdep-loop",
 		[TC_INIT_MODULE_RETCODES] = "",
 	},
 	.modules_loaded = "mod-loop-b",
@@ -154,7 +154,7 @@ DEFINE_TEST(modprobe_install_cmd_loop,
 	.description = "check if modprobe breaks install-commands loop",
 	.config = {
 		[TC_UNAME_R] = "4.4.4",
-		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-modprobe/install-cmd-loop",
+		[TC_ROOTFS] = "test-modprobe/install-cmd-loop",
 		[TC_INIT_MODULE_RETCODES] = "",
 	},
 	.env_vars = (const struct keyval[]) {
@@ -173,10 +173,10 @@ DEFINE_TEST(modprobe_param_kcmdline_show_deps,
 	.description = "check if params from kcmdline are passed to (f)init_module call",
 	.config = {
 		[TC_UNAME_R] = "4.4.4",
-		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-modprobe/module-param-kcmdline",
+		[TC_ROOTFS] = "test-modprobe/module-param-kcmdline",
 	},
 	.output = {
-		.out = TESTSUITE_ROOTFS "test-modprobe/module-param-kcmdline/correct.txt",
+		.out = "test-modprobe/module-param-kcmdline/correct.txt",
 	});
 
 static noreturn int modprobe_param_kcmdline(const struct test *t)
@@ -188,40 +188,40 @@ DEFINE_TEST_WITH_FUNC(modprobe_param_kcmdline2, modprobe_param_kcmdline,
 	.description = "check if params with no value are parsed correctly from kcmdline",
 	.config = {
 		[TC_UNAME_R] = "4.4.4",
-		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-modprobe/module-param-kcmdline2",
+		[TC_ROOTFS] = "test-modprobe/module-param-kcmdline2",
 	},
 	.output = {
-		.out = TESTSUITE_ROOTFS "test-modprobe/module-param-kcmdline2/correct.txt",
+		.out = "test-modprobe/module-param-kcmdline2/correct.txt",
 	});
 
 DEFINE_TEST_WITH_FUNC(modprobe_param_kcmdline3, modprobe_param_kcmdline,
 	.description = "check if unrelated strings in kcmdline are correctly ignored",
 	.config = {
 		[TC_UNAME_R] = "4.4.4",
-		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-modprobe/module-param-kcmdline3",
+		[TC_ROOTFS] = "test-modprobe/module-param-kcmdline3",
 	},
 	.output = {
-		.out = TESTSUITE_ROOTFS "test-modprobe/module-param-kcmdline3/correct.txt",
+		.out = "test-modprobe/module-param-kcmdline3/correct.txt",
 	});
 
 DEFINE_TEST_WITH_FUNC(modprobe_param_kcmdline4, modprobe_param_kcmdline,
 	.description = "check if unrelated strings in kcmdline are correctly ignored",
 	.config = {
 		[TC_UNAME_R] = "4.4.4",
-		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-modprobe/module-param-kcmdline4",
+		[TC_ROOTFS] = "test-modprobe/module-param-kcmdline4",
 	},
 	.output = {
-		.out = TESTSUITE_ROOTFS "test-modprobe/module-param-kcmdline4/correct.txt",
+		.out = "test-modprobe/module-param-kcmdline4/correct.txt",
 	});
 
 DEFINE_TEST_WITH_FUNC(modprobe_param_kcmdline5, modprobe_param_kcmdline,
 	.description = "check if params with spaces are parsed correctly from kcmdline",
 	.config = {
 		[TC_UNAME_R] = "4.4.4",
-		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-modprobe/module-param-kcmdline5",
+		[TC_ROOTFS] = "test-modprobe/module-param-kcmdline5",
 	},
 	.output = {
-		.out = TESTSUITE_ROOTFS "test-modprobe/module-param-kcmdline5/correct.txt",
+		.out = "test-modprobe/module-param-kcmdline5/correct.txt",
 	},
 	.modules_loaded = "",
 	);
@@ -230,40 +230,40 @@ DEFINE_TEST_WITH_FUNC(modprobe_param_kcmdline6, modprobe_param_kcmdline,
 	.description = "check if dots on other parts of kcmdline don't confuse our parser",
 	.config = {
 		[TC_UNAME_R] = "4.4.4",
-		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-modprobe/module-param-kcmdline6",
+		[TC_ROOTFS] = "test-modprobe/module-param-kcmdline6",
 	},
 	.output = {
-		.out = TESTSUITE_ROOTFS "test-modprobe/module-param-kcmdline6/correct.txt",
+		.out = "test-modprobe/module-param-kcmdline6/correct.txt",
 	});
 
 DEFINE_TEST_WITH_FUNC(modprobe_param_kcmdline7, modprobe_param_kcmdline,
 	.description = "check if dots on other parts of kcmdline don't confuse our parser",
 	.config = {
 		[TC_UNAME_R] = "4.4.4",
-		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-modprobe/module-param-kcmdline7",
+		[TC_ROOTFS] = "test-modprobe/module-param-kcmdline7",
 	},
 	.output = {
-		.out = TESTSUITE_ROOTFS "test-modprobe/module-param-kcmdline7/correct.txt",
+		.out = "test-modprobe/module-param-kcmdline7/correct.txt",
 	});
 
 DEFINE_TEST_WITH_FUNC(modprobe_param_kcmdline8, modprobe_param_kcmdline,
 	.description = "check if dots on other parts of kcmdline don't confuse our parser",
 	.config = {
 		[TC_UNAME_R] = "4.4.4",
-		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-modprobe/module-param-kcmdline8",
+		[TC_ROOTFS] = "test-modprobe/module-param-kcmdline8",
 	},
 	.output = {
-		.out = TESTSUITE_ROOTFS "test-modprobe/module-param-kcmdline8/correct.txt",
+		.out = "test-modprobe/module-param-kcmdline8/correct.txt",
 	});
 
 DEFINE_TEST_WITH_FUNC(modprobe_param_kcmdline9, modprobe_param_kcmdline,
 	.description = "check if multiple blacklists are parsed correctly",
 	.config = {
 		[TC_UNAME_R] = "4.4.4",
-		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-modprobe/module-param-kcmdline9",
+		[TC_ROOTFS] = "test-modprobe/module-param-kcmdline9",
 	},
 	.output = {
-		.out = TESTSUITE_ROOTFS "test-modprobe/module-param-kcmdline9/correct.txt",
+		.out = "test-modprobe/module-param-kcmdline9/correct.txt",
 	});
 
 static noreturn int modprobe_force(const struct test *t)
@@ -275,7 +275,7 @@ DEFINE_TEST(modprobe_force,
 	.description = "check modprobe --force",
 	.config = {
 		[TC_UNAME_R] = "4.4.4",
-		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-modprobe/force",
+		[TC_ROOTFS] = "test-modprobe/force",
 		[TC_INIT_MODULE_RETCODES] = "",
 	},
 	.modules_loaded = "mod-simple",
@@ -290,7 +290,7 @@ DEFINE_TEST(modprobe_oldkernel,
 	.description = "check modprobe with kernel without finit_module()",
 	.config = {
 		[TC_UNAME_R] = "3.3.3",
-		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-modprobe/oldkernel",
+		[TC_ROOTFS] = "test-modprobe/oldkernel",
 		[TC_INIT_MODULE_RETCODES] = "",
 	},
 	.modules_loaded = "mod-simple",
@@ -305,7 +305,7 @@ DEFINE_TEST(modprobe_oldkernel_force,
 	.description = "check modprobe --force with kernel without finit_module()",
 	.config = {
 		[TC_UNAME_R] = "3.3.3",
-		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-modprobe/oldkernel-force",
+		[TC_ROOTFS] = "test-modprobe/oldkernel-force",
 		[TC_INIT_MODULE_RETCODES] = "",
 	},
 	.modules_loaded = "mod-simple",
@@ -320,7 +320,7 @@ DEFINE_TEST(modprobe_external,
 	.description = "check modprobe able to load external module",
 	.config = {
 		[TC_UNAME_R] = "4.4.4",
-		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-modprobe/external",
+		[TC_ROOTFS] = "test-modprobe/external",
 		[TC_INIT_MODULE_RETCODES] = "",
 	},
 	.modules_loaded = "mod-simple",
@@ -335,7 +335,7 @@ DEFINE_TEST(modprobe_module_from_abspath,
 	.description = "check modprobe able to load module given as an absolute path",
 	.config = {
 		[TC_UNAME_R] = "4.4.4",
-		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-modprobe/module-from-abspath",
+		[TC_ROOTFS] = "test-modprobe/module-from-abspath",
 		[TC_INIT_MODULE_RETCODES] = "",
 	},
 	.modules_loaded = "mod-simple",
@@ -355,7 +355,7 @@ DEFINE_TEST(modprobe_module_from_relpath,
 	.description = "check modprobe able to load module given as a relative path",
 	.config = {
 		[TC_UNAME_R] = "4.4.4",
-		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-modprobe/module-from-relpath",
+		[TC_ROOTFS] = "test-modprobe/module-from-relpath",
 		[TC_INIT_MODULE_RETCODES] = "",
 	},
 	.modules_loaded = "mod-simple",

--- a/testsuite/test-new-module.c
+++ b/testsuite/test-new-module.c
@@ -53,10 +53,10 @@ static int from_name(const struct test *t)
 DEFINE_TEST(from_name,
 	.description = "check if module names are parsed correctly",
 	.config = {
-		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-new-module/from_name/",
+		[TC_ROOTFS] = "test-new-module/from_name/",
 	},
 	.output = {
-		.out = TESTSUITE_ROOTFS "test-new-module/from_name/correct.txt",
+		.out = "test-new-module/from_name/correct.txt",
 	});
 
 static int from_alias(const struct test *t)
@@ -97,10 +97,10 @@ static int from_alias(const struct test *t)
 DEFINE_TEST(from_alias,
 	.description = "check if aliases are parsed correctly",
 	.config = {
-		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-new-module/from_alias/",
+		[TC_ROOTFS] = "test-new-module/from_alias/",
 	},
 	.output = {
-		.out = TESTSUITE_ROOTFS "test-new-module/from_alias/correct.txt",
+		.out = "test-new-module/from_alias/correct.txt",
 	});
 
 TESTSUITE_MAIN();

--- a/testsuite/test-testsuite.c
+++ b/testsuite/test-testsuite.c
@@ -64,7 +64,7 @@ static int testsuite_rootfs_fopen(const struct test *t)
 }
 DEFINE_TEST(testsuite_rootfs_fopen, .description = "test if rootfs works - fopen()",
 	    .config = {
-		    [TC_ROOTFS] = TESTSUITE_ROOTFS "test-rootfs/",
+		    [TC_ROOTFS] = "test-rootfs/",
 	    });
 
 static int testsuite_rootfs_open(const struct test *t)
@@ -95,7 +95,7 @@ static int testsuite_rootfs_open(const struct test *t)
 }
 DEFINE_TEST(testsuite_rootfs_open, .description = "test if rootfs works - open()",
 	    .config = {
-		    [TC_ROOTFS] = TESTSUITE_ROOTFS "test-rootfs/",
+		    [TC_ROOTFS] = "test-rootfs/",
 	    });
 
 static int testsuite_rootfs_stat(const struct test *t)
@@ -111,7 +111,7 @@ static int testsuite_rootfs_stat(const struct test *t)
 }
 DEFINE_TEST(testsuite_rootfs_stat, .description = "test if rootfs works - stat()",
 	    .config = {
-		    [TC_ROOTFS] = TESTSUITE_ROOTFS "test-rootfs/",
+		    [TC_ROOTFS] = "test-rootfs/",
 	    });
 
 static int testsuite_rootfs_opendir(const struct test *t)
@@ -129,7 +129,7 @@ static int testsuite_rootfs_opendir(const struct test *t)
 }
 DEFINE_TEST(testsuite_rootfs_opendir, .description = "test if rootfs works - opendir()",
 	    .config = {
-		    [TC_ROOTFS] = TESTSUITE_ROOTFS "test-rootfs/",
+		    [TC_ROOTFS] = "test-rootfs/",
 	    });
 
 TESTSUITE_MAIN();

--- a/testsuite/test-util.c
+++ b/testsuite/test-util.c
@@ -54,10 +54,10 @@ static int alias_1(const struct test *t)
 DEFINE_TEST(alias_1,
 	.description = "check if alias_normalize does the right thing",
 	.config = {
-		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-util/",
+		[TC_ROOTFS] = "test-util/",
 	},
 	.output = {
-		.out = TESTSUITE_ROOTFS "test-util/alias-correct.txt",
+		.out = "test-util/alias-correct.txt",
 	});
 
 static int test_freadline_wrapped(const struct test *t)
@@ -83,10 +83,10 @@ static int test_freadline_wrapped(const struct test *t)
 DEFINE_TEST(test_freadline_wrapped,
 	.description = "check if freadline_wrapped() does the right thing",
 	.config = {
-		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-util/",
+		[TC_ROOTFS] = "test-util/",
 	},
 	.output = {
-		.out = TESTSUITE_ROOTFS "test-util/freadline_wrapped-correct.txt",
+		.out = "test-util/freadline_wrapped-correct.txt",
 	});
 
 static int test_strchr_replace(const struct test *t)
@@ -161,7 +161,7 @@ DEFINE_TEST(test_path_ends_with_kmod_ext,
 	    .description = "check implementation of path_ends_with_kmod_ext()")
 
 #define TEST_WRITE_STR_SAFE_FILE "/write-str-safe"
-#define TEST_WRITE_STR_SAFE_PATH TESTSUITE_ROOTFS "test-util2/" TEST_WRITE_STR_SAFE_FILE
+#define TEST_WRITE_STR_SAFE_PATH "test-util2/" TEST_WRITE_STR_SAFE_FILE
 static int test_write_str_safe(const struct test *t)
 {
 	const char *s = "test";
@@ -178,7 +178,7 @@ static int test_write_str_safe(const struct test *t)
 DEFINE_TEST(test_write_str_safe,
 	.description = "check implementation of write_str_safe()",
 	.config = {
-		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-util2/",
+		[TC_ROOTFS] = "test-util2/",
 	},
 	.output = {
 		.files = (const struct keyval[]) {

--- a/testsuite/test-weakdep.c
+++ b/testsuite/test-weakdep.c
@@ -79,11 +79,11 @@ DEFINE_TEST(test_weakdep,
 	.description = "check if modprobe breaks weakdep",
 	.config = {
 		[TC_UNAME_R] = "4.4.4",
-		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-weakdep",
+		[TC_ROOTFS] = "test-weakdep",
 		[TC_INIT_MODULE_RETCODES] = "",
 	},
 	.output = {
-		.out = TESTSUITE_ROOTFS "test-weakdep/correct-weakdep.txt",
+		.out = "test-weakdep/correct-weakdep.txt",
 	});
 
 TESTSUITE_MAIN();

--- a/testsuite/testsuite.c
+++ b/testsuite/testsuite.c
@@ -59,7 +59,7 @@ static const char *test_rootfs(const struct test *t)
 	if (t->config[TC_ROOTFS] == NULL)
 		return NULL;
 
-	snprintf(dirname, sizeof(dirname), "%s", t->config[TC_ROOTFS]);
+	snprintf(dirname, sizeof(dirname), TESTSUITE_ROOTFS "%s", t->config[TC_ROOTFS]);
 	return dirname;
 }
 
@@ -69,7 +69,7 @@ static const char *test_actual_filename(const char *fn)
 	if (fn == NULL)
 		return NULL;
 
-	snprintf(filename, sizeof(filename), "%s", fn);
+	snprintf(filename, sizeof(filename), TESTSUITE_ROOTFS "%s", fn);
 	return filename;
 }
 

--- a/testsuite/testsuite.c
+++ b/testsuite/testsuite.c
@@ -63,6 +63,16 @@ static const char *test_rootfs(const struct test *t)
 	return dirname;
 }
 
+static const char *test_actual_filename(const char *fn)
+{
+	static char filename[PATH_MAX];
+	if (fn == NULL)
+		return NULL;
+
+	snprintf(filename, sizeof(filename), "%s", fn);
+	return filename;
+}
+
 static void help(void)
 {
 	const struct option *itr;
@@ -699,13 +709,13 @@ static bool check_generated_files(const struct test *t)
 		char bufa[4096];
 		char bufb[4096];
 
-		fda = open(k->key, O_RDONLY);
+		fda = open(test_actual_filename(k->key), O_RDONLY);
 		if (fda < 0) {
 			ERR("could not open %s\n - %m\n", k->key);
 			goto fail;
 		}
 
-		fdb = open(k->val, O_RDONLY);
+		fdb = open(test_actual_filename(k->val), O_RDONLY);
 		if (fdb < 0) {
 			ERR("could not open %s\n - %m\n", k->val);
 			goto fail;


### PR DESCRIPTION
This series started off as de-duplicating the macros that we copy-paste across the tests and ultimately paved the way to allowing the tests to run in a VM aka https://github.com/kmod-project/kmod/issues/50.

That goal is not yet complete, but the general premise is that:
 - `DEFINE_TEST` provides the rootfs (_just_ the test sub-folder) and uname
 - any files (output.out, output.err, output.files) are stored and defined as relative to ^^
   - some tests are currently bugged wrt ^^
 - path construction - be that for `output` or the `TESTSUITE_ROOTFS` happens in the shared places - `testsuite.c` and/or `path.c`
 - (to be added as follow-up PR) machinery will copy/mount the sub-test folder into a chroot-like setup and run the test

As you can see the patch series isn't even complete yet. Although since it's churn _heavy_ I thought that sending it out early to feedback, would be a good idea.

Aside: I have another 1-2 series to further reduce the boilerplate, following which the tests will start to flow :crossed_fingers: 