### PR TITLE
libkmod: release memory on builtin error path

### DIFF
--- a/libkmod/libkmod-builtin.c
+++ b/libkmod/libkmod-builtin.c
@@ -150,9 +150,9 @@ static char **strbuf_to_vector(struct strbuf *buf, size_t count)
 	vector = realloc(buf->bytes, total_size);
 	if (vector == NULL)
 		return NULL;
-	buf->bytes = NULL;
 	memmove(vector + count + 1, vector, strbuf_used(buf));
 	s = (char *)(vector + count + 1);
+	strbuf_init(buf);
 
 	for (n = 0; n < count; n++) {
 		vector[n] = s;
@@ -167,13 +167,12 @@ static char **strbuf_to_vector(struct strbuf *buf, size_t count)
 ssize_t kmod_builtin_get_modinfo(struct kmod_ctx *ctx, const char *modname,
 				 char ***modinfo)
 {
+	DECLARE_STRBUF(buf);
 	struct kmod_builtin_info info;
-	struct strbuf buf;
 	ssize_t count;
 
 	if (!kmod_builtin_info_init(&info, ctx))
 		return -errno;
-	strbuf_init(&buf);
 
 	count = get_strings(&info, modname, &buf);
 	if (count == 0)
@@ -183,7 +182,6 @@ ssize_t kmod_builtin_get_modinfo(struct kmod_ctx *ctx, const char *modname,
 		if (*modinfo == NULL) {
 			count = -errno;
 			ERR(ctx, "strbuf_to_vector: %s\n", strerror(errno));
-			strbuf_release(&buf);
 		}
 	}
 


### PR DESCRIPTION
If the modules.builtin.modinfo file contains valid and invalid lines, it is possible that libkmod leaks memory on error path.

Call strbuf_release on get_strings error path as well.

Proof of concept is a bit tricky, unfortunately. Look for one of the entries in /lib/modules/$(uname -r)/modules.builtin.modinfo and replace a '.' with '\0'.
```
mkdir -p /tmp/broken/lib/modules
cp -R /lib/modules/$(uname -r) /tmp/broken/lib/modules
# modify /tmp/broken/lib/$(uname -r)/modules.builtin.modinfo accordingly
```

A kmod compiled with memory sanitizer gives this output:
```
modinfo -b /tmp/broken rapl                                                                    
name:           rapl
filename:       (builtin)
libkmod: ERROR ../libkmod/libkmod-builtin.c:103 get_strings: get_strings: unexpected string without modname prefix
modinfo: ERROR: could not get modinfo from 'rapl': Invalid argument

=================================================================
==986==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 128 byte(s) in 1 object(s) allocated from:
    #0 0x7f3217321b18 in realloc ../../../../libsanitizer/asan/asan_malloc_linux.cpp:85
    #1 0x563df7e524c7 in buf_realloc ../shared/strbuf.c:20
    #2 0x563df7e52892 in strbuf_reserve_extra ../shared/strbuf.c:48
    #3 0x563df7e5331a in strbuf_pushmem ../shared/strbuf.c:106
    #4 0x563df7e86fe6 in strbuf_pushchars ../shared/strbuf.h:75
    #5 0x563df7e86fe6 in get_strings ../libkmod/libkmod-builtin.c:117
    #6 0x563df7e86fe6 in kmod_builtin_get_modinfo ../libkmod/libkmod-builtin.c:178
    #7 0x563df7e818ad in kmod_module_get_info ../libkmod/libkmod-module.c:1870
    #8 0x563df7e437e0 in modinfo_do ../tools/modinfo.c:182
    #9 0x563df7e45232 in modinfo_alias_do ../tools/modinfo.c:309
    #10 0x563df7e45232 in do_modinfo ../tools/modinfo.c:472
    #11 0x7f321635cb27 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

SUMMARY: AddressSanitizer: 128 byte(s) leaked in 1 allocation(s).
```