### PR TITLE
libkmod: Fix UB for non-existent keys

### DIFF
--- a/libkmod/libkmod-module.c
+++ b/libkmod/libkmod-module.c
@@ -1770,7 +1770,8 @@ static struct kmod_module_info *kmod_module_info_new(const char *key, size_t key
 	info->key = (char *)info + sizeof(struct kmod_module_info) + valuelen + 1;
 	memcpy(info->key, key, keylen);
 	info->key[keylen] = '\0';
-	memcpy(info->value, value, valuelen);
+	if (value)
+		memcpy(info->value, value, valuelen);
 	info->value[valuelen] = '\0';
 	return info;
 }


### PR DESCRIPTION
When running the testsuite with UBSAN and a non-existent info key is used, the following happens:

TESTSUITE: running test_modinfo_sig_hashalgo, in forked context
TESTSUITE: ERR: 'test_modinfo_sig_hashalgo' [4212] terminated by signal 6 (Aborted)
TESTSUITE: ------
TESTSUITE: running test_modinfo_sig_key, in forked context
TESTSUITE: ERR: 'test_modinfo_sig_key' [4292] terminated by signal 6 (Aborted)
TESTSUITE: ------
TESTSUITE: running test_modinfo_signer, in forked context
TESTSUITE: ERR: 'test_modinfo_signer' [4348] terminated by signal 6 (Aborted)

In CI this happens when disabling module signature handling with -D openssl=disabled. The UBSAN report is as below:

../dist-unpack/kmod-34/libkmod/libkmod-module.c:1773:2: runtime error: null pointer passed as argument 2, which is declared to never be null
    #0 0x55bb657aa13b  (/__w/kmod/kmod/build/meson-private/dist-build/kmod+0x9f13b) (BuildId: 2c8f9c0ffdbcdf249a3cca29a9d2bc47f706a324)
    #1 0x55bb6580a4be  (/__w/kmod/kmod/build/meson-private/dist-build/kmod+0xff4be) (BuildId: 2c8f9c0ffdbcdf249a3cca29a9d2bc47f706a324)
    #2 0x55bb657cc360  (/__w/kmod/kmod/build/meson-private/dist-build/kmod+0xc1360) (BuildId: 2c8f9c0ffdbcdf249a3cca29a9d2bc47f706a324)
    #3 0x55bb657cdf43  (/__w/kmod/kmod/build/meson-private/dist-build/kmod+0xc2f43) (BuildId: 2c8f9c0ffdbcdf249a3cca29a9d2bc47f706a324)
    #4 0x7f0651bb3487  (/usr/lib/libc.so.6+0x27487) (BuildId: 0b707b217b15b106c25fe51df3724b25848310c0)
    #5 0x7f0651bb354b  (/usr/lib/libc.so.6+0x2754b) (BuildId: 0b707b217b15b106c25fe51df3724b25848310c0)
    #6 0x55bb657aeb14  (/__w/kmod/kmod/build/meson-private/dist-build/kmod+0xa3b14) (BuildId: 2c8f9c0ffdbcdf249a3cca29a9d2bc47f706a324)

Keep the current behavior of appending a 0-length value, just skipping the pointless memcpy.