### PR TITLE
NEWS: squash a couple of typos

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,8 +14,8 @@ kmod 34
 	  target distros while developers can use the build-dev.ini configuration
 	  file.
 
-	- Allow to load decompression libraries ondemand: liblzma.so, libz.so
-	  and libzstd.so can now be loaded ondemand, only when there is
+	- Allow to load decompression libraries on demand: liblzma.so, libz.so
+	  and libzstd.so can now be loaded on demand, only when there is
 	  such a need. For use during early boot for loading modules, if
 	  configured well it means none of these libraries are loaded: the
 	  module loading logic via finit_module() will just hand over to kernel
@@ -130,7 +130,7 @@ kmod 34
 
 	- Install configuration directories,
 	  /{etc,usr/lib}/{depmod,modprobe}.d/ as part of installation, matching
-	  what several distros do during packaging. (mson only)
+	  what several distros do during packaging. (meson only)
 
 - Bug fixes
 


### PR DESCRIPTION
Namely:
 - ondemand -> on demand
 - mson -> meson

Fixes: 88940379 ("kmod 34")