### PR TITLE
Depmod: Add tmpfile-util to generate temporary file

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -372,6 +372,8 @@ libshared = static_library(
     'shared/strbuf.h',
     'shared/util.c',
     'shared/util.h',
+    'shared/tmpfile-util.c',
+    'shared/tmpfile-util.h',
   ),
   gnu_symbol_visibility : 'hidden',
   install : false,

--- a/shared/tmpfile-util.c
+++ b/shared/tmpfile-util.c
@@ -1,0 +1,102 @@
+
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * Copyright (C) 2025  Intel Corporation.
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <libgen.h>
+#include <limits.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "tmpfile-util.h"
+#include "macro.h"
+#include "util.h"
+
+FILE *tmpfile_openat(int dirfd, const char *tmpname_tmpl, mode_t mode,
+		     struct tmpfile *file)
+{
+	const char *tmpname;
+	char tmpfile_path[PATH_MAX];
+	int fd, n, err;
+	_cleanup_free_ char *targetdir;
+	FILE *fp;
+
+	if (file == NULL || tmpname_tmpl == NULL) {
+		return NULL;
+	}
+
+	err = fd_lookup_path(dirfd, &targetdir);
+	if (err < 0) {
+		goto create_fail;
+	}
+
+	n = snprintf(tmpfile_path, PATH_MAX, "%s/%s", targetdir, tmpname_tmpl);
+	if (n < 0 || n >= PATH_MAX) {
+		goto create_fail;
+	}
+
+	fd = mkstemp(tmpfile_path);
+	if (fd < 0) {
+		goto create_fail;
+	}
+
+	if (fchmod(fd, mode) < 0) {
+		goto checkout_fail;
+	}
+
+	fp = fdopen(fd, "wb");
+	if (fp == NULL) {
+		goto checkout_fail;
+	}
+
+	tmpname = basename(tmpfile_path);
+	memset(file->tmpname, 0, PATH_MAX);
+	memcpy(file->tmpname, tmpname, strlen(tmpname));
+
+	file->dirfd = dirfd;
+	file->fd = fd;
+
+	return fp;
+
+checkout_fail:
+	close(fd);
+	remove(tmpfile_path);
+create_fail:
+	return NULL;
+}
+
+int tmpfile_publish(struct tmpfile *file, const char *targetname)
+{
+	if (file == NULL || targetname == NULL) {
+		return -EINVAL;
+	}
+
+	if (renameat(file->dirfd, file->tmpname, file->dirfd, targetname) != 0) {
+		return -errno;
+	}
+
+	file->fd = 0;
+	file->dirfd = 0;
+	memset(file->tmpname, 0, PATH_MAX);
+	return 0;
+}
+
+void tmpfile_release(struct tmpfile *file)
+{
+	if (file == NULL) {
+		return;
+	}
+
+	unlinkat(file->dirfd, file->tmpname, 0);
+
+	file->fd = 0;
+	file->dirfd = 0;
+	memset(file->tmpname, 0, PATH_MAX);
+}

--- a/shared/tmpfile-util.h
+++ b/shared/tmpfile-util.h
@@ -1,7 +1,14 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * Copyright (C) 2025  Intel Corporation.
+ */
+
 #pragma once
 
 #include <stdio.h>
 #include <linux/limits.h>
+
+#include <shared/macro.h>
 
 struct tmpfile {
 	char tmpname[PATH_MAX];
@@ -12,15 +19,15 @@ struct tmpfile {
 /*
  * Create a temporary file at the directory of `dirfd`
 */
-FILE *tmpfile_openat(int dirfd, const char *tmpname_tmpl, mode_t mode,
-		     struct tmpfile *file);
+_must_check_ _nonnull_(3) FILE *tmpfile_openat(int dirfd, mode_t mode,
+					       struct tmpfile *file);
 
 /*
  * Move the temporary file to `targetname`
 */
-int tmpfile_publish(struct tmpfile *file, const char *targetname);
+_nonnull_all_ int tmpfile_publish(struct tmpfile *file, const char *targetname);
 
 /*
  * Delete the temporary file
 */
-void tmpfile_release(struct tmpfile *file);
+_nonnull_all_ void tmpfile_release(struct tmpfile *file);

--- a/shared/tmpfile-util.h
+++ b/shared/tmpfile-util.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <stdio.h>
+#include <linux/limits.h>
+
+struct tmpfile {
+	char tmpname[PATH_MAX];
+	int dirfd;
+	int fd;
+};
+
+/*
+ * Create a temporary file at the directory of `dirfd`
+*/
+FILE *tmpfile_openat(int dirfd, const char *tmpname_tmpl, mode_t mode,
+		     struct tmpfile *file);
+
+/*
+ * Move the temporary file to `targetname`
+*/
+int tmpfile_publish(struct tmpfile *file, const char *targetname);
+
+/*
+ * Delete the temporary file
+*/
+void tmpfile_release(struct tmpfile *file);

--- a/shared/util.c
+++ b/shared/util.c
@@ -476,6 +476,31 @@ int mkdir_parents(const char *path, mode_t mode)
 	return mkdir_p(path, end - path, mode);
 }
 
+int fd_lookup_path(int fd, char **ret_path)
+{
+	char proc_path[PATH_MAX];
+	char fd_path[PATH_MAX];
+	ssize_t len;
+
+	len = snprintf(proc_path, sizeof(proc_path), "/proc/self/fd/%d", fd);
+	if (len < 0 || len >= (ssize_t)sizeof(proc_path)) {
+		return -errno;
+	}
+
+	len = readlink(proc_path, fd_path, sizeof(fd_path) - 1);
+	if (len < 0 || len >= (ssize_t)sizeof(fd_path)) {
+		return -errno;
+	}
+
+	fd_path[len] = '\0';
+
+	if (ret_path != NULL) {
+		*ret_path = strdup(fd_path);
+	}
+
+	return 0;
+}
+
 static unsigned long long ts_usec(const struct timespec *ts)
 {
 	return (unsigned long long)ts->tv_sec * USEC_PER_SEC +

--- a/shared/util.h
+++ b/shared/util.h
@@ -35,8 +35,8 @@ _nonnull_all_ bool path_ends_with_kmod_ext(const char *path, size_t len);
 
 /* read-like and fread-like functions                                       */
 /* ************************************************************************ */
-_must_check_ _nonnull_(2) ssize_t pread_str_safe(int fd, char *buf, size_t buflen,
-						 off_t off);
+_must_check_ _nonnull_(2) ssize_t
+	pread_str_safe(int fd, char *buf, size_t buflen, off_t off);
 _must_check_ _nonnull_(2) ssize_t read_str_safe(int fd, char *buf, size_t buflen);
 _nonnull_(2) ssize_t write_str_safe(int fd, const char *buf, size_t buflen);
 _must_check_ _nonnull_(2) int read_str_long(int fd, long *value, int base);
@@ -54,7 +54,7 @@ static inline _must_check_ _nonnull_all_ bool path_is_absolute(const char *p)
 int mkdir_p(const char *path, int len, mode_t mode);
 int mkdir_parents(const char *path, mode_t mode);
 unsigned long long stat_mstamp(const struct stat *st);
-int fd_lookup_path(int fd, char **ret_path);
+char *fd_lookup_path(int fd);
 
 /* time-related functions
  * ************************************************************************ */

--- a/shared/util.h
+++ b/shared/util.h
@@ -35,8 +35,8 @@ _nonnull_all_ bool path_ends_with_kmod_ext(const char *path, size_t len);
 
 /* read-like and fread-like functions                                       */
 /* ************************************************************************ */
-_must_check_ _nonnull_(2) ssize_t
-	pread_str_safe(int fd, char *buf, size_t buflen, off_t off);
+_must_check_ _nonnull_(2) ssize_t pread_str_safe(int fd, char *buf, size_t buflen,
+						 off_t off);
 _must_check_ _nonnull_(2) ssize_t read_str_safe(int fd, char *buf, size_t buflen);
 _nonnull_(2) ssize_t write_str_safe(int fd, const char *buf, size_t buflen);
 _must_check_ _nonnull_(2) int read_str_long(int fd, long *value, int base);

--- a/shared/util.h
+++ b/shared/util.h
@@ -54,6 +54,7 @@ static inline _must_check_ _nonnull_all_ bool path_is_absolute(const char *p)
 int mkdir_p(const char *path, int len, mode_t mode);
 int mkdir_parents(const char *path, mode_t mode);
 unsigned long long stat_mstamp(const struct stat *st);
+int fd_lookup_path(int fd, char **ret_path);
 
 /* time-related functions
  * ************************************************************************ */

--- a/tools/depmod.c
+++ b/tools/depmod.c
@@ -2611,10 +2611,9 @@ static int depmod_output(struct depmod *depmod, FILE *out)
 		int r, ferr;
 
 		if (fp == NULL) {
-			const char *tmpname_tmpl = "tmpfileXXXXXX";
 			mode_t mode = 0644;
 
-			fp = tmpfile_openat(dfd, tmpname_tmpl, mode, &file);
+			fp = tmpfile_openat(dfd, mode, &file);
 			if (fp == NULL) {
 				ERR("Could not create temporary file at '%s'\n", dname);
 				continue;

--- a/tools/depmod.c
+++ b/tools/depmod.c
@@ -24,6 +24,7 @@
 #include <shared/hash.h>
 #include <shared/macro.h>
 #include <shared/strbuf.h>
+#include <shared/tmpfile-util.h>
 #include <shared/util.h>
 
 #include <libkmod/libkmod-internal.h>
@@ -2606,34 +2607,16 @@ static int depmod_output(struct depmod *depmod, FILE *out)
 
 	for (itr = depfiles; itr->name != NULL; itr++) {
 		FILE *fp = out;
-		char tmp[NAME_MAX] = "";
+		struct tmpfile file;
 		int r, ferr;
 
 		if (fp == NULL) {
-			int flags = O_CREAT | O_EXCL | O_WRONLY;
-			int mode = 0644;
-			int fd;
-			int n;
+			const char *tmpname_tmpl = "tmpfileXXXXXX";
+			mode_t mode = 0644;
 
-			n = snprintf(tmp, sizeof(tmp), "%s.%i.%lli.%lli", itr->name,
-				     getpid(), (long long)tv.tv_usec,
-				     (long long)tv.tv_sec);
-			if (n >= (int)sizeof(tmp)) {
-				ERR("bad filename: %s.%i.%lli.%lli: path too long\n",
-				    itr->name, getpid(), (long long)tv.tv_usec,
-				    (long long)tv.tv_sec);
-				continue;
-			}
-			fd = openat(dfd, tmp, flags, mode);
-			if (fd < 0) {
-				ERR("openat(%s, %s, %o, %o): %m\n", dname, tmp, flags,
-				    mode);
-				continue;
-			}
-			fp = fdopen(fd, "wb");
+			fp = tmpfile_openat(dfd, tmpname_tmpl, mode, &file);
 			if (fp == NULL) {
-				ERR("fdopen(%d=%s/%s): %m\n", fd, dname, tmp);
-				close(fd);
+				ERR("Could not create temporary file at '%s'\n", dname);
 				continue;
 			}
 		}
@@ -2645,18 +2628,16 @@ static int depmod_output(struct depmod *depmod, FILE *out)
 		ferr = ferror(fp) | fclose(fp);
 
 		if (r < 0) {
-			if (unlinkat(dfd, tmp, 0) != 0)
-				ERR("unlinkat(%s, %s): %m\n", dname, tmp);
+			tmpfile_release(&file);
 
 			ERR("Could not write index '%s': %s\n", itr->name, strerror(-r));
 			err = -errno;
 			break;
 		}
 
-		if (renameat(dfd, tmp, dfd, itr->name) != 0) {
-			err = -errno;
-			CRIT("renameat(%s, %s, %s, %s): %m\n", dname, tmp, dname,
-			     itr->name);
+		err = tmpfile_publish(&file, itr->name);
+		if (err != 0) {
+			CRIT("publish temporary from %s to %s\n", file.tmpname, itr->name);
 			break;
 		}
 


### PR DESCRIPTION
Closes: #51 

Considering O_TMPFILE is not supported on all linux system (refer by [here)](https://man7.org/linux/man-pages/man2/open.2.html#:~:text=O_TMPFILE%20requires%20support%20by%20the,Linux%20filesystems%20provide%20that%20support.). And mkstemp is a more general function to create temp file. We use mkstemp to refactor this code.


Signed-off-by: Wenjie Wang <wenjie2.wang@intel.com>
Signed-off-by: Gongjun Song <gongjun.song@intel.com>
Signed-off-by: Dan He <dan.h.he@intel.com>
Signed-off-by: Qingqing Li <qingqing.li@intel.com>
Signed-off-by: Yuchi Chen <yuchi.chen@intel.com>