### PR TITLE
v34: Fix tarball

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -6,13 +6,17 @@ oldpwd=$(pwd)
 
 if [ -n "$MESON_DIST_ROOT" ]; then
     topdir="$MESON_DIST_ROOT"
+    gtkdocize_args="--copy"
+    autoreconf_args=
 else
     topdir=$(dirname $0)
+    gtkdocize_args=
+    autoreconf_args="--symlink"
 fi
 
 cd $topdir
 
-gtkdocize --docdir libkmod/docs || NO_GTK_DOC="yes"
+gtkdocize ${gtkdocize_args} --docdir libkmod/docs || NO_GTK_DOC="yes"
 if [ "x$NO_GTK_DOC" = "xyes" ]
 then
 	for f in libkmod/docs/gtk-doc.make m4/gtk-doc.m4
@@ -22,7 +26,7 @@ then
 	done
 fi
 
-autoreconf --force --install --symlink
+autoreconf --force --install ${autoreconf_args}
 
 libdir() {
         echo $(cd "$1/$(gcc -print-multi-os-directory)"; pwd)

--- a/meson.build
+++ b/meson.build
@@ -548,7 +548,7 @@ endif
 # dist && autotools compat
 # ------------------------------------------------------------------------------
 
-meson.add_dist_script('autogen.sh')
+meson.add_dist_script('scripts/autogen-for-tarball.sh')
 
 # ------------------------------------------------------------------
 # documentation

--- a/scripts/autogen-for-tarball.sh
+++ b/scripts/autogen-for-tarball.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+cd "$MESON_DIST_ROOT"
+./autogen.sh
+rm -rf autom4te.cache


### PR DESCRIPTION
Tweak the autogen.sh so the commands used do not create symlinks and also remove the autom4te.cache dir that was not in the kmod-33 release.

This is v34-only since autotools was completely removed from master branch.