### PR TITLE
testsuite: fix dirty rootfs error message

### DIFF
--- a/testsuite/testsuite.c
+++ b/testsuite/testsuite.c
@@ -261,7 +261,7 @@ static inline int test_run_child(const struct test *t, int fdout[2], int fderr[2
 		}
 
 		if (stat_mstamp(&rootfsst) > stat_mstamp(&stampst)) {
-			ERR("rootfs %s is dirty, please run 'meson compile testsuite/stamp-rootfs' before running this test\n",
+			ERR("rootfs %s is dirty, please run 'meson compile testsuite/create-rootfs' before running this test\n",
 			    rootfs);
 			exit(EXIT_FAILURE);
 		}


### PR DESCRIPTION
Running a test binary directly on a dirty rootfs results in the following error message:

        ERR: rootfs is dirty, please run
	'meson compile testsuite/stamp-rootfs' before running this test

Running the command specified by the error message fails:

        $ meson compile testsuite/stamp-rootfs
        ERROR: Can't invoke target `testsuite/stamp-rootfs`:
	target not found

Fix the error message to display the proper target.

Fixes: b85b2a0 ("testsuite: update "make rootfs" error message")