### PR TITLE
tools/log.c related cleanups

### DIFF
--- a/tools/insmod.c
+++ b/tools/insmod.c
@@ -65,7 +65,7 @@ static int do_insmod(int argc, char *argv[])
 	const char *filename;
 	char *opts = NULL;
 	int verbose = LOG_ERR;
-	int use_syslog = 0;
+	bool use_syslog = false;
 	int c, r = 0;
 	const char *null_config = NULL;
 	unsigned int flags = 0;
@@ -77,7 +77,7 @@ static int do_insmod(int argc, char *argv[])
 			flags |= KMOD_PROBE_FORCE_VERMAGIC;
 			break;
 		case 's':
-			use_syslog = 1;
+			use_syslog = true;
 			break;
 		case 'v':
 			verbose++;

--- a/tools/log.c
+++ b/tools/log.c
@@ -80,6 +80,7 @@ _printf_format_(6, 0) static void log_kmod(void *data, int priority, const char 
 	free(str);
 	(void)data;
 }
+
 void log_open(bool use_syslog)
 {
 	log_use_syslog = use_syslog;

--- a/tools/lsmod.c
+++ b/tools/lsmod.c
@@ -44,13 +44,13 @@ static int do_lsmod(int argc, char *argv[])
 	const char *null_config = NULL;
 	struct kmod_list *list, *itr;
 	int verbose = LOG_ERR;
-	int use_syslog = 0;
+	bool use_syslog = false;
 	int err, c, r = 0;
 
 	while ((c = getopt_long(argc, argv, cmdopts_s, cmdopts, NULL)) != -1) {
 		switch (c) {
 		case 's':
-			use_syslog = 1;
+			use_syslog = true;
 			break;
 		case 'v':
 			verbose++;

--- a/tools/modprobe.c
+++ b/tools/modprobe.c
@@ -28,7 +28,6 @@
 #include "kmod.h"
 
 static int log_priority = LOG_CRIT;
-static bool use_syslog = false;
 #define LOG(...) log_printf(log_priority, __VA_ARGS__)
 
 #define DEFAULT_VERBOSE LOG_WARNING
@@ -765,6 +764,7 @@ static int do_modprobe(int argc, char **orig_argv)
 	int do_show_exports = 0;
 	int err;
 	struct stat stat_buf;
+	bool use_syslog = false;
 
 	argv = prepend_options_from_env(&argc, orig_argv);
 	if (argv == NULL) {

--- a/tools/modprobe.c
+++ b/tools/modprobe.c
@@ -28,7 +28,7 @@
 #include "kmod.h"
 
 static int log_priority = LOG_CRIT;
-static int use_syslog = 0;
+static bool use_syslog = false;
 #define LOG(...) log_printf(log_priority, __VA_ARGS__)
 
 #define DEFAULT_VERBOSE LOG_WARNING
@@ -861,7 +861,7 @@ static int do_modprobe(int argc, char **orig_argv)
 			break;
 		case 's':
 			env_modprobe_options_append("-s");
-			use_syslog = 1;
+			use_syslog = true;
 			break;
 		case 'q':
 			env_modprobe_options_append("-q");
@@ -894,7 +894,7 @@ static int do_modprobe(int argc, char **orig_argv)
 
 	if (!use_syslog &&
 	    (!stderr || fileno(stderr) == -1 || fstat(fileno(stderr), &stat_buf)))
-		use_syslog = 1;
+		use_syslog = true;
 
 	log_open(use_syslog);
 

--- a/tools/rmmod.c
+++ b/tools/rmmod.c
@@ -94,7 +94,7 @@ static int do_rmmod(int argc, char *argv[])
 	struct kmod_ctx *ctx;
 	const char *null_config = NULL;
 	int verbose = LOG_ERR;
-	int use_syslog = 0;
+	bool use_syslog = false;
 	int flags = 0;
 	int i, c, r = 0;
 
@@ -104,7 +104,7 @@ static int do_rmmod(int argc, char *argv[])
 			flags |= KMOD_REMOVE_FORCE;
 			break;
 		case 's':
-			use_syslog = 1;
+			use_syslog = true;
 			break;
 		case 'v':
 			verbose++;


### PR DESCRIPTION
Things noticed while looking at `tools/log.c`:

- Use `bool` for `use_syslog` variables since they are used for `log_open(bool)` as argument anyway
- Reduce variable visibility
- Add a missing newline