### PR TITLE
Fix errno bugs

### DIFF
--- a/libkmod/libkmod-file.c
+++ b/libkmod/libkmod-file.c
@@ -80,6 +80,7 @@ struct kmod_file *kmod_file_open(const struct kmod_ctx *ctx, const char *filenam
 	struct kmod_file *file;
 	char buf[7];
 	ssize_t sz;
+	int err = 0;
 
 	assert_cc(sizeof(magic_zstd) < sizeof(buf));
 	assert_cc(sizeof(magic_xz) < sizeof(buf));
@@ -98,12 +99,13 @@ struct kmod_file *kmod_file_open(const struct kmod_ctx *ctx, const char *filenam
 	sz = pread_str_safe(file->fd, buf, sizeof(buf), 0);
 	if (sz != (sizeof(buf) - 1)) {
 		if (sz < 0)
-			errno = -sz;
+			err = -sz;
 		else
-			errno = EINVAL;
+			err = EINVAL;
 
 		close(file->fd);
 		free(file);
+		errno = err;
 		return NULL;
 	}
 

--- a/shared/util.c
+++ b/shared/util.c
@@ -274,7 +274,6 @@ int read_str_long(int fd, long *value, int base)
 	err = read_str_safe(fd, buf, sizeof(buf));
 	if (err < 0)
 		return err;
-	errno = 0;
 	v = strtol(buf, &end, base);
 	if (end == buf || !isspace(*end))
 		return -EINVAL;
@@ -293,7 +292,6 @@ int read_str_ulong(int fd, unsigned long *value, int base)
 	err = read_str_safe(fd, buf, sizeof(buf));
 	if (err < 0)
 		return err;
-	errno = 0;
 	v = strtoul(buf, &end, base);
 	if (end == buf || !isspace(*end))
 		return -EINVAL;

--- a/tools/modinfo.c
+++ b/tools/modinfo.c
@@ -52,8 +52,10 @@ static struct param *add_param(const char *name, size_t namelen, const char *par
 
 	if (it == NULL) {
 		it = malloc(sizeof(struct param));
-		if (it == NULL)
+		if (it == NULL) {
+			errno = ENOMEM;
 			return NULL;
+		}
 		it->next = *list;
 		*list = it;
 		it->name = name;
@@ -105,7 +107,7 @@ static int process_parm(const char *key, const char *value, struct param **param
 	it = add_param(name, namelen, param, paramlen, type, typelen, params);
 	if (it == NULL) {
 		ERR("Unable to add parameter: %m\n");
-		return -ENOMEM;
+		return -errno;
 	}
 
 	return 0;


### PR DESCRIPTION
libkmod: make sure errno is not overwritten in libkmod-file
shared: do not set errno in read_str_long and read_str_ulong
tools: make sure errno is set correctly in modinfo

Closes: https://github.com/kmod-project/kmod/issues/244