### PR TITLE
tmpfile-util: Drop libgen.h

### DIFF
--- a/shared/tmpfile-util.c
+++ b/shared/tmpfile-util.c
@@ -5,7 +5,6 @@
 
 #include <errno.h>
 #include <fcntl.h>
-#include <libgen.h>
 #include <limits.h>
 #include <stdarg.h>
 #include <stdlib.h>


### PR DESCRIPTION
We don't want the version of basename() that may leak memory - we want the sane one. I remembered to add the missing.h while editing commit aae48bc9f73a ("depmod: add tmpfile-util to generate temporary file") to merge it, but completely forgot to remove the libgen.h. Fix it now.

Fixes: aae48bc9f73a ("depmod: add tmpfile-util to generate temporary file")