### PR TITLE
build: support missing gtkdocize in releases

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -12,7 +12,16 @@ fi
 
 cd $topdir
 
-gtkdocize --docdir libkmod/docs || touch libkmod/docs/gtk-doc.make
+gtkdocize --docdir libkmod/docs || NO_GTK_DOC="yes"
+if [ "x$NO_GTK_DOC" = "xyes" ]
+then
+	for f in libkmod/docs/gtk-doc.make m4/gtk-doc.m4
+	do
+		rm -f $f
+		touch $f
+	done
+fi
+
 autoreconf --force --install --symlink
 
 libdir() {


### PR DESCRIPTION
The release tarballs may already contain symbolic links into the file system for gtk-doc specific files.

If gtk-doc is not installed, and thus not desired for building, remove the symbolic links and create empty files instead.