### PR TITLE
depmod: Fix unlikely strbuf memory leak

### DIFF
--- a/tools/depmod.c
+++ b/tools/depmod.c
@@ -2380,6 +2380,7 @@ static int output_symbols_bin(struct depmod *depmod, FILE *out)
 
 err_alloc:
 	index_destroy(idx);
+	strbuf_release(&salias);
 
 	if (ret < 0)
 		ERR("output symbols: %s\n", strerror(-ret));


### PR DESCRIPTION
The string buffer is initialized to use stack memory, but sufficiently long input strings could lead to heap allocation. Release strbuf when leaving output_symbols_bin.