### PR TITLE
ci: Auto triggering workflow to build documents

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,68 @@
+name: Trigger kmod-project.github.io
+
+on:
+  # Runs on pushes targeting master and tag with prefix `v`
+  push:
+    branches:
+      - 'master'
+      - 'ci-test-docs'
+    tags:
+      - 'v*'
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    container:
+      image: 'ubuntu:24.04'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Ubuntu
+        uses: ./.github/actions/setup-ubuntu
+
+      - name: Build docs
+        run: |
+          meson setup -Ddocs=true build .
+          meson compile -C build
+
+      - name: Extract docs version
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF}" == refs/heads/* ]]; then
+            echo DOC_VERSION=${GITHUB_REF#refs/heads/} >> $GITHUB_ENV
+          elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo DOC_VERSION=${GITHUB_REF#refs/tags/} >> $GITHUB_ENV
+          else
+            exit 1
+          fi
+
+          echo DOC_VERSION_COMMIT="${GITHUB_SHA}" >> $GITHUB_ENV
+
+      - name: Push docs to kmod-project.github.io
+        uses: QXIP/github-action-push-to-another-repository@a910af640bd64288db58f0e71a361aabac022f8b
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.KMOD_DOCS }}
+        with:
+          source-directory: 'build/libkmod/docs/html'
+          destination-github-username: '${{ github.repository_owner }}'
+          destination-repository-name: 'kmod-project.github.io'
+          user-name: 'github-actions[bot]'
+          user-email: '41898282+github-actions[bot]@users.noreply.github.com'
+          target-branch: 'pages'
+          commit-message: 'Auto-add ${{ env.DOC_VERSION }} docs for commit ${{ env.DOC_VERSION_COMMIT }}'
+          target-directory: '${{ env.DOC_VERSION }}'
+
+      - name: Dispatch kmod-project.github.io
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.KMOD_DOCS }}
+          repository: ${{ github.repository_owner }}/kmod-project.github.io
+          event-type: publish-doc
+          client-payload: '{"source":"${{ github.repository }}","version":"${{ env.DOC_VERSION }}"}'


### PR DESCRIPTION
[Issue: 46] Publish API docs github pages
[Issue: 297]New frontpage for kmod pages

Fixes: #46 and #297

1. When master or a new tag is pushed, build API documents
2. Track the newly built documents by branch gh-pages
3. Build GitHub Pages

Signed-off-by: Chen, Yuchi <yuchi.chen@intel.com>
Signed-off-by: Gongjun Song <gongjun.song@intel.com>
Signed-off-by: Dan He <dan.h.he@intel.com>
Signed-off-by: Wenjie Wang <wenjie2.wang@intel.com>
Signed-off-by: Qingqing Li <qingqing.li@intel.com>
