### PR TITLE
Reduce strbuf API and simplify its uses

### DIFF
--- a/libkmod/libkmod-index.c
+++ b/libkmod/libkmod-index.c
@@ -534,7 +534,7 @@ static void index_searchwild__all(struct index_node_f *node, int j, struct strbu
 	if (node->values) {
 		const char *s = strbuf_str(buf);
 
-		if (s != NULL && fnmatch(s, subkey, 0) == 0)
+		if (fnmatch(s, subkey, 0) == 0)
 			index_searchwild__allvalues(node, out);
 		else
 			index_close(node);
@@ -997,7 +997,7 @@ static void index_mm_searchwild_all(struct index_mm_node *node, int j, struct st
 	if (node->value_count > 0) {
 		const char *s = strbuf_str(buf);
 
-		if (s != NULL && fnmatch(s, subkey, 0) == 0)
+		if (fnmatch(s, subkey, 0) == 0)
 			index_mm_searchwild_allvalues(node, out);
 	}
 

--- a/libkmod/libkmod-index.c
+++ b/libkmod/libkmod-index.c
@@ -428,20 +428,18 @@ static void index_dump_node(struct index_node_f *node, struct strbuf *buf,
 
 void index_dump(struct index_file *in, int fd, bool alias_prefix)
 {
+	DECLARE_STRBUF_WITH_STACK(buf, 128);
 	struct index_node_f *root;
-	struct strbuf buf;
 	struct wrtbuf wbuf;
 
 	root = index_readroot(in);
 	if (root == NULL)
 		return;
 
-	strbuf_init(&buf);
 	wrtbuf_init(&wbuf, fd);
 	if (!alias_prefix || strbuf_pushchars(&buf, "alias "))
 		index_dump_node(root, &buf, &wbuf);
 	wrtbuf_flush(&wbuf);
-	strbuf_release(&buf);
 }
 
 static char *index_search__node(struct index_node_f *node, const char *key, int i)
@@ -615,13 +613,11 @@ static void index_searchwild__node(struct index_node_f *node, struct strbuf *buf
  */
 struct index_value *index_searchwild(struct index_file *in, const char *key)
 {
+	DECLARE_STRBUF_WITH_STACK(buf, 128);
 	struct index_node_f *root = index_readroot(in);
-	struct strbuf buf;
 	struct index_value *out = NULL;
 
-	strbuf_init(&buf);
 	index_searchwild__node(root, &buf, key, &out);
-	strbuf_release(&buf);
 	return out;
 }
 
@@ -892,20 +888,18 @@ static void index_mm_dump_node(struct index_mm_node *node, struct strbuf *buf,
 
 void index_mm_dump(const struct index_mm *idx, int fd, bool alias_prefix)
 {
+	DECLARE_STRBUF_WITH_STACK(buf, 128);
 	struct index_mm_node nbuf, *root;
-	struct strbuf buf;
 	struct wrtbuf wbuf;
 
 	root = index_mm_readroot(idx, &nbuf);
 	if (root == NULL)
 		return;
 
-	strbuf_init(&buf);
 	wrtbuf_init(&wbuf, fd);
 	if (!alias_prefix || strbuf_pushchars(&buf, "alias "))
 		index_mm_dump_node(root, &buf, &wbuf);
 	wrtbuf_flush(&wbuf);
-	strbuf_release(&buf);
 }
 
 static char *index_mm_search_node(struct index_mm_node *node, const char *key)
@@ -1074,13 +1068,11 @@ static void index_mm_searchwild_node(struct index_mm_node *node, struct strbuf *
  */
 struct index_value *index_mm_searchwild(const struct index_mm *idx, const char *key)
 {
+	DECLARE_STRBUF_WITH_STACK(buf, 128);
 	struct index_mm_node nbuf, *root;
-	struct strbuf buf;
 	struct index_value *out = NULL;
 
 	root = index_mm_readroot(idx, &nbuf);
-	strbuf_init(&buf);
 	index_mm_searchwild_node(root, &buf, key, &out);
-	strbuf_release(&buf);
 	return out;
 }

--- a/libkmod/libkmod-module.c
+++ b/libkmod/libkmod-module.c
@@ -1835,8 +1835,6 @@ static struct kmod_list *kmod_module_info_append_hex(struct kmod_list **list,
 		if (!kmod_module_strbuf_pushhex(&sbuf, value, valuelen))
 			goto list_error;
 		hex = strbuf_str(&sbuf);
-		if (hex == NULL)
-			goto list_error;
 
 		n = kmod_module_info_append(list, key, keylen, hex, strlen(hex));
 		if (n == NULL)

--- a/shared/strbuf.c
+++ b/shared/strbuf.c
@@ -36,13 +36,13 @@ static bool buf_realloc(struct strbuf *buf, size_t sz)
 
 bool strbuf_reserve_extra(struct strbuf *buf, size_t n)
 {
-	if (uaddsz_overflow(buf->used, n, &n) || n > SIZE_MAX - BUF_STEP)
+	if (uaddsz_overflow(buf->used, n, &n) || n >= SIZE_MAX - BUF_STEP)
 		return false;
 
-	if (n <= buf->size)
+	if (n < buf->size)
 		return true;
 
-	if (n % BUF_STEP)
+	if (++n % BUF_STEP)
 		n = ((n / BUF_STEP) + 1) * BUF_STEP;
 
 	return buf_realloc(buf, n);
@@ -64,11 +64,11 @@ void strbuf_release(struct strbuf *buf)
 
 const char *strbuf_str(struct strbuf *buf)
 {
-	if (!buf->used || buf->bytes[buf->used - 1]) {
-		if (!strbuf_reserve_extra(buf, 1))
-			return NULL;
+	if (!buf->used)
+		return "";
+
+	if (buf->bytes[buf->used - 1])
 		buf->bytes[buf->used] = '\0';
-	}
 	return buf->bytes;
 }
 

--- a/shared/strbuf.c
+++ b/shared/strbuf.c
@@ -34,7 +34,7 @@ static bool buf_realloc(struct strbuf *buf, size_t sz)
 	return true;
 }
 
-bool strbuf_reserve_extra(struct strbuf *buf, size_t n)
+static bool strbuf_reserve_extra(struct strbuf *buf, size_t n)
 {
 	if (uaddsz_overflow(buf->used, n, &n) || n >= SIZE_MAX - BUF_STEP)
 		return false;

--- a/shared/strbuf.c
+++ b/shared/strbuf.c
@@ -36,11 +36,11 @@ static bool buf_realloc(struct strbuf *buf, size_t sz)
 
 static bool strbuf_reserve_extra(struct strbuf *buf, size_t n)
 {
+	if (n < buf->size - buf->used)
+		return true;
+
 	if (uaddsz_overflow(buf->used, n, &n) || n >= SIZE_MAX - BUF_STEP)
 		return false;
-
-	if (n < buf->size)
-		return true;
 
 	if (++n % BUF_STEP)
 		n = ((n / BUF_STEP) + 1) * BUF_STEP;

--- a/shared/strbuf.c
+++ b/shared/strbuf.c
@@ -62,20 +62,6 @@ void strbuf_release(struct strbuf *buf)
 		free(buf->bytes);
 }
 
-char *strbuf_steal(struct strbuf *buf)
-{
-	char *bytes;
-
-	if (!buf_realloc(buf, buf->used + 1))
-		return NULL;
-
-	bytes = buf->bytes;
-	buf->bytes = NULL;
-	bytes[buf->used] = '\0';
-
-	return bytes;
-}
-
 const char *strbuf_str(struct strbuf *buf)
 {
 	if (!buf->used || buf->bytes[buf->used - 1]) {

--- a/shared/strbuf.h
+++ b/shared/strbuf.h
@@ -50,12 +50,6 @@ void strbuf_clear(struct strbuf *buf);
  */
 const char *strbuf_str(struct strbuf *buf);
 
-/*
- * Reserve enough space for @n bytes, ensuring additional pushes up to @n bytes
- * don't cause re-allocations
- */
-bool strbuf_reserve_extra(struct strbuf *buf, size_t n);
-
 bool strbuf_pushchar(struct strbuf *buf, char ch);
 size_t strbuf_pushmem(struct strbuf *buf, const char *src, size_t sz);
 static inline size_t strbuf_pushchars(struct strbuf *buf, const char *str)

--- a/shared/strbuf.h
+++ b/shared/strbuf.h
@@ -44,18 +44,6 @@ void strbuf_release(struct strbuf *buf);
 void strbuf_clear(struct strbuf *buf);
 
 /*
- * Return a copy as a C string, guaranteed to be nul-terminated. On success, the @buf
- * becomes invalid and shouldn't be used anymore, except for an (optional) call to
- * strbuf_release() which still does the right thing on an invalidated buffer. On failure,
- * NULL is returned and the buffer remains valid: strbuf_release() should be called.
- * Consider using _cleanup_strbuf_ attribute to release the buffer as needed.
- *
- * The copy may use the same underlying storage as the buffer and should be free'd later
- * with free().
- */
-char *strbuf_steal(struct strbuf *buf);
-
-/*
  * Return a C string owned by the buffer. It becomes an invalid
  * pointer if strbuf is changed. It may also not survive a return
  * from current function if it was initialized with stack space

--- a/testsuite/test-strbuf.c
+++ b/testsuite/test-strbuf.c
@@ -133,42 +133,15 @@ static int test_strbuf_with_heap(const struct test *t)
 }
 DEFINE_TEST(test_strbuf_with_heap, .description = "test strbuf with heap only");
 
-static int test_strbuf_reserve_extra(const struct test *t)
-{
-	_cleanup_strbuf_ struct strbuf buf;
-	size_t size;
-
-	strbuf_init(&buf);
-	strbuf_reserve_extra(&buf, strlen(TEXT) + 1);
-	size = buf.size;
-	assert_return(size >= strlen(TEXT) + 1, EXIT_FAILURE);
-
-	strbuf_pushchars(&buf, TEXT);
-	strbuf_pushchar(&buf, '\0');
-	assert_return(size == buf.size, EXIT_FAILURE);
-
-	strbuf_clear(&buf);
-	strbuf_pushchars(&buf, TEXT);
-	assert_return(size == buf.size, EXIT_FAILURE);
-
-	return 0;
-}
-DEFINE_TEST(test_strbuf_reserve_extra, .description = "test strbuf_reserve_extra");
-
 static int test_strbuf_pushmem(const struct test *t)
 {
 	_cleanup_strbuf_ struct strbuf buf;
-	size_t size;
 
 	strbuf_init(&buf);
 	strbuf_pushmem(&buf, "", 0);
-	strbuf_reserve_extra(&buf, strlen(TEXT) + 1);
-	size = buf.size;
 	strbuf_pushmem(&buf, TEXT, strlen(TEXT) + 1);
 
-	assert_return(size == buf.size, EXIT_FAILURE);
 	assert_return(streq(TEXT, strbuf_str(&buf)), EXIT_FAILURE);
-	assert_return(size == buf.size, EXIT_FAILURE);
 
 	return 0;
 }
@@ -184,7 +157,8 @@ static int test_strbuf_used(const struct test *t)
 	strbuf_pushchars(&buf, TEXT);
 	assert_return(strbuf_used(&buf) == strlen(TEXT), EXIT_FAILURE);
 
-	strbuf_reserve_extra(&buf, 1);
+	strbuf_pushchar(&buf, 'a');
+	strbuf_popchar(&buf);
 	assert_return(strbuf_used(&buf) == strlen(TEXT), EXIT_FAILURE);
 
 	assert_return(streq(TEXT, strbuf_str(&buf)), EXIT_FAILURE);

--- a/tools/depmod.c
+++ b/tools/depmod.c
@@ -1362,7 +1362,7 @@ static int depmod_modules_search_dir(struct depmod *depmod, DIR *d, struct strbu
 		namelen = strlen(name);
 
 		if (!strbuf_pushchars(path, name) ||
-		    /* Ensure space for (possible) '/' or '\0' */
+		    /* Ensure space for (possible) '/' */
 		    !strbuf_reserve_extra(path, 1)) {
 			err = -ENOMEM;
 			ERR("No memory\n");
@@ -2360,8 +2360,7 @@ static int output_symbols_bin(struct depmod *depmod, FILE *out)
 
 		strbuf_shrink_to(&salias, baselen);
 
-		if (!strbuf_pushchars(&salias, sym->name) ||
-		    !strbuf_reserve_extra(&salias, 1)) {
+		if (!strbuf_pushchars(&salias, sym->name)) {
 			ret = -ENOMEM;
 			goto err_alloc;
 		}

--- a/tools/depmod.c
+++ b/tools/depmod.c
@@ -2157,10 +2157,10 @@ end:
 
 static int output_deps_bin(struct depmod *depmod, FILE *out)
 {
+	DECLARE_STRBUF_WITH_STACK(sbuf, 2048);
 	struct index_node *idx;
 	size_t i;
 	struct array array;
-	struct strbuf sbuf;
 
 	if (out == stdout)
 		return 0;
@@ -2170,7 +2170,6 @@ static int output_deps_bin(struct depmod *depmod, FILE *out)
 		return -ENOMEM;
 
 	array_init(&array, 64);
-	strbuf_init(&sbuf);
 
 	for (i = 0; i < depmod->modules.count; i++) {
 		const struct mod *mod = depmod->modules.array[i];
@@ -2206,7 +2205,6 @@ static int output_deps_bin(struct depmod *depmod, FILE *out)
 			WRN("duplicate module deps:\n%s\n", line);
 	}
 
-	strbuf_release(&sbuf);
 	array_free_array(&array);
 	index_write(idx, out);
 	index_destroy(idx);


### PR DESCRIPTION
The strbuf handling can be simplified, because we know that eventually we want to handle a C string, i.e. a string ending in `\0`. This means that whenever strbuf memory is allocated, we can already add one more byte for the eventually added `\0', making strbuf_str a function which never fails.

I have refactored the strbuf callers to allow even more optimization: Start with a stack-based strbuf as often as possible.

In total, it slightly increases the binary and library by a few bytes, but improve performance by removing heap allocations in regular use cases of `depmod` and `modprobe -c`. On Arch Linux, `depmod` allocates 8 MB less heap in total and performs around 40.000 allocation calls. The `modprobe -c` case performs 10 % less instructions in total and 2 less heap allocations.

The last commit is a general improvement. Without it, binary sizes stay the same and instructions only slightly increase.