### PR TITLE
modinfo: reduce amount of continue statements

### DIFF
--- a/tools/modinfo.c
+++ b/tools/modinfo.c
@@ -201,32 +201,24 @@ static int modinfo_do(struct kmod_module *mod)
 	kmod_list_foreach(l, list) {
 		const char *key = kmod_module_info_get_key(l);
 		const char *value = kmod_module_info_get_value(l);
-		size_t keylen;
 
 		if (field != NULL) {
-			if (!streq(field, key))
-				continue;
-			/* filtered output contains no key, just value */
-			printf("%s%c", value, separator);
-			continue;
-		}
-
-		if (streq(key, "parm") || streq(key, "parmtype")) {
+			if (streq(field, key)) {
+				/* filtered output contains no key, just value */
+				printf("%s%c", value, separator);
+			}
+		} else if (streq(key, "parm") || streq(key, "parmtype")) {
 			err = process_parm(key, value, &params);
 			if (err < 0)
 				goto end;
-			continue;
-		}
-
-		if (separator == '\0') {
+		} else if (separator == '\0') {
 			printf("%s=%s%c", key, value, separator);
-			continue;
+		} else {
+			size_t keylen = strlen(key);
+			if (keylen > 15)
+				keylen = 15;
+			printf("%s:%-*s%s%c", key, 15 - (int)keylen, "", value, separator);
 		}
-
-		keylen = strlen(key);
-		if (keylen > 15)
-			keylen = 15;
-		printf("%s:%-*s%s%c", key, 15 - (int)keylen, "", value, separator);
 	}
 
 	if (field != NULL)


### PR DESCRIPTION
Clarify that the code does not perform error checks, for which we regularly use checks and continue at the start, but merely checks how to print/filter the data.

Nice benefit: Reduces binary size if compiled with GCC.