### PR TITLE
testsuite: Fix build when linking with lld

### DIFF
--- a/shared/macro.h
+++ b/shared/macro.h
@@ -49,6 +49,7 @@
 #define _retain_ __attribute((retain))
 #define _section_(a) __attribute((section(a)))
 #define _aligned_(a) __attribute((aligned(a)))
+#define _alignedptr_ _aligned_(sizeof(void *))
 
 #if defined(__clang_analyzer__)
 #define _clang_suppress_ __attribute__((suppress))

--- a/shared/macro.h
+++ b/shared/macro.h
@@ -45,6 +45,10 @@
 #define _printf_format_(a, b) __attribute__((format(printf, a, b)))
 #define _always_inline_ __inline__ __attribute__((always_inline))
 #define _sentinel_ __attribute__((sentinel))
+#define _used_ __attribute((used))
+#define _retain_ __attribute((retain))
+#define _section_(a) __attribute((section(a)))
+#define _aligned_(a) __attribute((aligned(a)))
 
 #if defined(__clang_analyzer__)
 #define _clang_suppress_ __attribute__((suppress))

--- a/testsuite/test-hash.c
+++ b/testsuite/test-hash.c
@@ -250,7 +250,7 @@ static int test_hash_add_unique(const struct test *t)
 	return 0;
 }
 DEFINE_TEST(test_hash_add_unique,
-	    .description = "test hash_add_unique with different key orders")
+	    .description = "test hash_add_unique with different key orders");
 
 static int test_hash_massive_add_del(const struct test *t)
 {
@@ -282,6 +282,6 @@ static int test_hash_massive_add_del(const struct test *t)
 	return 0;
 }
 DEFINE_TEST(test_hash_massive_add_del,
-	    .description = "test multiple adds followed by multiple dels")
+	    .description = "test multiple adds followed by multiple dels");
 
 TESTSUITE_MAIN();

--- a/testsuite/test-modinfo.c
+++ b/testsuite/test-modinfo.c
@@ -100,7 +100,7 @@ DEFINE_TEST(test_modinfo_external,
 	},
 	.output = {
 		.out = TESTSUITE_ROOTFS "test-modinfo/correct-external.txt",
-	})
+	});
 
 static noreturn int test_modinfo_builtin(const struct test *t)
 {
@@ -122,6 +122,6 @@ DEFINE_TEST(test_modinfo_builtin,
 	},
 	.output = {
 		.out = TESTSUITE_ROOTFS "test-modinfo/correct-builtin.txt",
-	})
+	});
 
 TESTSUITE_MAIN();

--- a/testsuite/test-util.c
+++ b/testsuite/test-util.c
@@ -99,7 +99,8 @@ static int test_strchr_replace(const struct test *t)
 
 	return EXIT_SUCCESS;
 }
-DEFINE_TEST(test_strchr_replace, .description = "check implementation of strchr_replace()")
+DEFINE_TEST(test_strchr_replace,
+	    .description = "check implementation of strchr_replace()");
 
 static int test_underscores(const struct test *t)
 {
@@ -124,7 +125,7 @@ static int test_underscores(const struct test *t)
 
 	return EXIT_SUCCESS;
 }
-DEFINE_TEST(test_underscores, .description = "check implementation of underscores()")
+DEFINE_TEST(test_underscores, .description = "check implementation of underscores()");
 
 static int test_path_ends_with_kmod_ext(const struct test *t)
 {
@@ -158,7 +159,7 @@ static int test_path_ends_with_kmod_ext(const struct test *t)
 	return EXIT_SUCCESS;
 }
 DEFINE_TEST(test_path_ends_with_kmod_ext,
-	    .description = "check implementation of path_ends_with_kmod_ext()")
+	    .description = "check implementation of path_ends_with_kmod_ext()");
 
 #define TEST_WRITE_STR_SAFE_FILE "/write-str-safe"
 #define TEST_WRITE_STR_SAFE_PATH TESTSUITE_ROOTFS "test-util2/" TEST_WRITE_STR_SAFE_FILE
@@ -203,7 +204,7 @@ static int test_uadd32_overflow(const struct test *t)
 	return EXIT_SUCCESS;
 }
 DEFINE_TEST(test_uadd32_overflow,
-	    .description = "check implementation of uadd32_overflow()")
+	    .description = "check implementation of uadd32_overflow()");
 
 static int test_uadd64_overflow(const struct test *t)
 {
@@ -220,7 +221,7 @@ static int test_uadd64_overflow(const struct test *t)
 	return EXIT_SUCCESS;
 }
 DEFINE_TEST(test_uadd64_overflow,
-	    .description = "check implementation of uadd64_overflow()")
+	    .description = "check implementation of uadd64_overflow()");
 
 static int test_umul32_overflow(const struct test *t)
 {
@@ -237,7 +238,7 @@ static int test_umul32_overflow(const struct test *t)
 	return EXIT_SUCCESS;
 }
 DEFINE_TEST(test_umul32_overflow,
-	    .description = "check implementation of umul32_overflow()")
+	    .description = "check implementation of umul32_overflow()");
 
 static int test_umul64_overflow(const struct test *t)
 {
@@ -254,7 +255,7 @@ static int test_umul64_overflow(const struct test *t)
 	return EXIT_SUCCESS;
 }
 DEFINE_TEST(test_umul64_overflow,
-	    .description = "check implementation of umul64_overflow()")
+	    .description = "check implementation of umul64_overflow()");
 
 static int test_backoff_time(const struct test *t)
 {
@@ -292,6 +293,6 @@ static int test_backoff_time(const struct test *t)
 	return EXIT_SUCCESS;
 }
 DEFINE_TEST(test_backoff_time,
-	    .description = "check implementation of get_backoff_delta_msec()")
+	    .description = "check implementation of get_backoff_delta_msec()");
 
 TESTSUITE_MAIN();

--- a/testsuite/testsuite.h
+++ b/testsuite/testsuite.h
@@ -135,7 +135,7 @@ int test_run(const struct test *t);
 	_alignedptr_                                                                     \
 	static const struct test UNIQ(s##_name) = {                                      \
 		.name = #_name, .func = _func, ##__VA_ARGS__                             \
-	};
+	}
 // clang-format on
 
 #define DEFINE_TEST(_name, ...) DEFINE_TEST_WITH_FUNC(_name, _name, __VA_ARGS__)

--- a/testsuite/testsuite.h
+++ b/testsuite/testsuite.h
@@ -132,7 +132,7 @@ int test_run(const struct test *t);
 	_used_                                                                           \
 	_retain_                                                                         \
 	_section_("kmod_tests")                                                          \
-	_aligned_(8)                                                                     \
+	_alignedptr_                                                                     \
 	static const struct test UNIQ(s##_name) = {                                      \
 		.name = #_name, .func = _func, ##__VA_ARGS__                             \
 	};

--- a/testsuite/testsuite.h
+++ b/testsuite/testsuite.h
@@ -129,8 +129,11 @@ int test_run(const struct test *t);
 // clang-format off: At least up to version 18, it just makes a mess with _Pragma()
 #define DEFINE_TEST_WITH_FUNC(_name, _func, ...)                                         \
 	_Pragma("GCC diagnostic ignored \"-Wattributes\"")                               \
-	static const struct test UNIQ(s##_name)                                          \
-	__attribute__((retain, used, section("kmod_tests"), aligned(8))) = {             \
+	_used_                                                                           \
+	_retain_                                                                         \
+	_section_("kmod_tests")                                                          \
+	_aligned_(8)                                                                     \
+	static const struct test UNIQ(s##_name) = {                                      \
 		.name = #_name, .func = _func, ##__VA_ARGS__                             \
 	};
 // clang-format on

--- a/testsuite/testsuite.h
+++ b/testsuite/testsuite.h
@@ -126,19 +126,20 @@ int test_run(const struct test *t);
 	} while (false)
 
 /* Test definitions */
-#define DEFINE_TEST_WITH_FUNC(_name, _func, ...)                             \
-	static const struct test UNIQ(s##_name)                              \
-		__attribute__((used, section("kmod_tests"), aligned(8))) = { \
-			.name = #_name, .func = _func, ##__VA_ARGS__         \
-		};
+// clang-format off: At least up to version 18, it just makes a mess with _Pragma()
+#define DEFINE_TEST_WITH_FUNC(_name, _func, ...)                                         \
+	_Pragma("GCC diagnostic ignored \"-Wattributes\"")                               \
+	static const struct test UNIQ(s##_name)                                          \
+	__attribute__((retain, used, section("kmod_tests"), aligned(8))) = {             \
+		.name = #_name, .func = _func, ##__VA_ARGS__                             \
+	};
+// clang-format on
 
 #define DEFINE_TEST(_name, ...) DEFINE_TEST_WITH_FUNC(_name, _name, __VA_ARGS__)
 
 #define TESTSUITE_MAIN()                                                                 \
-	extern struct test __start_kmod_tests[]                                          \
-		__attribute__((weak, visibility("hidden")));                             \
-	extern struct test __stop_kmod_tests[]                                           \
-		__attribute__((weak, visibility("hidden")));                             \
+	extern struct test __start_kmod_tests[] __attribute__((visibility("hidden")));   \
+	extern struct test __stop_kmod_tests[] __attribute__((visibility("hidden")));    \
 	int main(int argc, char *argv[])                                                 \
 	{                                                                                \
 		const struct test *t;                                                    \


### PR DESCRIPTION
When building with clang and linking with lld there is an issue with keeping the kmod_tests sections: On ELF targets, __attribute__((used)) prevents compiler discarding, but does not affect linker --gc-sections, according to https://lld.llvm.org/ELF/start-stop-gc.

Make sure the _start/_stop symbols are not weak and add the "retain" attribute.

Closes: https://github.com/kmod-project/kmod/issues/269