### PR TITLE
Add TAKE_PTR()

### DIFF
--- a/libkmod/libkmod-config.c
+++ b/libkmod/libkmod-config.c
@@ -146,8 +146,9 @@ static int kmod_config_add_command(struct kmod_config *config, const char *modna
 	if (!l)
 		return -ENOMEM;
 
+	TAKE_PTR(cmd);
 	*list = l;
-	cmd = NULL;
+
 	return 0;
 }
 
@@ -175,8 +176,9 @@ static int kmod_config_add_options(struct kmod_config *config, const char *modna
 	if (!list)
 		return -ENOMEM;
 
-	opt = NULL;
+	TAKE_PTR(opt);
 	config->options = list;
+
 	return 0;
 }
 
@@ -202,8 +204,9 @@ static int kmod_config_add_alias(struct kmod_config *config, const char *name,
 	if (!list)
 		return -ENOMEM;
 
-	alias = NULL;
+	TAKE_PTR(alias);
 	config->aliases = list;
+
 	return 0;
 }
 
@@ -222,8 +225,9 @@ static int kmod_config_add_blacklist(struct kmod_config *config, const char *mod
 	if (!list)
 		return -ENOMEM;
 
-	p = NULL;
+	TAKE_PTR(p);
 	config->blacklists = list;
+
 	return 0;
 }
 

--- a/libkmod/libkmod-file-zlib.c
+++ b/libkmod/libkmod-file-zlib.c
@@ -22,9 +22,9 @@
 
 int kmod_file_load_zlib(struct kmod_file *file)
 {
+	_cleanup_free_ unsigned char *p = NULL;
 	int err = 0;
 	off_t did = 0, total = 0;
-	_cleanup_free_ unsigned char *p = NULL;
 	gzFile gzf;
 	int gzfd;
 
@@ -68,10 +68,10 @@ int kmod_file_load_zlib(struct kmod_file *file)
 		did += r;
 	}
 
-	file->memory = p;
+	file->memory = TAKE_PTR(p);
 	file->size = did;
-	p = NULL;
 	gzclose(gzf);
+
 	return 0;
 
 error:

--- a/libkmod/libkmod-module.c
+++ b/libkmod/libkmod-module.c
@@ -648,9 +648,9 @@ static int do_finit_module(struct kmod_module *mod, unsigned int flags, const ch
 
 static int do_init_module(struct kmod_module *mod, unsigned int flags, const char *args)
 {
+	_cleanup_free_ const void *stripped = NULL;
 	struct kmod_elf *elf;
 	const void *mem;
-	_cleanup_free_ const void *stripped = NULL;
 	off_t size;
 	int err;
 

--- a/shared/util.c
+++ b/shared/util.c
@@ -332,11 +332,12 @@ char *freadline_wrapped(FILE *fp, unsigned int *linenum)
 			n++;
 
 			{
-				char *ret = buf;
+				char *ret = TAKE_PTR(buf);
+
 				ret[i] = '\0';
-				buf = NULL;
 				if (linenum)
 					*linenum += n;
+
 				return ret;
 			}
 
@@ -390,7 +391,8 @@ char *path_make_absolute_cwd(const char *p)
 	if (r == NULL)
 		return NULL;
 
-	cwd = NULL;
+	TAKE_PTR(cwd);
+
 	r[cwdlen] = '/';
 	memcpy(&r[cwdlen + 1], p, plen + 1);
 

--- a/shared/util.h
+++ b/shared/util.h
@@ -158,3 +158,10 @@ static inline bool umulsz_overflow(size_t a, size_t b, size_t *res)
 #error "Unknown sizeof(size_t)"
 #endif
 }
+
+#define TAKE_PTR(x)                \
+	({                         \
+		typeof(x) x__ = x; \
+		(x) = NULL;        \
+		x__;               \
+	})


### PR DESCRIPTION
Similar to macro in systemd codebase: add a macro that documents we are "leaking" a pointer that would otherwise be cleaned up by the cleanup attribute.