### PR TITLE
Allow to dlopen compression libraries

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,8 +34,13 @@ jobs:
           - name: 'debian:unstable'
             multilib: 'true'
           - name: 'fedora:latest'
+          - name: 'fedora:latest'
+            meson_setup: '-D xz=disabled -D dlopen=all'
           - name: 'ubuntu:22.04'
             multilib: 'true'
+          - name: 'ubuntu:22.04'
+            multilib: 'true'
+            meson_setup: '-D dlopen=zstd,zlib'
           - name: 'ubuntu:24.04'
             multilib: 'true'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,8 +80,18 @@ jobs:
               return 1
             fi
           }
+          should_pass() {
+            rm -rf build-setup-test/
+            meson setup "$@" build-setup-test/
+          }
+
           should_fail -D distconfdir=relative/
           should_fail -D moduledir=relative/
+          should_fail -D dlopen=nonexistent
+          should_fail -D xz=disabled -D dlopen=xz
+
+          should_pass -D dlopen=xz
+          should_pass -D dlopen=xz -D xz=enabled
 
       - name: configure (meson)
         if: ${{ matrix.build == 'meson' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,14 +74,14 @@ jobs:
         if: ${{ matrix.build == 'meson' }}
         run: |
           should_fail() {
-            if meson setup "$@" build/; then
+            rm -rf build-setup-test/
+            if meson setup "$@" build-setup-test/; then
               echo Command was expected to fail, but was successful
               return 1
             fi
           }
           should_fail -D distconfdir=relative/
           should_fail -D moduledir=relative/
-          rm -rf build/
 
       - name: configure (meson)
         if: ${{ matrix.build == 'meson' }}

--- a/Makefile.am
+++ b/Makefile.am
@@ -58,6 +58,7 @@ noinst_LTLIBRARIES = shared/libshared.la
 shared_libshared_la_SOURCES = \
 	shared/array.c \
 	shared/array.h \
+	shared/elf-note.h \
 	shared/hash.c \
 	shared/hash.h \
 	shared/macro.h \

--- a/configure.ac
+++ b/configure.ac
@@ -111,9 +111,10 @@ AC_ARG_WITH([zstd],
 	[], [with_zstd=no])
 AS_IF([test "x$with_zstd" != "xno"], [
 	PKG_CHECK_MODULES([libzstd], [libzstd >= 1.4.4], [LIBS="$LIBS $libzstd_LIBS"])
-	AC_DEFINE([ENABLE_ZSTD], [1], [Enable Zstandard for modules.])
+	AC_DEFINE([ENABLE_ZSTD], [1], [Zstandard for modules.])
 	module_compressions="zstd $module_compressions"
 ], [
+	AC_DEFINE([ENABLE_ZSTD], [0], [Zstandard for modules.])
 	AC_MSG_NOTICE([Zstandard support not requested])
 ])
 CC_FEATURE_APPEND([with_features], [with_zstd], [ZSTD])
@@ -124,9 +125,10 @@ AC_ARG_WITH([xz],
 	[], [with_xz=no])
 AS_IF([test "x$with_xz" != "xno"], [
 	PKG_CHECK_MODULES([liblzma], [liblzma >= 4.99], [LIBS="$LIBS $liblzma_LIBS"])
-	AC_DEFINE([ENABLE_XZ], [1], [Enable Xz for modules.])
+	AC_DEFINE([ENABLE_XZ], [1], [xz for modules.])
 	module_compressions="xz $module_compressions"
 ], [
+	AC_DEFINE([ENABLE_XZ], [0], [xz for modules.])
 	AC_MSG_NOTICE([Xz support not requested])
 ])
 CC_FEATURE_APPEND([with_features], [with_xz], [XZ])
@@ -137,9 +139,10 @@ AC_ARG_WITH([zlib],
 	[], [with_zlib=no])
 AS_IF([test "x$with_zlib" != "xno"], [
 	PKG_CHECK_MODULES([zlib], [zlib], [LIBS="$LIBS $zlib_LIBS"])
-	AC_DEFINE([ENABLE_ZLIB], [1], [Enable zlib for modules.])
+	AC_DEFINE([ENABLE_ZLIB], [1], [zlib for modules.])
 	module_compressions="gzip $module_compressions"
 ], [
+	AC_DEFINE([ENABLE_ZLIB], [0], [zlib for modules.])
 	AC_MSG_NOTICE([zlib support not requested])
 ])
 CC_FEATURE_APPEND([with_features], [with_zlib], [ZLIB])
@@ -150,9 +153,10 @@ AC_ARG_WITH([openssl],
 	[], [with_openssl=no])
 AS_IF([test "x$with_openssl" != "xno"], [
 	PKG_CHECK_MODULES([libcrypto], [libcrypto >= 1.1.0], [LIBS="$LIBS $libcrypto_LIBS"])
-	AC_DEFINE([ENABLE_OPENSSL], [1], [Enable openssl for modinfo.])
+	AC_DEFINE([ENABLE_OPENSSL], [1], [openssl for modinfo.])
 	module_signatures="PKCS7 $module_signatures"
 ], [
+	AC_DEFINE([ENABLE_OPENSSL], [0], [openssl for modinfo.])
 	AC_MSG_NOTICE([openssl support not requested])
 ])
 CC_FEATURE_APPEND([with_features], [with_openssl], [LIBCRYPTO])

--- a/configure.ac
+++ b/configure.ac
@@ -119,6 +119,7 @@ AS_IF([test "x$with_zstd" != "xno"], [
 ])
 CC_FEATURE_APPEND([with_features], [with_zstd], [ZSTD])
 AM_CONDITIONAL([ENABLE_ZSTD], [test "x$with_zstd" != "xno"])
+AC_DEFINE([ENABLE_ZSTD_DLOPEN], [0], [dlopen zstd])
 
 AC_ARG_WITH([xz],
 	AS_HELP_STRING([--with-xz], [handle Xz-compressed modules @<:@default=disabled@:>@]),
@@ -133,6 +134,7 @@ AS_IF([test "x$with_xz" != "xno"], [
 ])
 CC_FEATURE_APPEND([with_features], [with_xz], [XZ])
 AM_CONDITIONAL([ENABLE_XZ], [test "x$with_xz" != "xno"])
+AC_DEFINE([ENABLE_XZ_DLOPEN], [0], [dlopen xz])
 
 AC_ARG_WITH([zlib],
 	AS_HELP_STRING([--with-zlib], [handle gzipped modules @<:@default=disabled@:>@]),
@@ -147,6 +149,7 @@ AS_IF([test "x$with_zlib" != "xno"], [
 ])
 CC_FEATURE_APPEND([with_features], [with_zlib], [ZLIB])
 AM_CONDITIONAL([ENABLE_ZLIB], [test "x$with_zlib" != "xno"])
+AC_DEFINE([ENABLE_ZLIB_DLOPEN], [0], [dlopen zlib])
 
 AC_ARG_WITH([openssl],
 	AS_HELP_STRING([--with-openssl], [handle PKCS7 signatures @<:@default=disabled@:>@]),

--- a/libkmod/libkmod-file-xz.c
+++ b/libkmod/libkmod-file-xz.c
@@ -14,6 +14,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <shared/elf-note.h>
 #include <shared/util.h>
 
 #include "libkmod.h"
@@ -29,12 +30,16 @@ DL_SYMBOL_TABLE(DECLARE_SYM)
 
 static int dlopen_lzma(void)
 {
+#if !DLSYM_LOCALLY_ENABLED
+	return 0;
+#else
 	static void *dl = NULL;
 
-	if (!DLSYM_LOCALLY_ENABLED)
-		return 0;
+	ELF_NOTE_DLOPEN("xz", "Support for uncompressing xz-compressed modules",
+			ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED, "liblzma.so.5");
 
 	return dlsym_many(&dl, "liblzma.so.5", DL_SYMBOL_TABLE(DLSYM_ARG) NULL);
+#endif
 }
 
 static void xz_uncompress_belch(struct kmod_file *file, lzma_ret ret)

--- a/libkmod/libkmod-file-xz.c
+++ b/libkmod/libkmod-file-xz.c
@@ -3,8 +3,7 @@
  * Copyright © 2024 Intel Corporation
  */
 
-/* TODO: replace with build system define once supported */
-#define DLSYM_LOCALLY_ENABLED 0
+#define DLSYM_LOCALLY_ENABLED ENABLE_XZ_DLOPEN
 
 #include <errno.h>
 #include <lzma.h>

--- a/libkmod/libkmod-file-zlib.c
+++ b/libkmod/libkmod-file-zlib.c
@@ -3,8 +3,7 @@
  * Copyright © 2024 Intel Corporation
  */
 
-/* TODO: replace with build system define once supported */
-#define DLSYM_LOCALLY_ENABLED 0
+#define DLSYM_LOCALLY_ENABLED ENABLE_ZLIB_DLOPEN
 
 #include <errno.h>
 #include <stdio.h>

--- a/libkmod/libkmod-file-zlib.c
+++ b/libkmod/libkmod-file-zlib.c
@@ -14,6 +14,7 @@
 #include <unistd.h>
 #include <zlib.h>
 
+#include <shared/elf-note.h>
 #include <shared/util.h>
 
 #include "libkmod.h"
@@ -32,12 +33,16 @@ DL_SYMBOL_TABLE(DECLARE_SYM)
 
 static int dlopen_zlib(void)
 {
+#if !DLSYM_LOCALLY_ENABLED
+	return 0;
+#else
 	static void *dl = NULL;
 
-	if (!DLSYM_LOCALLY_ENABLED)
-		return 0;
+	ELF_NOTE_DLOPEN("zlib", "Support for uncompressing zlib-compressed modules",
+			ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED, "libz.so.1");
 
 	return dlsym_many(&dl, "libz.so.1", DL_SYMBOL_TABLE(DLSYM_ARG) NULL);
+#endif
 }
 
 int kmod_file_load_zlib(struct kmod_file *file)

--- a/libkmod/libkmod-file-zlib.c
+++ b/libkmod/libkmod-file-zlib.c
@@ -3,6 +3,9 @@
  * Copyright © 2024 Intel Corporation
  */
 
+/* TODO: replace with build system define once supported */
+#define DLSYM_LOCALLY_ENABLED 0
+
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -20,6 +23,24 @@
 
 #define READ_STEP (4 * 1024 * 1024)
 
+#define DL_SYMBOL_TABLE(M) \
+	M(gzclose)         \
+	M(gzdopen)         \
+	M(gzerror)         \
+	M(gzread)
+
+DL_SYMBOL_TABLE(DECLARE_SYM)
+
+static int dlopen_zlib(void)
+{
+	static void *dl = NULL;
+
+	if (!DLSYM_LOCALLY_ENABLED)
+		return 0;
+
+	return dlsym_many(&dl, "libz.so.1", DL_SYMBOL_TABLE(DLSYM_ARG) NULL);
+}
+
 int kmod_file_load_zlib(struct kmod_file *file)
 {
 	int ret = 0;
@@ -28,12 +49,19 @@ int kmod_file_load_zlib(struct kmod_file *file)
 	gzFile gzf;
 	int gzfd;
 
+	ret = dlopen_zlib();
+	if (ret < 0) {
+		ERR(file->ctx, "zlib: can't load and resolve symbols (%s)",
+		    strerror(-ret));
+		return -EINVAL;
+	}
+
 	errno = 0;
 	gzfd = fcntl(file->fd, F_DUPFD_CLOEXEC, 3);
 	if (gzfd < 0)
 		return -errno;
 
-	gzf = gzdopen(gzfd, "rb"); /* takes ownership of the fd */
+	gzf = sym_gzdopen(gzfd, "rb"); /* takes ownership of the fd */
 	if (gzf == NULL) {
 		close(gzfd);
 		return -errno;
@@ -52,12 +80,12 @@ int kmod_file_load_zlib(struct kmod_file *file)
 			p = tmp;
 		}
 
-		r = gzread(gzf, p + did, total - did);
+		r = sym_gzread(gzf, p + did, total - did);
 		if (r == 0)
 			break;
 		else if (r < 0) {
 			int gzerr;
-			const char *gz_errmsg = gzerror(gzf, &gzerr);
+			const char *gz_errmsg = sym_gzerror(gzf, &gzerr);
 
 			ERR(file->ctx, "gzip: %s\n", gz_errmsg);
 
@@ -71,10 +99,10 @@ int kmod_file_load_zlib(struct kmod_file *file)
 	file->memory = p;
 	file->size = did;
 	p = NULL;
-	gzclose(gzf);
+	sym_gzclose(gzf);
 	return 0;
 
 error:
-	gzclose(gzf); /* closes the gzfd */
+	sym_gzclose(gzf);
 	return ret;
 }

--- a/libkmod/libkmod-file-zlib.c
+++ b/libkmod/libkmod-file-zlib.c
@@ -22,7 +22,7 @@
 
 int kmod_file_load_zlib(struct kmod_file *file)
 {
-	int err = 0;
+	int ret = 0;
 	off_t did = 0, total = 0;
 	_cleanup_free_ unsigned char *p = NULL;
 	gzFile gzf;
@@ -45,7 +45,7 @@ int kmod_file_load_zlib(struct kmod_file *file)
 		if (did == total) {
 			void *tmp = realloc(p, total + READ_STEP);
 			if (tmp == NULL) {
-				err = -errno;
+				ret = -errno;
 				goto error;
 			}
 			total += READ_STEP;
@@ -62,7 +62,7 @@ int kmod_file_load_zlib(struct kmod_file *file)
 			ERR(file->ctx, "gzip: %s\n", gz_errmsg);
 
 			/* gzip might not set errno here */
-			err = gzerr == Z_ERRNO ? -errno : -EINVAL;
+			ret = gzerr == Z_ERRNO ? -errno : -EINVAL;
 			goto error;
 		}
 		did += r;
@@ -76,5 +76,5 @@ int kmod_file_load_zlib(struct kmod_file *file)
 
 error:
 	gzclose(gzf); /* closes the gzfd */
-	return err;
+	return ret;
 }

--- a/libkmod/libkmod-file-zstd.c
+++ b/libkmod/libkmod-file-zstd.c
@@ -22,9 +22,10 @@
 int kmod_file_load_zstd(struct kmod_file *file)
 {
 	void *src_buf = MAP_FAILED, *dst_buf = NULL;
-	size_t src_size, dst_size, ret;
+	size_t src_size, dst_size;
 	unsigned long long frame_size;
 	struct stat st;
+	int ret;
 
 	if (fstat(file->fd, &st) < 0) {
 		ret = -errno;
@@ -64,9 +65,9 @@ int kmod_file_load_zstd(struct kmod_file *file)
 		goto out;
 	}
 
-	ret = ZSTD_decompress(dst_buf, dst_size, src_buf, src_size);
-	if (ZSTD_isError(ret)) {
-		ERR(file->ctx, "zstd: %s\n", ZSTD_getErrorName(ret));
+	dst_size = ZSTD_decompress(dst_buf, dst_size, src_buf, src_size);
+	if (ZSTD_isError(dst_size)) {
+		ERR(file->ctx, "zstd: %s\n", ZSTD_getErrorName(dst_size));
 		ret = -EINVAL;
 		goto out;
 	}

--- a/libkmod/libkmod-file-zstd.c
+++ b/libkmod/libkmod-file-zstd.c
@@ -3,8 +3,7 @@
  * Copyright © 2024 Intel Corporation
  */
 
-/* TODO: replace with build system define once supported */
-#define DLSYM_LOCALLY_ENABLED 0
+#define DLSYM_LOCALLY_ENABLED ENABLE_ZSTD_DLOPEN
 
 #include <errno.h>
 #include <stdio.h>

--- a/libkmod/libkmod-file-zstd.c
+++ b/libkmod/libkmod-file-zstd.c
@@ -15,6 +15,7 @@
 #include <unistd.h>
 #include <zstd.h>
 
+#include <shared/elf-note.h>
 #include <shared/util.h>
 
 #include "libkmod.h"
@@ -31,12 +32,16 @@ DL_SYMBOL_TABLE(DECLARE_SYM)
 
 static int dlopen_zstd(void)
 {
+#if !DLSYM_LOCALLY_ENABLED
+	return 0;
+#else
 	static void *dl = NULL;
 
-	if (!DLSYM_LOCALLY_ENABLED)
-		return 0;
+	ELF_NOTE_DLOPEN("zstd", "Support for uncompressing zstd-compressed modules",
+			ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED, "libzstd.so.1");
 
 	return dlsym_many(&dl, "libzstd.so.1", DL_SYMBOL_TABLE(DLSYM_ARG) NULL);
+#endif
 }
 
 int kmod_file_load_zstd(struct kmod_file *file)

--- a/libkmod/libkmod-internal-file.h
+++ b/libkmod/libkmod-internal-file.h
@@ -20,7 +20,7 @@ struct kmod_file {
 	struct kmod_elf *elf;
 };
 
-#ifdef ENABLE_XZ
+#if ENABLE_XZ
 int kmod_file_load_xz(struct kmod_file *file);
 #else
 static inline int kmod_file_load_xz(struct kmod_file *file)
@@ -29,7 +29,7 @@ static inline int kmod_file_load_xz(struct kmod_file *file)
 }
 #endif
 
-#ifdef ENABLE_ZLIB
+#if ENABLE_ZLIB
 int kmod_file_load_zlib(struct kmod_file *file);
 #else
 static inline int kmod_file_load_zlib(struct kmod_file *file)
@@ -38,7 +38,7 @@ static inline int kmod_file_load_zlib(struct kmod_file *file)
 }
 #endif
 
-#ifdef ENABLE_ZSTD
+#if ENABLE_ZSTD
 int kmod_file_load_zstd(struct kmod_file *file);
 #else
 static inline int kmod_file_load_zstd(struct kmod_file *file)

--- a/libkmod/libkmod-signature.c
+++ b/libkmod/libkmod-signature.c
@@ -5,7 +5,7 @@
 
 #include <endian.h>
 #include <inttypes.h>
-#ifdef ENABLE_OPENSSL
+#if ENABLE_OPENSSL
 #include <openssl/pkcs7.h>
 #include <openssl/ssl.h>
 #endif
@@ -109,7 +109,7 @@ static bool fill_default(const char *mem, off_t size,
 	return true;
 }
 
-#ifdef ENABLE_OPENSSL
+#if ENABLE_OPENSSL
 
 struct pkcs7_private {
 	PKCS7 *pkcs7;

--- a/meson.build
+++ b/meson.build
@@ -363,6 +363,7 @@ libshared = static_library(
   files(
     'shared/array.c',
     'shared/array.h',
+    'shared/elf-note.h',
     'shared/hash.c',
     'shared/hash.h',
     'shared/macro.h',

--- a/meson.build
+++ b/meson.build
@@ -289,23 +289,23 @@ endif
 
 zstd = dependency('libzstd', version : '>= 1.4.4', required : get_option('zstd'))
 if zstd.found()
-  cdata.set('ENABLE_ZSTD', true)
   module_compressions += 'zstd '
 endif
+cdata.set10('ENABLE_ZSTD', zstd.found())
 features += ['@0@ZSTD'.format(zstd.found() ? '+' : '-')]
 
 xz = dependency('liblzma', version : '>= 4.99', required : get_option('xz'))
 if xz.found()
-  cdata.set('ENABLE_XZ', true)
   module_compressions += 'xz '
 endif
+cdata.set10('ENABLE_XZ', xz.found())
 features += ['@0@XZ'.format(xz.found() ? '+' : '-')]
 
 zlib = dependency('zlib', required : get_option('zlib'))
 if zlib.found()
-  cdata.set('ENABLE_ZLIB', true)
   module_compressions += 'zlib '
 endif
+cdata.set10('ENABLE_ZLIB', zlib.found())
 features += ['@0@ZLIB'.format(zlib.found() ? '+' : '-')]
 
 #-------------------------------------------------------------------------------
@@ -314,11 +314,11 @@ features += ['@0@ZLIB'.format(zlib.found() ? '+' : '-')]
 
 crypto = dependency('libcrypto', version : '>= 1.1.0', required : get_option('openssl'))
 if crypto.found()
-  cdata.set('ENABLE_OPENSSL', true)
   module_signatures = 'PKCS7 legacy'
 else
   module_signatures = 'legacy'
 endif
+cdata.set10('ENABLE_OPENSSL', crypto.found())
 features += ['@0@LIBCRYPTO'.format(crypto.found() ? '+' : '-')]
 
 cdata.set_quoted('KMOD_FEATURES', ' '.join(features))

--- a/meson.build
+++ b/meson.build
@@ -174,6 +174,7 @@ module_compressions = ''
 module_signatures = ''
 
 features = []
+dep_map = {}
 
 #-------------------------------------------------------------------------------
 # Directories
@@ -287,26 +288,29 @@ endif
 # Compression support
 #-------------------------------------------------------------------------------
 
-zstd = dependency('libzstd', version : '>= 1.4.4', required : get_option('zstd'))
-if zstd.found()
-  module_compressions += 'zstd '
-endif
-cdata.set10('ENABLE_ZSTD', zstd.found())
-features += ['@0@ZSTD'.format(zstd.found() ? '+' : '-')]
+_compression = [
+  ['zstd', 'libzstd', '>= 1.4.4'],
+  ['xz',   'liblzma', '>= 4.99'],
+  ['zlib', 'zlib',    '>= 0'],
+]
 
-xz = dependency('liblzma', version : '>= 4.99', required : get_option('xz'))
-if xz.found()
-  module_compressions += 'xz '
-endif
-cdata.set10('ENABLE_XZ', xz.found())
-features += ['@0@XZ'.format(xz.found() ? '+' : '-')]
+foreach tuple : _compression
+  opt = tuple[0]
+  pkg_dep = tuple[1]
+  pkg_dep_version = tuple[2]
 
-zlib = dependency('zlib', required : get_option('zlib'))
-if zlib.found()
-  module_compressions += 'zlib '
-endif
-cdata.set10('ENABLE_ZLIB', zlib.found())
-features += ['@0@ZLIB'.format(zlib.found() ? '+' : '-')]
+  dep = dependency(pkg_dep, version : pkg_dep_version, required : get_option(opt))
+  have = dep.found()
+
+  cdata.set10('ENABLE_' + opt.to_upper(), have)
+
+  if have
+    module_compressions += '@0@ '.format(opt)
+  endif
+
+  features += ['@0@@1@'.format(have ? '+' : '-', opt.to_upper())]
+  dep_map += {opt : dep}
+endforeach
 
 #-------------------------------------------------------------------------------
 # Signed modules
@@ -370,19 +374,19 @@ libkmod_files = files(
 
 libkmod_deps = []
 
-if zstd.found()
+if dep_map.get('zstd').found()
   libkmod_files += files('libkmod/libkmod-file-zstd.c')
-  libkmod_deps += zstd
+  libkmod_deps += dep_map['zstd']
 endif
 
-if xz.found()
+if dep_map.get('xz').found()
   libkmod_files += files('libkmod/libkmod-file-xz.c')
-  libkmod_deps += xz
+  libkmod_deps += dep_map['xz']
 endif
 
-if zlib.found()
+if dep_map.get('zlib').found()
   libkmod_files += files('libkmod/libkmod-file-zlib.c')
-  libkmod_deps += zlib
+  libkmod_deps += dep_map['zlib']
 endif
 
 if crypto.found()

--- a/meson.build
+++ b/meson.build
@@ -316,14 +316,22 @@ endforeach
 # Signed modules
 #-------------------------------------------------------------------------------
 
-crypto = dependency('libcrypto', version : '>= 1.1.0', required : get_option('openssl'))
-if crypto.found()
+opt = 'openssl'
+dep = dependency('libcrypto', version : '>= 1.1.0', required : get_option(opt))
+have = dep.found()
+
+if have
   module_signatures = 'PKCS7 legacy'
 else
   module_signatures = 'legacy'
 endif
-cdata.set10('ENABLE_OPENSSL', crypto.found())
-features += ['@0@LIBCRYPTO'.format(crypto.found() ? '+' : '-')]
+cdata.set10('ENABLE_' + opt.to_upper(), have)
+features += ['@0@@1@'.format(have ? '+' : '-', opt.to_upper())]
+dep_map += {opt : dep}
+
+#-------------------------------------------------------------------------------
+# Config output
+#-------------------------------------------------------------------------------
 
 cdata.set_quoted('KMOD_FEATURES', ' '.join(features))
 
@@ -389,8 +397,8 @@ if dep_map.get('zlib').found()
   libkmod_deps += dep_map['zlib']
 endif
 
-if crypto.found()
-  libkmod_deps += crypto
+if dep_map.get('openssl').found()
+  libkmod_deps += dep_map['openssl']
 endif
 
 install_headers('libkmod/libkmod.h')

--- a/meson.build
+++ b/meson.build
@@ -176,6 +176,9 @@ module_signatures = ''
 features = []
 dep_map = {}
 
+# keep in sync with meson_options.txt
+dlopen_all = get_option('dlopen').contains('all')
+
 #-------------------------------------------------------------------------------
 # Directories
 #-------------------------------------------------------------------------------
@@ -299,10 +302,19 @@ foreach tuple : _compression
   pkg_dep = tuple[1]
   pkg_dep_version = tuple[2]
 
+  dlopen = dlopen_all or get_option('dlopen').contains(opt)
+  if not dlopen_all and dlopen and get_option(opt).disabled()
+    error('Incompatiable options: dlopen=@0@ for disabled @0@'.format(opt))
+  endif
+
   dep = dependency(pkg_dep, version : pkg_dep_version, required : get_option(opt))
   have = dep.found()
+  if have and dlopen
+    dep = dep.partial_dependency(compile_args : true, includes : true)
+  endif
 
   cdata.set10('ENABLE_' + opt.to_upper(), have)
+  cdata.set10('ENABLE_' + opt.to_upper() + '_DLOPEN', have and dlopen)
 
   if have
     module_compressions += '@0@ '.format(opt)
@@ -567,6 +579,7 @@ summary({
   'build-tests'     : get_option('build-tests'),
   'manpages'        : get_option('manpages'),
   'docs'            : get_option('docs'),
+  'dlopen'          : get_option('dlopen'),
 }, section : 'Options')
 
 summary({

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -68,6 +68,14 @@ option(
 )
 
 option(
+  'dlopen',
+  type : 'array',
+  choices : ['zstd', 'xz', 'zlib', 'all'],
+  value : [],
+  description : 'Libraries to dlopen rather than linking. Use \'all\' to . Default: none',
+)
+
+option(
   'logging',
   type : 'boolean',
   value : true,

--- a/shared/elf-note.h
+++ b/shared/elf-note.h
@@ -1,0 +1,53 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include "macro.h"
+
+/*
+ * Originally from systemd codebase.
+ *
+ * Reference: https://systemd.io/ELF_PACKAGE_METADATA/
+ */
+
+// clang-format off
+
+#define ELF_NOTE_DLOPEN_VENDOR "FDO"
+#define ELF_NOTE_DLOPEN_TYPE UINT32_C(0x407c0c0a)
+#define ELF_NOTE_DLOPEN_PRIORITY_REQUIRED "required"
+#define ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED "recommended"
+#define ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED "suggested"
+
+/* Add an ".note.dlopen" ELF note to our binary that declares our weak dlopen() dependency. This
+ * information can be read from an ELF file via "readelf -p .note.dlopen" or an equivalent command. */
+#define _ELF_NOTE_DLOPEN(json, variable_name)                              \
+        __attribute__((used, section(".note.dlopen"))) _Alignas(sizeof(uint32_t)) static const struct { \
+                struct {                                                   \
+                        uint32_t n_namesz, n_descsz, n_type;               \
+                } nhdr;                                                    \
+                char name[sizeof(ELF_NOTE_DLOPEN_VENDOR)];                 \
+                _Alignas(sizeof(uint32_t)) char dlopen_json[sizeof(json)]; \
+        } variable_name = {                                                \
+                .nhdr = {                                                  \
+                        .n_namesz = sizeof(ELF_NOTE_DLOPEN_VENDOR),        \
+                        .n_descsz = sizeof(json),                          \
+                        .n_type   = ELF_NOTE_DLOPEN_TYPE,                  \
+                },                                                         \
+                .name = ELF_NOTE_DLOPEN_VENDOR,                            \
+                .dlopen_json = json,                                       \
+        }
+
+#define _SONAME_ARRAY1(a) "[\""a"\"]"
+#define _SONAME_ARRAY2(a, b) "[\""a"\",\""b"\"]"
+#define _SONAME_ARRAY3(a, b, c) "[\""a"\",\""b"\",\""c"\"]"
+#define _SONAME_ARRAY4(a, b, c, d) "[\""a"\",\""b"\",\""c"\"",\""d"\"]"
+#define _SONAME_ARRAY5(a, b, c, d, e) "[\""a"\",\""b"\",\""c"\"",\""d"\",\""e"\"]"
+#define _SONAME_ARRAY_GET(_1,_2,_3,_4,_5,NAME,...) NAME
+#define _SONAME_ARRAY(...) _SONAME_ARRAY_GET(__VA_ARGS__, _SONAME_ARRAY5, _SONAME_ARRAY4, _SONAME_ARRAY3, _SONAME_ARRAY2, _SONAME_ARRAY1)(__VA_ARGS__)
+
+/* The 'priority' must be one of 'required', 'recommended' or 'suggested' as per specification, use the
+ * macro defined above to specify it.
+ * Multiple sonames can be passed and they will be automatically constructed into a json array (but note that
+ * due to preprocessor language limitations if more than the limit defined above is used, a new
+ * _SONAME_ARRAY<X+1> will need to be added). */
+#define ELF_NOTE_DLOPEN(feature, description, priority, ...) \
+        _ELF_NOTE_DLOPEN("[{\"feature\":\"" feature "\",\"description\":\"" description "\",\"priority\":\"" priority "\",\"soname\":" _SONAME_ARRAY(__VA_ARGS__) "}]", UNIQ_T(s, UNIQ))

--- a/shared/macro.h
+++ b/shared/macro.h
@@ -37,6 +37,7 @@
 #define XCONCATENATE(x, y) x##y
 #define CONCATENATE(x, y) XCONCATENATE(x, y)
 #define UNIQ(x) CONCATENATE(x, __COUNTER__)
+#define UNIQ_T(x, uniq) CONCATENATE(__unique_prefix_, CONCATENATE(x, uniq))
 
 /* Attributes */
 

--- a/shared/macro.h
+++ b/shared/macro.h
@@ -43,6 +43,7 @@
 #define _must_check_ __attribute__((warn_unused_result))
 #define _printf_format_(a, b) __attribute__((format(printf, a, b)))
 #define _always_inline_ __inline__ __attribute__((always_inline))
+#define _sentinel_ __attribute__((sentinel))
 
 #if defined(__clang_analyzer__)
 #define _clang_suppress_ __attribute__((suppress))

--- a/shared/util.c
+++ b/shared/util.c
@@ -7,6 +7,7 @@
 
 #include <assert.h>
 #include <ctype.h>
+#include <dlfcn.h>
 #include <errno.h>
 #include <stdarg.h>
 #include <stddef.h>
@@ -557,4 +558,47 @@ unsigned long long stat_mstamp(const struct stat *st)
 #else
 	return (unsigned long long)st->st_mtime;
 #endif
+}
+
+static int dlsym_manyv(void *dl, va_list ap)
+{
+	void (**fn)(void);
+
+	while ((fn = va_arg(ap, typeof(fn)))) {
+		const char *symbol;
+
+		symbol = va_arg(ap, typeof(symbol));
+		*fn = dlsym(dl, symbol);
+		if (!*fn)
+			return -ENXIO;
+	}
+
+	return 0;
+}
+
+int dlsym_many(void **dlp, const char *filename, ...)
+{
+	va_list ap;
+	void *dl;
+	int r;
+
+	if (*dlp)
+		return 0;
+
+	dl = dlopen(filename, RTLD_LAZY);
+	if (!dl)
+		return -ENOENT;
+
+	va_start(ap, filename);
+	r = dlsym_manyv(dl, ap);
+	va_end(ap);
+
+	if (r < 0) {
+		dlclose(dl);
+		return r;
+	}
+
+	*dlp = dl;
+
+	return 1;
 }

--- a/shared/util.c
+++ b/shared/util.c
@@ -27,13 +27,13 @@ static const struct kmod_ext {
 	size_t len;
 } kmod_exts[] = {
 	{ KMOD_EXTENSION_UNCOMPRESSED, sizeof(KMOD_EXTENSION_UNCOMPRESSED) - 1 },
-#ifdef ENABLE_ZLIB
+#if ENABLE_ZLIB
 	{ ".ko.gz", sizeof(".ko.gz") - 1 },
 #endif
-#ifdef ENABLE_XZ
+#if ENABLE_XZ
 	{ ".ko.xz", sizeof(".ko.xz") - 1 },
 #endif
-#ifdef ENABLE_ZSTD
+#if ENABLE_ZSTD
 	{ ".ko.zst", sizeof(".ko.zst") - 1 },
 #endif
 	{},

--- a/shared/util.h
+++ b/shared/util.h
@@ -2,6 +2,7 @@
 
 #include <inttypes.h>
 #include <limits.h>
+#include <stdarg.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -158,3 +159,37 @@ static inline bool umulsz_overflow(size_t a, size_t b, size_t *res)
 #error "Unknown sizeof(size_t)"
 #endif
 }
+
+/* dlfcn helpers                                                            */
+/* ************************************************************************ */
+
+/*
+ * Load many various symbols from @filename.
+ * @dlp: pointer to the previous results of this call: it's set when it succeeds
+ * @filename: the library to dlopen() and look for symbols
+ * @...: or 1 more tuples created by DLSYM_ARG() with ( &var, "symbol name" ).
+ */
+_sentinel_ int dlsym_many(void **dlp, const char *filename, ...);
+
+/*
+ * Helper to create tuples passed as arguments to dlsym_many().
+ * @symbol__: symbol to create arguments for. Example: DLSYM_ARG(foo) expands to
+ * `&sym_foo, "foo"`
+ */
+#define DLSYM_ARG(symbol__) &sym_##symbol__, STRINGIFY(symbol__),
+
+/* For symbols being dynamically loaded */
+#define DECLARE_DLSYM(symbol) typeof(symbol) *sym_##symbol = NULL
+
+/* Pointer indirection to support linking directly */
+#define DECLARE_PTRSYM(symbol) typeof(symbol) *sym_##symbol = symbol
+
+/*
+ * Helper defines, to be done locally before including this header to switch between
+ * implementations
+ */
+#if defined(DLSYM_LOCALLY_ENABLED) && DLSYM_LOCALLY_ENABLED
+#define DECLARE_SYM(sym__) DECLARE_DLSYM(sym__);
+#else
+#define DECLARE_SYM(sym__) DECLARE_PTRSYM(sym__);
+#endif

--- a/testsuite/test-modinfo.c
+++ b/testsuite/test-modinfo.c
@@ -37,7 +37,7 @@ static const char *progname = TOOLS_DIR "/modinfo";
 #define DEFINE_MODINFO_GENERIC_TEST(_field) \
 	DEFINE_MODINFO_TEST(_field, , "/mod-simple.ko")
 
-#ifdef ENABLE_OPENSSL
+#if ENABLE_OPENSSL
 #define DEFINE_MODINFO_SIGN_TEST(_field)                             \
 	DEFINE_MODINFO_TEST(_field, -openssl, "/mod-simple-sha1.ko", \
 			    "/mod-simple-sha256.ko", "/mod-simple-pkcs7.ko")

--- a/testsuite/test-util.c
+++ b/testsuite/test-util.c
@@ -133,13 +133,13 @@ static int test_path_ends_with_kmod_ext(const struct test *t)
 		bool res;
 	} teststr[] = {
 		{ "/bla.ko", true },
-#ifdef ENABLE_ZLIB
+#if ENABLE_ZLIB
 		{ "/bla.ko.gz", true },
 #endif
-#ifdef ENABLE_XZ
+#if ENABLE_XZ
 		{ "/bla.ko.xz", true },
 #endif
-#ifdef ENABLE_ZSTD
+#if ENABLE_ZSTD
 		{ "/bla.ko.zst", true },
 #endif
 		{ "/bla.ko.x", false },


### PR DESCRIPTION
Allow to dlopen the compression libraries so distros can choose one to match the MODULE_COMPRESS_* option in the kernel, while still allowing to work with other compressed formats.

I'm not very happy with the meson integration, but I gave up while trying to handle the dependencies between the options.

~~Still missing here: the ELF note to declare the implicit dependency.~~

Closes: #48