### PR TITLE
`ln -r` is not POSIX

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -513,7 +513,7 @@ if get_option('tools')
   mkdir_p = 'mkdir -p "$DESTDIR@0@"'
   meson.add_install_script('sh', '-c', mkdir_p.format(sbindir))
 
-  ln_s = 'ln -sfr "$DESTDIR@0@/kmod" "$DESTDIR@1@"'
+  ln_s = 'ln -sf "$DESTDIR@0@/kmod" "$DESTDIR@1@"'
   foreach tool : _tools
     meson.add_install_script('sh', '-c', ln_s.format(bindir, sbindir / tool))
   endforeach


### PR DESCRIPTION
Hey there, thanks for your time and effort!

This makes `ln` POSIX compliant, because not all `ln` implementations support `-r`.