### PR TITLE
libkmod: fix buffer-overflow in weakdep_to_char

### DIFF
--- a/libkmod/libkmod-config.c
+++ b/libkmod/libkmod-config.c
@@ -581,7 +581,7 @@ static char *weakdep_to_char(struct kmod_weakdep *dep)
 	/* Rely on the fact that dep->weak[] is a strv that points to a contiguous buffer */
 	if (dep->n_weak > 0) {
 		start = dep->weak[0];
-		end = dep->weak[dep->n_weak - 1] + strlen(dep->weak[dep->n_weak - 1]);
+		end = dep->weak[dep->n_weak - 1] + strlen(dep->weak[dep->n_weak - 1]) + 1;
 		sz = end - start;
 	} else
 		sz = 0;
@@ -594,8 +594,8 @@ static char *weakdep_to_char(struct kmod_weakdep *dep)
 		char *p;
 
 		/* include last '\0' */
-		memcpy(itr, dep->weak[0], sz + 1);
-		for (p = itr; p < itr + sz; p++) {
+		memcpy(itr, dep->weak[0], sz);
+		for (p = itr; p < itr + sz - 1; p++) {
 			if (*p == '\0')
 				*p = ' ';
 		}

--- a/testsuite/rootfs-pristine/test-weakdep/modprobe-c.txt
+++ b/testsuite/rootfs-pristine/test-weakdep/modprobe-c.txt
@@ -1,0 +1,7 @@
+weakdep mod_loop_b mod-loop-a mod-simple
+weakdep mod_weakdep mod-simple
+
+# End of configuration files. Dumping indexes now:
+
+alias symbol:printA mod_loop_a
+alias symbol:printB mod_loop_b

--- a/testsuite/test-weakdep.c
+++ b/testsuite/test-weakdep.c
@@ -96,7 +96,6 @@ static noreturn int modprobe_config(const struct test *t)
 	exit(EXIT_FAILURE);
 }
 DEFINE_TEST(modprobe_config,
-	.expected_fail = true,
 	.description = "check modprobe config parsing with weakdep",
 	.config = {
 		[TC_UNAME_R] = "4.4.4",

--- a/testsuite/test-weakdep.c
+++ b/testsuite/test-weakdep.c
@@ -15,6 +15,10 @@
 
 #include "testsuite.h"
 
+#define EXEC_MODPROBE(...)                     \
+	test_spawn_prog(TOOLS_DIR "/modprobe", \
+			(const char *[]){ TOOLS_DIR "/modprobe", ##__VA_ARGS__, NULL })
+
 static const char *const mod_name[] = {
 	"mod-loop-b",
 	"mod-weakdep",
@@ -76,7 +80,7 @@ static int test_weakdep(const struct test *t)
 	return EXIT_SUCCESS;
 }
 DEFINE_TEST(test_weakdep,
-	.description = "check if modprobe breaks weakdep",
+	.description = "check if libkmod breaks weakdep",
 	.config = {
 		[TC_UNAME_R] = "4.4.4",
 		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-weakdep",
@@ -84,6 +88,22 @@ DEFINE_TEST(test_weakdep,
 	},
 	.output = {
 		.out = TESTSUITE_ROOTFS "test-weakdep/correct-weakdep.txt",
+	});
+
+static noreturn int modprobe_config(const struct test *t)
+{
+	EXEC_MODPROBE("-c");
+	exit(EXIT_FAILURE);
+}
+DEFINE_TEST(modprobe_config,
+	.expected_fail = true,
+	.description = "check modprobe config parsing with weakdep",
+	.config = {
+		[TC_UNAME_R] = "4.4.4",
+		[TC_ROOTFS] = TESTSUITE_ROOTFS "test-weakdep",
+	},
+	.output = {
+		.out = TESTSUITE_ROOTFS "test-weakdep/modprobe-c.txt",
 	});
 
 TESTSUITE_MAIN();


### PR DESCRIPTION
modprobe -c with any sample weakdep command in modprobe.d will overflow memcpy due to size calculation not incorporating trailing null byte, for example:

==462449==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x50200000067b at pc 0x7a83fe6faf59 bp 0x7ffdf6c25060 sp 0x7ffdf6c24808 WRITE of size 12 at 0x50200000067b thread T0
    0 0x7b687e6faf58 in memcpy /usr/src/debug/gcc/gcc/libsanitizer/sanitizer_common/sanitizer_common_interceptors_memintrinsics.inc:115
    1 0x5e22b821235f in weakdep_to_char ../libkmod/libkmod-config.c:623
    2 0x5e22b821235f in weakdep_get_plain_weakdep ../libkmod/libkmod-config.c:1166
    3 0x5e22b821d049 in kmod_config_iter_get_value ../libkmod/libkmod-config.c:1317
    4 0x5e22b81fd5ec in show_config ../tools/modprobe.c:187
    5 0x5e22b81fd5ec in do_modprobe ../tools/modprobe.c:946
    6 0x7b687d635487  (/usr/lib/libc.so.6+0x27487) (BuildId: 0b707b217b15b106c25fe51df3724b25848310c0)
    7 0x7b687d63554b in __libc_start_main (/usr/lib/libc.so.6+0x2754b) (BuildId: 0b707b217b15b106c25fe51df3724b25848310c0)
    8 0x5e22b81da114 in _start ($PWD/kmod+0xaa114) (BuildId: c36444aefc2ca73423765d4ebf017a24e55017ee)

May also appear as:

*** buffer overflow detected ***: terminated
Aborted (core dumped)