### PR TITLE
tools: Unify help messages

### DIFF
--- a/tools/kmod.c
+++ b/tools/kmod.c
@@ -76,7 +76,7 @@ static int kmod_help(int argc, char *argv[])
 static const struct kmod_cmd kmod_cmd_help = {
 	.name = "help",
 	.cmd = kmod_help,
-	.help = "Show help message",
+	.help = "show help message",
 };
 
 static int handle_kmod_commands(int argc, char *argv[])

--- a/tools/static-nodes.c
+++ b/tools/static-nodes.c
@@ -274,5 +274,5 @@ finish:
 const struct kmod_cmd kmod_cmd_static_nodes = {
 	.name = "static-nodes",
 	.cmd = do_static_nodes,
-	.help = "outputs the static-node information installed with the currently running kernel",
+	.help = "output the static-node information installed with the currently running kernel",
 };


### PR DESCRIPTION
Unify help messages shown when kmod is called without any arguments to use the same grammar and capitalisation.