### PR TITLE
tools: use space for long opts

### DIFF
--- a/man/depmod.8.scd
+++ b/man/depmod.8.scd
@@ -46,7 +46,7 @@ rather than the current kernel version (as returned by *uname -r*).
 	*modules.dep* file before any work is done: if not, it silently exits
 	rather than regenerating the files.
 
-*-b* _basedir_, *--basedir*=_basedir_
+*-b* _basedir_, *--basedir* _basedir_
 	Override the base directory <BASEDIR> where modules are located.
 	If your modules are not currently in the (normal) directory
 	@MODULE_DIRECTORY@/_version_, but in a staging area, you can specify a
@@ -66,7 +66,7 @@ rather than the current kernel version (as returned by *uname -r*).
 	_/my/build/staging/dir@MODULE_DIRECTORY@/$(uname -r)_ and generates
 	index files under that same directory.
 
-*-m* _moduledir_, *--moduledir*=_moduledir_
+*-m* _moduledir_, *--moduledir* _moduledir_
 	Override the module directory <MODULEDIR>, which defaults to
 	@MODULE_DIRECTORY@ prefix set at build time. This is useful when
 	building *modules.dep* file in _basedir_ for a system that uses a
@@ -93,7 +93,7 @@ depmod -b /tmp/build -m kernel-modules
 	handle that arbitrary location, it won't work in runtime.
 
 
-*-o* _outdir_, *--outdir*=_outdir_
+*-o* _outdir_, *--outdir* _outdir_
 	Set the output directory where *depmod* will store any generated file.
 	_outdir_ serves as a root to that location, similar to how _basedir_ is
 	used. Also this setting takes precedence and if used together with
@@ -110,7 +110,7 @@ depmod -b /tmp/build -m kernel-modules
 	_@MODULE_DIRECTORY@/$(uname -r)_ and generates index files under
 	_/my/build/staging/dir@MODULE_DIRECTORY@/$(uname -r)_.
 
-*-C* _file_ _or_ _directory_, *--config*=_file_ _or_ _directory_
+*-C* _file_ _or_ _directory_, *--config* _file_ _or_ _directory_
 	This option overrides the default configuration files. See
 	*depmod.d*(5).
 
@@ -122,13 +122,13 @@ depmod -b /tmp/build -m kernel-modules
 	assumption can break especially when additionally updated third party
 	drivers are not correctly installed or were built incorrectly.
 
-*-E* _Module.symvers_, *--symvers*=_Module.symvers_
+*-E* _Module.symvers_, *--symvers* _Module.symvers_
 	When combined with the *-e* option, this reports any symbol versions
 	supplied by modules that do not match with the symbol versions provided
 	by the kernel in its _Module.symvers_. This option is mutually
 	incompatible with *-F*.
 
-*-F* _System.map_, *--filesyms*=_System.map_
+*-F* _System.map_, *--filesyms* _System.map_
 	Supplied with the _System.map_ produced when the kernel was built, this
 	allows the *-e* option to report unresolved symbols. This option is
 	mutually incompatible with *-E*.

--- a/man/modinfo.8.scd
+++ b/man/modinfo.8.scd
@@ -31,14 +31,14 @@ architecture.
 *-V*, *--version*
 	Print the *modinfo* version.
 
-*-F* _field_, *--field*=_field_
+*-F* _field_, *--field* _field_
 	Only print this _field_ value, one per line. This is most useful for
 	scripts. Field names are case-insensitive. Common fields (which may not
 	be in every module) include author, description, license, parm, depends,
 	and alias. There are often multiple parm, alias and depends fields. The
 	special _field_ filename lists the filename of the module.
 
-*-b* _basedir_, *--basedir*=_basedir_
+*-b* _basedir_, *--basedir* _basedir_
 	Root directory for modules, / by default.
 
 *-k* _kernel_

--- a/man/modprobe.8.scd
+++ b/man/modprobe.8.scd
@@ -54,7 +54,7 @@ database.
 	configuration files (if any) to module names as well. It is usually used
 	by *udev*(7).
 
-*-C* _directory_, *--config*=_directory_
+*-C* _directory_, *--config* _directory_
 	This option overrides the default configuration directory. See
 	*modprobe.d*(5).
 
@@ -150,14 +150,14 @@ database.
 	require it. Your distribution kernel may not have been built to support
 	removal of modules at all.
 
-*-w* _TIMEOUT_MSEC_, *--wait*=_TIMEOUT_MSEC_
+*-w* _TIMEOUT_MSEC_, *--wait* _TIMEOUT_MSEC_
 	This option causes *modprobe -r *to continue trying to remove a module
 	if it fails due to the module being busy, i.e. its refcount is not 0 at
 	the time the call is made. Modprobe tries to remove the module with an
 	incremental sleep time between each tentative up until the maximum wait
 	time in milliseconds passed in this option.
 
-*-S* _version_, *--set-version*=_version_
+*-S* _version_, *--set-version* _version_
 	Set the kernel version, rather than using *uname*(2) to decide on the
 	kernel version (which dictates where to find the modules).
 

--- a/tools/depmod.c
+++ b/tools/depmod.c
@@ -85,20 +85,20 @@ static void help(void)
 	       "\t-e, --errsyms        Report not supplied symbols\n"
 	       "\t-n, --show           Write the dependency file on stdout only\n"
 	       "\t-P, --symbol-prefix  Architecture symbol prefix\n"
-	       "\t-C, --config=PATH    Read configuration from PATH\n"
+	       "\t-C, --config PATH    Read configuration from PATH\n"
 	       "\t-v, --verbose        Enable verbose mode\n"
 	       "\t-w, --warn           Warn on duplicates\n"
 	       "\t-V, --version        show version\n"
 	       "\t-h, --help           show this help\n"
 	       "\n"
 	       "The following options are useful for people managing distributions:\n"
-	       "\t-b, --basedir=DIR    Root path (default: /).\n"
-	       "\t-m, --moduledir=DIR  Module directory (default: " MODULE_DIRECTORY
+	       "\t-b, --basedir DIR    Root path (default: /).\n"
+	       "\t-m, --moduledir DIR  Module directory (default: " MODULE_DIRECTORY
 	       ").\n"
-	       "\t-o, --outdir=DIR     Output root path (default: same as <basedir>).\n"
-	       "\t-F, --filesyms=FILE  Use the file instead of the\n"
+	       "\t-o, --outdir DIR     Output root path (default: same as <basedir>).\n"
+	       "\t-F, --filesyms FILE  Use the file instead of the\n"
 	       "\t                     current kernel symbols.\n"
-	       "\t-E, --symvers=FILE   Use Module.symvers file to check\n"
+	       "\t-E, --symvers FILE   Use Module.symvers file to check\n"
 	       "\t                     symbol versions.\n",
 	       program_invocation_short_name);
 }

--- a/tools/modinfo.c
+++ b/tools/modinfo.c
@@ -336,9 +336,9 @@ static void help(void)
 	       "\t-n, --filename              Print only 'filename'\n"
 	       "\t-0, --null                  Use \\0 instead of \\n\n"
 	       "\t-m, --modname               Handle argument as module name instead of alias or filename\n"
-	       "\t-F, --field=FIELD           Print only provided FIELD\n"
-	       "\t-k, --set-version=VERSION   Use VERSION instead of `uname -r`\n"
-	       "\t-b, --basedir=DIR           Use DIR as filesystem root for " MODULE_DIRECTORY
+	       "\t-F, --field FIELD           Print only provided FIELD\n"
+	       "\t-k, --set-version VERSION   Use VERSION instead of `uname -r`\n"
+	       "\t-b, --basedir DIR           Use DIR as filesystem root for " MODULE_DIRECTORY
 	       "\n"
 	       "\t-V, --version               Show version\n"
 	       "\t-h, --help                  Show this help\n",

--- a/tools/modprobe.c
+++ b/tools/modprobe.c
@@ -102,7 +102,7 @@ static void help(void)
 	       "\t-r, --remove                Remove modules instead of inserting\n"
 	       "\t    --remove-dependencies   Deprecated: use --remove-holders\n"
 	       "\t    --remove-holders        Also remove module holders (use together with -r)\n"
-	       "\t-w, --wait=<MSEC>           When removing a module, wait up to MSEC for\n"
+	       "\t-w, --wait <MSEC>           When removing a module, wait up to MSEC for\n"
 	       "\t                            module's refcount to become 0 so it can be\n"
 	       "\t                            removed (use together with -r)\n"
 	       "\t    --first-time            Fail if module already inserted or removed\n"
@@ -128,10 +128,10 @@ static void help(void)
 	       "\t-n, --dry-run               Do not execute operations, just print out\n"
 	       "\t-n, --show                  Same as --dry-run\n"
 
-	       "\t-C, --config=FILE           Use FILE instead of default search paths\n"
-	       "\t-d, --dirname=DIR           Use DIR as filesystem root for " MODULE_DIRECTORY
+	       "\t-C, --config FILE           Use FILE instead of default search paths\n"
+	       "\t-d, --dirname DIR           Use DIR as filesystem root for " MODULE_DIRECTORY
 	       "\n"
-	       "\t-S, --set-version=VERSION   Use VERSION instead of `uname -r`\n"
+	       "\t-S, --set-version VERSION   Use VERSION instead of `uname -r`\n"
 
 	       "\t-s, --syslog                print to syslog, not stderr\n"
 	       "\t-q, --quiet                 disable messages\n"

--- a/tools/static-nodes.c
+++ b/tools/static-nodes.c
@@ -126,8 +126,8 @@ static void help(void)
 	       "kmod static-nodes outputs the static-node information of the currently running kernel.\n"
 	       "\n"
 	       "Options:\n"
-	       "\t-f, --format=FORMAT  choose format to use: see \"Formats\"\n"
-	       "\t-o, --output=FILE    write output to file\n"
+	       "\t-f, --format FORMAT  choose format to use: see \"Formats\"\n"
+	       "\t-o, --output FILE    write output to file\n"
 	       "\t-h, --help           show this help\n"
 	       "\n"
 	       "Formats:\n",


### PR DESCRIPTION
The getopt_long() API handles both space and = separated long options just fine. On the other hand, supporting both in the shell completions means that we'll have to quadruple them in terms of size/complexity.

So let's try to keep things simple and consistent, by recommending only the space variant.

Make sure to update both the tools' --help and the respective man pages.