### PR TITLE
ci: add pahole for Debian unstable

### DIFF
--- a/.github/actions/setup-debian/action.yml
+++ b/.github/actions/setup-debian/action.yml
@@ -28,6 +28,7 @@ runs:
           libzstd-dev \
           linux-headers-generic \
           meson \
+          pahole \
           scdoc \
           zlib1g-dev \
           zstd


### PR DESCRIPTION
The pahole package is required in our test suite.