### PR TITLE
depmod: Fix possible 0 return on error

### DIFF
--- a/tools/depmod.c
+++ b/tools/depmod.c
@@ -2630,7 +2630,7 @@ static int depmod_output(struct depmod *depmod, FILE *out)
 			tmpfile_release(&file);
 
 			ERR("Could not write index '%s': %s\n", itr->name, strerror(-r));
-			err = -errno;
+			err = r;
 			break;
 		}
 


### PR DESCRIPTION
errno may be long overwritten at this point and doesn't mean much on a return from the cb(). Just replace with the same error we are output on the log.