### PR TITLE
ci: remove no longer needed libtool

### DIFF
--- a/.github/actions/setup-fedora/action.yml
+++ b/.github/actions/setup-fedora/action.yml
@@ -22,7 +22,6 @@ runs:
           libasan \
           libhwasan \
           liblsan \
-          libtool \
           libtsan \
           libubsan \
           libzstd-devel \


### PR DESCRIPTION
We've dropped libtool across all distros but Fedora. The tool is not needed anymore, so let's remove it.

Fixes: 04520dc9 ("ci: Remove autotools dependencies from containers")