### PR TITLE
Support Extended Modversions

### DIFF
--- a/libkmod/libkmod-elf.c
+++ b/libkmod/libkmod-elf.c
@@ -945,25 +945,18 @@ fallback:
 	return kmod_elf_get_symbols_symtab(elf, array);
 }
 
-static int kmod_elf_crc_find(const struct kmod_elf *elf, uint64_t off,
-			     uint64_t versionslen, const char *name, uint64_t *crc)
+static int kmod_modversion_crc_find(const struct kmod_modversion *vers, size_t count,
+				    const char *name, uint64_t *crc)
 {
-	size_t namlen, verlen, crclen;
-	uint64_t i;
+	size_t i;
 
-	elf_get_modversion_lengths(elf, &verlen, &crclen, &namlen);
-
-	for (i = 0; i < versionslen; i += verlen) {
-		const char *symbol = elf_get_mem(elf, off + i + crclen);
-		if (strnlen(symbol, namlen) == namlen || !streq(name, symbol)) {
-			ELFDBG(elf, "symbol name at index %" PRIu64 " too long\n", i);
-			continue;
+	for (i = 0; i < count; i++) {
+		if (!strcmp(vers[i].symbol, name)) {
+			*crc = vers[i].crc;
+			return i;
 		}
-		*crc = elf_get_uint(elf, off + i, crclen);
-		return i / verlen;
 	}
 
-	ELFDBG(elf, "could not find crc for symbol '%s'\n", name);
 	*crc = 0;
 	return -1;
 }
@@ -977,32 +970,14 @@ static int kmod_elf_crc_find(const struct kmod_elf *elf, uint64_t off,
 int kmod_elf_get_dependency_symbols(const struct kmod_elf *elf,
 				    struct kmod_modversion **array)
 {
-	uint64_t versionslen, strtablen, symtablen, str_off, sym_off, ver_off;
+	uint64_t strtablen, symtablen, str_off, sym_off;
 	uint64_t str_sec_off, sym_sec_off;
-	struct kmod_modversion *a;
-	size_t i, count, namlen, vercount, verlen, symcount, symlen, crclen;
+	struct kmod_modversion *a, *version_array;
+	size_t i, count, symcount, symlen, vercount;
+	int verres;
 	bool handle_register_symbols;
 	uint8_t *visited_versions;
 	uint64_t *symcrcs;
-
-	ver_off = elf->sections[KMOD_ELF_SECTION_VERSIONS].offset;
-	versionslen = elf->sections[KMOD_ELF_SECTION_VERSIONS].size;
-	if (ver_off == 0) {
-		versionslen = 0;
-		verlen = 0;
-		crclen = 0;
-		namlen = 0;
-	} else {
-		elf_get_modversion_lengths(elf, &verlen, &crclen, &namlen);
-		if (versionslen % verlen != 0) {
-			ELFDBG(elf,
-			       "unexpected __versions of length %" PRIu64
-			       ", not multiple of %zu as expected.\n",
-			       versionslen, verlen);
-			ver_off = 0;
-			versionslen = 0;
-		}
-	}
 
 	str_sec_off = elf->sections[KMOD_ELF_SECTION_STRTAB].offset;
 	strtablen = elf->sections[KMOD_ELF_SECTION_STRTAB].size;
@@ -1031,14 +1006,27 @@ int kmod_elf_get_dependency_symbols(const struct kmod_elf *elf,
 		return -EINVAL;
 	}
 
-	if (versionslen == 0) {
-		vercount = 0;
+	version_array = NULL;
+	verres = kmod_elf_get_modversions(elf, &version_array);
+	if (verres < 0) {
+		if (verres == -ENODATA)
+			/* we allow no MODVERSIONS */
+			vercount = 0;
+		else
+			/* but error out on bugged MODVERSIONS */
+			return verres;
+	} else {
+		vercount = verres;
+	}
+
+	if (vercount == 0) {
 		visited_versions = NULL;
 	} else {
-		vercount = versionslen / verlen;
 		visited_versions = calloc(vercount, sizeof(uint8_t));
-		if (visited_versions == NULL)
+		if (visited_versions == NULL) {
+			free(version_array);
 			return -ENOMEM;
+		}
 	}
 
 	handle_register_symbols =
@@ -1052,6 +1040,7 @@ int kmod_elf_get_dependency_symbols(const struct kmod_elf *elf,
 	symcrcs = calloc(symcount, sizeof(uint64_t));
 	if (symcrcs == NULL) {
 		free(visited_versions);
+		free(version_array);
 		return -ENOMEM;
 	}
 
@@ -1105,6 +1094,7 @@ int kmod_elf_get_dependency_symbols(const struct kmod_elf *elf,
 			       ".\n",
 			       strtablen, i, name_off);
 			free(visited_versions);
+			free(version_array);
 			free(symcrcs);
 			return -EINVAL;
 		}
@@ -1117,32 +1107,20 @@ int kmod_elf_get_dependency_symbols(const struct kmod_elf *elf,
 
 		count++;
 
-		idx = kmod_elf_crc_find(elf, ver_off, versionslen, name, &crc);
+		idx = kmod_modversion_crc_find(version_array, vercount, name, &crc);
 		if (idx >= 0 && visited_versions != NULL)
 			visited_versions[idx] = 1;
+		else
+			ELFDBG(elf, "could not find crc for symbol '%s'\n", name);
 		symcrcs[i] = crc;
 	}
 
 	if (visited_versions != NULL) {
 		/* module_layout/struct_module are not visited, but needed */
 		for (i = 0; i < vercount; i++) {
-			if (visited_versions[i] == 0) {
-				const char *name;
-				size_t nlen;
-
-				name = elf_get_mem(elf, ver_off + i * verlen + crclen);
-				nlen = strnlen(name, namlen);
-
-				if (nlen == namlen) {
-					ELFDBG(elf, "symbol name at index %zu too long\n",
-					       i);
-					free(visited_versions);
-					free(symcrcs);
-					return -EINVAL;
-				}
-
+			if (visited_versions[i] == 0)
+				/* no verification; version_array handled it */
 				count++;
-			}
 		}
 	}
 
@@ -1156,6 +1134,7 @@ int kmod_elf_get_dependency_symbols(const struct kmod_elf *elf,
 
 	if (count == 0) {
 		free(visited_versions);
+		free(version_array);
 		free(symcrcs);
 		*array = NULL;
 		return 0;
@@ -1164,6 +1143,7 @@ int kmod_elf_get_dependency_symbols(const struct kmod_elf *elf,
 	*array = a = malloc(sizeof(struct kmod_modversion) * count);
 	if (*array == NULL) {
 		free(visited_versions);
+		free(version_array);
 		free(symcrcs);
 		return -errno;
 	}
@@ -1244,21 +1224,16 @@ int kmod_elf_get_dependency_symbols(const struct kmod_elf *elf,
 
 	/* add unvisited (module_layout/struct_module) */
 	for (i = 0; i < vercount; i++) {
-		const char *name;
-		uint64_t crc;
-
 		if (visited_versions[i] != 0)
 			continue;
 
-		name = elf_get_mem(elf, ver_off + i * verlen + crclen);
-		crc = elf_get_uint(elf, ver_off + i * verlen, crclen);
-
-		a[count].crc = crc;
+		a[count].crc = version_array[i].crc;
 		a[count].bind = KMOD_SYMBOL_UNDEF;
-		a[count].symbol = name;
+		a[count].symbol = version_array[i].symbol;
 
 		count++;
 	}
 	free(visited_versions);
+	free(version_array);
 	return count;
 }

--- a/scripts/setup-rootfs.sh
+++ b/scripts/setup-rootfs.sh
@@ -97,6 +97,7 @@ map=(
     ["test-modprobe/external/lib/modules/external/"]="mod-simple.ko"
     ["test-modprobe/module-from-abspath/home/foo/"]="mod-simple.ko"
     ["test-modprobe/module-from-relpath/home/foo/"]="mod-simple.ko"
+    ["test-modprobe/show-modversions/mod-simple.ko"]="mod-simple.ko"
     ["test-depmod/modules-order-compressed$MODULE_DIRECTORY/4.4.4/kernel/drivers/block/cciss.ko"]="mod-fake-cciss.ko"
     ["test-depmod/modules-order-compressed$MODULE_DIRECTORY/4.4.4/kernel/drivers/scsi/hpsa.ko"]="mod-fake-hpsa.ko"
     ["test-depmod/modules-order-compressed$MODULE_DIRECTORY/4.4.4/kernel/drivers/scsi/scsi_mod.ko"]="mod-fake-scsi-mod.ko"

--- a/testsuite/rootfs-pristine/test-modprobe/show-modversions/versions-mod-simple.txt
+++ b/testsuite/rootfs-pristine/test-modprobe/show-modversions/versions-mod-simple.txt
@@ -1,0 +1,11 @@
+0x........	single_open
+0x........	seq_write
+0x........	debugfs_remove
+0x........	seq_lseek
+0x........	seq_read
+0x........	single_release
+0x........	__fentry__
+0x........	debugfs_create_dir
+0x........	debugfs_create_file
+0x........	__x86_return_thunk
+0x........	module_layout

--- a/testsuite/test-modprobe.c
+++ b/testsuite/test-modprobe.c
@@ -361,4 +361,20 @@ DEFINE_TEST(modprobe_module_from_relpath,
 	.modules_loaded = "mod-simple",
 	);
 
+static noreturn int modprobe_show_modversions(const struct test *t)
+{
+	EXEC_MODPROBE("--show-modversions", "/mod-simple.ko");
+	exit(EXIT_FAILURE);
+}
+DEFINE_TEST(modprobe_show_modversions,
+	.description = "check if output for modprobe --show-modversions is correct",
+	.config = {
+		[TC_UNAME_R] = "4.4.4",
+		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-modprobe/show-modversions",
+	},
+	.output = {
+		.out = TESTSUITE_ROOTFS "test-modprobe/show-modversions/versions-mod-simple.txt",
+		.regex = true,
+	});
+
 TESTSUITE_MAIN();


### PR DESCRIPTION
A companion to the [`EXTENDED_MODVERSIONS` kernel patch series](https://lore.kernel.org/lkml/20241123-extended-modversions-v10-0-0fa754ffdee3@google.com/), this PR adds support for `libkmod` to access the new modversions format when present, falling back to the original format otherwise.

Tested with `KDIR=` override selecting a kernel with `EXTENDED_MODVERSIONS=y` and `BASIC_MODVERSIONS=n` enabled with the series above in addition to a normal existing kernel.