### PR TITLE
Some tmpfile inspired changes

### DIFF
--- a/libkmod/libkmod-builtin.c
+++ b/libkmod/libkmod-builtin.c
@@ -44,7 +44,7 @@ static bool kmod_builtin_info_init(struct kmod_builtin_info *info, struct kmod_c
 		errno = ENAMETOOLONG;
 		return false;
 	}
-	snprintf(path, PATH_MAX, "%s/" MODULES_BUILTIN_MODINFO, dirname);
+	snprintf(path, sizeof(path), "%s/" MODULES_BUILTIN_MODINFO, dirname);
 
 	fp = fopen(path, "r");
 	if (fp == NULL)

--- a/libkmod/libkmod-builtin.c
+++ b/libkmod/libkmod-builtin.c
@@ -40,7 +40,7 @@ static bool kmod_builtin_info_init(struct kmod_builtin_info *info, struct kmod_c
 	const char *dirname = kmod_get_dirname(ctx);
 	size_t len = strlen(dirname);
 
-	if ((len + 1 + strlen(MODULES_BUILTIN_MODINFO) + 1) >= PATH_MAX) {
+	if ((len + 1 + strlen(MODULES_BUILTIN_MODINFO) + 1) >= sizeof(path)) {
 		errno = ENAMETOOLONG;
 		return false;
 	}

--- a/libkmod/libkmod-module.c
+++ b/libkmod/libkmod-module.c
@@ -127,7 +127,7 @@ void kmod_module_parse_depline(struct kmod_module *mod, char *line)
 	*p = '\0';
 	dirname = kmod_get_dirname(mod->ctx);
 	dirnamelen = strlen(dirname);
-	if (dirnamelen + 2 >= PATH_MAX)
+	if (dirnamelen + 2 >= sizeof(buf))
 		return;
 
 	memcpy(buf, dirname, dirnamelen);
@@ -301,7 +301,7 @@ int kmod_module_new_from_alias(struct kmod_ctx *ctx, const char *alias, const ch
 	size_t namelen = strlen(name);
 	size_t aliaslen = strlen(alias);
 
-	if (namelen + aliaslen + 2 > PATH_MAX)
+	if (namelen + aliaslen + 2 > sizeof(key))
 		return -ENAMETOOLONG;
 
 	memcpy(key, name, namelen);

--- a/shared/tmpfile-util.c
+++ b/shared/tmpfile-util.c
@@ -69,7 +69,7 @@ int tmpfile_publish(struct tmpfile *file, const char *targetname)
 
 	file->fd = -1;
 	file->dirfd = -1;
-	memset(file->tmpname, 0, PATH_MAX);
+	memset(file->tmpname, 0, sizeof(file->tmpname));
 
 	return 0;
 }

--- a/shared/tmpfile-util.c
+++ b/shared/tmpfile-util.c
@@ -31,8 +31,8 @@ FILE *tmpfile_openat(int dirfd, mode_t mode, struct tmpfile *file)
 	if (targetdir == NULL)
 		goto create_fail;
 
-	n = snprintf(tmpfile_path, PATH_MAX, "%s/%s", targetdir, tmpname_tmpl);
-	if (n < 0 || n >= PATH_MAX)
+	n = snprintf(tmpfile_path, sizeof(tmpfile_path), "%s/%s", targetdir, tmpname_tmpl);
+	if (n < 0 || n >= (int)sizeof(tmpfile_path))
 		goto create_fail;
 
 	fd = mkstemp(tmpfile_path);

--- a/shared/tmpfile-util.c
+++ b/shared/tmpfile-util.c
@@ -20,20 +20,20 @@
 
 FILE *tmpfile_openat(int dirfd, mode_t mode, struct tmpfile *file)
 {
-	const char *tmpname_tmpl = "tmpfileXXXXXX";
+	const char *tmpname_tmpl = "/tmpfileXXXXXX";
 	const char *tmpname;
 	char tmpfile_path[PATH_MAX];
 	int fd, n;
-	_cleanup_free_ char *targetdir;
 	FILE *fp;
 
-	targetdir = fd_lookup_path(dirfd);
-	if (targetdir == NULL)
+	n = fd_lookup_path(dirfd, tmpfile_path, sizeof(tmpfile_path));
+	if (n < 0)
 		goto create_fail;
 
-	n = snprintf(tmpfile_path, sizeof(tmpfile_path), "%s/%s", targetdir, tmpname_tmpl);
-	if (n < 0 || n >= (int)sizeof(tmpfile_path))
+	if (n + strlen(tmpname_tmpl) + 1 > sizeof(tmpfile_path))
 		goto create_fail;
+
+	memcpy(tmpfile_path + n, tmpname_tmpl, strlen(tmpname_tmpl) + 1);
 
 	fd = mkstemp(tmpfile_path);
 	if (fd < 0)

--- a/shared/util.c
+++ b/shared/util.c
@@ -482,9 +482,7 @@ char *fd_lookup_path(int fd)
 	char fd_path[PATH_MAX];
 	ssize_t len;
 
-	len = snprintf(proc_path, sizeof(proc_path), "/proc/self/fd/%d", fd);
-	if (len < 0 || len >= (ssize_t)sizeof(proc_path))
-		return NULL;
+	snprintf(proc_path, sizeof(proc_path), "/proc/self/fd/%d", fd);
 
 	/*
 	 * We are using mkstemp to create a temporary file. We need to read the link since

--- a/shared/util.h
+++ b/shared/util.h
@@ -54,7 +54,7 @@ static inline _must_check_ _nonnull_all_ bool path_is_absolute(const char *p)
 int mkdir_p(const char *path, int len, mode_t mode);
 int mkdir_parents(const char *path, mode_t mode);
 unsigned long long stat_mstamp(const struct stat *st);
-char *fd_lookup_path(int fd);
+_nonnull_all_ int fd_lookup_path(int fd, char *path, size_t pathlen);
 
 /* time-related functions
  * ************************************************************************ */

--- a/tools/depmod.c
+++ b/tools/depmod.c
@@ -3011,17 +3011,17 @@ static int do_depmod(int argc, char *argv[])
 	while (module_directory[0] == '/')
 		module_directory++;
 
-	cfg.dirnamelen = snprintf(cfg.dirname, PATH_MAX, "%s/%s/%s", root,
+	cfg.dirnamelen = snprintf(cfg.dirname, sizeof(cfg.dirname), "%s/%s/%s", root,
 				  module_directory, cfg.kversion);
-	if (cfg.dirnamelen >= PATH_MAX) {
+	if (cfg.dirnamelen >= sizeof(cfg.dirname)) {
 		ERR("Bad directory %s/%s/%s: path too long\n", root, module_directory,
 		    cfg.kversion);
 		goto cmdline_failed;
 	}
 
-	cfg.outdirnamelen = snprintf(cfg.outdirname, PATH_MAX, "%s/%s/%s",
+	cfg.outdirnamelen = snprintf(cfg.outdirname, sizeof(cfg.outdirname), "%s/%s/%s",
 				     out_root ?: root, module_directory, cfg.kversion);
-	if (cfg.outdirnamelen >= PATH_MAX) {
+	if (cfg.outdirnamelen >= sizeof(cfg.outdirname)) {
 		ERR("Bad directory %s/%s/%s: path too long\n", out_root ?: root,
 		    module_directory, cfg.kversion);
 		goto cmdline_failed;


### PR DESCRIPTION
As the tmpfile helpers were introduced I've noticed we have a mix of `PATH_MAX` vs `sizeof()` handling across the project. The first two commits address most instances - the remaining ones might need more careful surgery.

The last two commits simplify the helpers wrt LoC and memory usage.