### PR TITLE
depmod: handle out of memory condition

### DIFF
--- a/tools/depmod.c
+++ b/tools/depmod.c
@@ -2200,6 +2200,10 @@ static int output_deps_bin(struct depmod *depmod, FILE *out)
 			}
 		}
 		line = strbuf_str(&sbuf);
+		if (line == NULL) {
+			ERR("could not write dependencies of %s\n", p);
+			continue;
+		}
 
 		duplicate = index_insert(idx, mod->modname, line, mod->idx);
 		if (duplicate && depmod->cfg->warn_dups)


### PR DESCRIPTION
The strbuf_str call may return NULL in case of out of memory condition. Check its return value before dereferencing the pointer.