### PR TITLE
static-nodes: do not open /dev/stdout explicitly

### DIFF
--- a/tools/static-nodes.c
+++ b/tools/static-nodes.c
@@ -145,7 +145,7 @@ static int do_static_nodes(int argc, char *argv[])
 {
 	struct utsname kernel;
 	char modules[PATH_MAX], buf[PATH_MAX];
-	const char *output = "/dev/stdout";
+	const char *output = NULL;
 	FILE *in = NULL, *out = NULL;
 	const struct static_nodes_format *format = &static_nodes_format_human;
 	int r, ret = EXIT_SUCCESS;
@@ -227,19 +227,24 @@ static int do_static_nodes(int argc, char *argv[])
 		goto finish;
 	}
 
-	r = mkdir_parents(output, 0755);
-	if (r < 0) {
-		fprintf(stderr, "Error: could not create parent directory for %s - %m.\n",
-			output);
-		ret = EXIT_FAILURE;
-		goto finish;
-	}
+	if (output == NULL) {
+		out = stdout;
+	} else {
+		r = mkdir_parents(output, 0755);
+		if (r < 0) {
+			fprintf(stderr,
+				"Error: could not create parent directory for %s - %m.\n",
+				output);
+			ret = EXIT_FAILURE;
+			goto finish;
+		}
 
-	out = fopen(output, "we");
-	if (out == NULL) {
-		fprintf(stderr, "Error: could not create %s - %m\n", output);
-		ret = EXIT_FAILURE;
-		goto finish;
+		out = fopen(output, "we");
+		if (out == NULL) {
+			fprintf(stderr, "Error: could not create %s - %m\n", output);
+			ret = EXIT_FAILURE;
+			goto finish;
+		}
 	}
 
 	while (fgets(buf, sizeof(buf), in) != NULL) {


### PR DESCRIPTION
If no -o option is given, use stdout directly without opening /dev/stdout manually. In a chroot environment, this could lead to /dev/stdout creation as a regular file.

Proof of Concept:

1. Run kmod static-nodes with strace
```
strace kmod static-nodes
```
You can see these two lines:
```
newfstatat(AT_FDCWD, "/dev", {st_mode=S_IFDIR|0755, st_size=3140, ...}, 0) = 0
openat(AT_FDCWD, "/dev/stdout", O_WRONLY|O_CREAT|O_TRUNC|O_CLOEXEC, 0666) = 4
```
2. Create a minimalistic chroot environment
```
MY_ROOT=$(mktemp -d)
install -D $(which kmod) $MY_ROOT/$(which kmod)
mkdir -p $MY_ROOT/lib/modules/$(uname -r)/
echo "mod dev b1:1" > $MY_ROOT/lib/modules/$(uname -r)/modules.devname
# Most likely you have to copy some libraries
for library in $(ldd $(which kmod) | grep -v vdso | sed 's#^[^/]*\(/.*\) .*$#\1#')
do
  install -D $library $MY_ROOT/$library
done
```
3. Run kmod static-nodes within chroot environment
```
sudo chroot $MY_ROOT $(which kmod) static-nodes
```

There won't be any output, because it is directed into newly created /dev/stdout file.