### PR TITLE
Reduce strerror and errno usage

### DIFF
--- a/libkmod/libkmod-builtin.c
+++ b/libkmod/libkmod-builtin.c
@@ -90,7 +90,7 @@ static ssize_t get_strings(struct kmod_builtin_info *info, const char *modname,
 		if (n == -1) {
 			if (!feof(info->fp)) {
 				count = -errno;
-				ERR(info->ctx, "get_string: %s\n", strerror(errno));
+				ERR(info->ctx, "get_string: %m\n");
 			}
 			break;
 		}
@@ -182,7 +182,7 @@ ssize_t kmod_builtin_get_modinfo(struct kmod_ctx *ctx, const char *modname,
 		*modinfo = strbuf_to_vector(&buf, (size_t)count);
 		if (*modinfo == NULL) {
 			count = -errno;
-			ERR(ctx, "strbuf_to_vector: %s\n", strerror(errno));
+			ERR(ctx, "strbuf_to_vector: %m\n");
 		}
 	}
 

--- a/libkmod/libkmod-builtin.c
+++ b/libkmod/libkmod-builtin.c
@@ -62,19 +62,6 @@ static void kmod_builtin_info_release(struct kmod_builtin_info *info)
 	fclose(info->fp);
 }
 
-static ssize_t get_string(struct kmod_builtin_info *info)
-{
-	ssize_t len;
-
-	len = getdelim(&info->buf, &info->bufsz, '\0', info->fp);
-	if (len > 0 && info->buf[len] != '\0') {
-		errno = EINVAL;
-		len = -1;
-	}
-
-	return len;
-}
-
 static ssize_t get_strings(struct kmod_builtin_info *info, const char *modname,
 			   struct strbuf *buf)
 {
@@ -84,11 +71,11 @@ static ssize_t get_strings(struct kmod_builtin_info *info, const char *modname,
 	for (count = 0; count < INTPTR_MAX;) {
 		char *dot, *line;
 
-		n = get_string(info);
+		n = getdelim(&info->buf, &info->bufsz, '\0', info->fp);
 		if (n == -1) {
 			if (!feof(info->fp)) {
 				count = -errno;
-				ERR(info->ctx, "get_string: %m\n");
+				ERR(info->ctx, "get_strings: %m\n");
 			}
 			break;
 		}

--- a/libkmod/libkmod-builtin.c
+++ b/libkmod/libkmod-builtin.c
@@ -140,10 +140,8 @@ static char **strbuf_to_vector(struct strbuf *buf, size_t count)
 	/* (string vector + NULL) * sizeof(char *) + strbuf_used() */
 	if (uaddsz_overflow(count, 1, &n) ||
 	    umulsz_overflow(sizeof(char *), n, &vec_size) ||
-	    uaddsz_overflow(strbuf_used(buf), vec_size, &total_size)) {
-		errno = ENOMEM;
+	    uaddsz_overflow(strbuf_used(buf), vec_size, &total_size))
 		return NULL;
-	}
 
 	vector = realloc(buf->bytes, total_size);
 	if (vector == NULL)
@@ -181,7 +179,7 @@ ssize_t kmod_builtin_get_modinfo(struct kmod_ctx *ctx, const char *modname,
 	else if (count > 0) {
 		*modinfo = strbuf_to_vector(&buf, (size_t)count);
 		if (*modinfo == NULL) {
-			count = -errno;
+			count = -ENOMEM;
 			ERR(ctx, "strbuf_to_vector: %m\n");
 		}
 	}

--- a/libkmod/libkmod-elf.c
+++ b/libkmod/libkmod-elf.c
@@ -317,11 +317,6 @@ struct kmod_elf *kmod_elf_new(const void *memory, off_t size)
 	assert_cc(sizeof(uint32_t) == sizeof(Elf32_Word));
 	assert_cc(sizeof(uint32_t) == sizeof(Elf64_Word));
 
-	if (!memory) {
-		errno = -EINVAL;
-		return NULL;
-	}
-
 	elf = malloc(sizeof(struct kmod_elf));
 	if (elf == NULL) {
 		return NULL;

--- a/libkmod/libkmod-file-zlib.c
+++ b/libkmod/libkmod-file-zlib.c
@@ -60,7 +60,6 @@ int kmod_file_load_zlib(struct kmod_file *file)
 		return -EINVAL;
 	}
 
-	errno = 0;
 	gzfd = fcntl(file->fd, F_DUPFD_CLOEXEC, 3);
 	if (gzfd < 0)
 		return -errno;

--- a/libkmod/libkmod-file.c
+++ b/libkmod/libkmod-file.c
@@ -135,7 +135,7 @@ int kmod_file_load_contents(struct kmod_file *file)
 	return file->load(file);
 }
 
-void *kmod_file_get_contents(const struct kmod_file *file)
+const void *kmod_file_get_contents(const struct kmod_file *file)
 {
 	return file->memory;
 }

--- a/libkmod/libkmod-file.c
+++ b/libkmod/libkmod-file.c
@@ -71,7 +71,11 @@ struct kmod_elf *kmod_file_get_elf(struct kmod_file *file)
 		return NULL;
 	}
 
-	file->elf = kmod_elf_new(file->memory, file->size);
+	err = kmod_elf_new(file->memory, file->size, &file->elf);
+	if (err) {
+		errno = -err;
+		return NULL;
+	}
 	return file->elf;
 }
 

--- a/libkmod/libkmod-internal.h
+++ b/libkmod/libkmod-internal.h
@@ -152,7 +152,7 @@ struct kmod_modversion {
 	const char *symbol;
 };
 
-_nonnull_all_ struct kmod_elf *kmod_elf_new(const void *memory, off_t size);
+_must_check_ _nonnull_all_ int kmod_elf_new(const void *memory, off_t size, struct kmod_elf **elf);
 _nonnull_all_ void kmod_elf_unref(struct kmod_elf *elf);
 _must_check_ _nonnull_all_ const void *kmod_elf_get_memory(const struct kmod_elf *elf);
 _must_check_ _nonnull_all_ int kmod_elf_get_modinfo_strings(const struct kmod_elf *elf, char ***array);

--- a/libkmod/libkmod-internal.h
+++ b/libkmod/libkmod-internal.h
@@ -138,7 +138,7 @@ _nonnull_all_ bool kmod_module_is_builtin(struct kmod_module *mod);
 _must_check_ _nonnull_all_ struct kmod_file *kmod_file_open(const struct kmod_ctx *ctx, const char *filename);
 _nonnull_all_ struct kmod_elf *kmod_file_get_elf(struct kmod_file *file);
 _nonnull_all_ int kmod_file_load_contents(struct kmod_file *file);
-_must_check_ _nonnull_all_ void *kmod_file_get_contents(const struct kmod_file *file);
+_must_check_ _nonnull_all_ const void *kmod_file_get_contents(const struct kmod_file *file);
 _must_check_ _nonnull_all_ off_t kmod_file_get_size(const struct kmod_file *file);
 _must_check_ _nonnull_all_ enum kmod_file_compression_type kmod_file_get_compression(const struct kmod_file *file);
 _must_check_ _nonnull_all_ int kmod_file_get_fd(const struct kmod_file *file);

--- a/libkmod/libkmod-internal.h
+++ b/libkmod/libkmod-internal.h
@@ -159,7 +159,7 @@ _must_check_ _nonnull_all_ int kmod_elf_get_modinfo_strings(const struct kmod_el
 _must_check_ _nonnull_all_ int kmod_elf_get_modversions(const struct kmod_elf *elf, struct kmod_modversion **array);
 _must_check_ _nonnull_all_ int kmod_elf_get_symbols(const struct kmod_elf *elf, struct kmod_modversion **array);
 _must_check_ _nonnull_all_ int kmod_elf_get_dependency_symbols(const struct kmod_elf *elf, struct kmod_modversion **array);
-_must_check_ _nonnull_all_ const void *kmod_elf_strip(const struct kmod_elf *elf, unsigned int flags);
+_must_check_ _nonnull_all_ int kmod_elf_strip(const struct kmod_elf *elf, unsigned int flags, const void **stripped);
 
 /*
  * Debug mock lib need to find section ".gnu.linkonce.this_module" in order to

--- a/libkmod/libkmod-internal.h
+++ b/libkmod/libkmod-internal.h
@@ -152,7 +152,7 @@ struct kmod_modversion {
 	const char *symbol;
 };
 
-struct kmod_elf *kmod_elf_new(const void *memory, off_t size);
+_nonnull_all_ struct kmod_elf *kmod_elf_new(const void *memory, off_t size);
 _nonnull_all_ void kmod_elf_unref(struct kmod_elf *elf);
 _must_check_ _nonnull_all_ const void *kmod_elf_get_memory(const struct kmod_elf *elf);
 _must_check_ _nonnull_all_ int kmod_elf_get_modinfo_strings(const struct kmod_elf *elf, char ***array);

--- a/libkmod/libkmod-internal.h
+++ b/libkmod/libkmod-internal.h
@@ -135,8 +135,10 @@ _nonnull_(1) void kmod_module_set_required(struct kmod_module *mod, bool require
 _nonnull_all_ bool kmod_module_is_builtin(struct kmod_module *mod);
 
 /* libkmod-file.c */
-_must_check_ _nonnull_all_ struct kmod_file *kmod_file_open(const struct kmod_ctx *ctx, const char *filename);
-_nonnull_all_ struct kmod_elf *kmod_file_get_elf(struct kmod_file *file);
+struct kmod_file;
+struct kmod_elf;
+_must_check_ _nonnull_all_ int kmod_file_open(const struct kmod_ctx *ctx, const char *filename, struct kmod_file **file);
+_must_check_ _nonnull_all_ int kmod_file_get_elf(struct kmod_file *file, struct kmod_elf **elf);
 _nonnull_all_ int kmod_file_load_contents(struct kmod_file *file);
 _must_check_ _nonnull_all_ const void *kmod_file_get_contents(const struct kmod_file *file);
 _must_check_ _nonnull_all_ off_t kmod_file_get_size(const struct kmod_file *file);
@@ -145,7 +147,6 @@ _must_check_ _nonnull_all_ int kmod_file_get_fd(const struct kmod_file *file);
 _nonnull_all_ void kmod_file_unref(struct kmod_file *file);
 
 /* libkmod-elf.c */
-struct kmod_elf;
 struct kmod_modversion {
 	uint64_t crc;
 	enum kmod_symbol_bind bind;

--- a/libkmod/libkmod-module.c
+++ b/libkmod/libkmod-module.c
@@ -1434,7 +1434,6 @@ KMOD_EXPORT int kmod_module_get_initstate(const struct kmod_module *mod)
 	fd = open(path, O_RDONLY | O_CLOEXEC);
 	if (fd < 0) {
 		err = -errno;
-
 		DBG(mod->ctx, "could not open '%s': %s\n", path, strerror(-err));
 
 		if (pathlen > (int)sizeof("/initstate") - 1) {
@@ -1442,9 +1441,10 @@ KMOD_EXPORT int kmod_module_get_initstate(const struct kmod_module *mod)
 			path[pathlen - (sizeof("/initstate") - 1)] = '\0';
 			if (stat(path, &st) == 0 && S_ISDIR(st.st_mode))
 				return KMOD_MODULE_COMING;
-		}
 
-		DBG(mod->ctx, "could not open '%s': %s\n", path, strerror(-err));
+			err = -errno;
+			DBG(mod->ctx, "could not open '%s': %s\n", path, strerror(-err));
+		}
 		return err;
 	}
 

--- a/libkmod/libkmod-module.c
+++ b/libkmod/libkmod-module.c
@@ -334,7 +334,7 @@ KMOD_EXPORT int kmod_module_new_from_path(struct kmod_ctx *ctx, const char *path
 	err = stat(abspath, &st);
 	if (err < 0) {
 		err = -errno;
-		DBG(ctx, "stat %s: %s\n", path, strerror(errno));
+		DBG(ctx, "stat %s: %m\n", path);
 		free(abspath);
 		return err;
 	}
@@ -664,8 +664,7 @@ static int do_init_module(struct kmod_module *mod, unsigned int flags, const cha
 
 		stripped = kmod_elf_strip(elf, flags);
 		if (stripped == NULL) {
-			ERR(mod->ctx, "Failed to strip version information: %s\n",
-			    strerror(errno));
+			ERR(mod->ctx, "Failed to strip version information: %m\n");
 			return -errno;
 		}
 		mem = stripped;
@@ -1362,7 +1361,7 @@ KMOD_EXPORT int kmod_module_new_from_loaded(struct kmod_ctx *ctx, struct kmod_li
 	fp = fopen("/proc/modules", "re");
 	if (fp == NULL) {
 		int err = -errno;
-		ERR(ctx, "could not open /proc/modules: %s\n", strerror(errno));
+		ERR(ctx, "could not open /proc/modules: %m\n");
 		return err;
 	}
 
@@ -1434,7 +1433,7 @@ KMOD_EXPORT int kmod_module_get_initstate(const struct kmod_module *mod)
 	fd = open(path, O_RDONLY | O_CLOEXEC);
 	if (fd < 0) {
 		err = -errno;
-		DBG(mod->ctx, "could not open '%s': %s\n", path, strerror(-err));
+		DBG(mod->ctx, "could not open '%s': %m\n", path);
 
 		if (pathlen > (int)sizeof("/initstate") - 1) {
 			struct stat st;
@@ -1443,7 +1442,7 @@ KMOD_EXPORT int kmod_module_get_initstate(const struct kmod_module *mod)
 				return KMOD_MODULE_COMING;
 
 			err = -errno;
-			DBG(mod->ctx, "could not open '%s': %s\n", path, strerror(-err));
+			DBG(mod->ctx, "could not open '%s': %m\n", path);
 		}
 		return err;
 	}
@@ -1499,7 +1498,7 @@ KMOD_EXPORT long kmod_module_get_size(const struct kmod_module *mod)
 	fp = fopen("/proc/modules", "re");
 	if (fp == NULL) {
 		int err = -errno;
-		ERR(mod->ctx, "could not open /proc/modules: %s\n", strerror(errno));
+		ERR(mod->ctx, "could not open /proc/modules: %m\n");
 		close(dfd);
 		return err;
 	}
@@ -1551,7 +1550,7 @@ KMOD_EXPORT int kmod_module_get_refcnt(const struct kmod_module *mod)
 	fd = open(path, O_RDONLY | O_CLOEXEC);
 	if (fd < 0) {
 		err = -errno;
-		DBG(mod->ctx, "could not open '%s': %s\n", path, strerror(errno));
+		DBG(mod->ctx, "could not open '%s': %m\n", path);
 		return err;
 	}
 
@@ -1580,7 +1579,7 @@ KMOD_EXPORT struct kmod_list *kmod_module_get_holders(const struct kmod_module *
 
 	d = opendir(dname);
 	if (d == NULL) {
-		ERR(mod->ctx, "could not open '%s': %s\n", dname, strerror(errno));
+		ERR(mod->ctx, "could not open '%s': %m\n", dname);
 		return NULL;
 	}
 
@@ -1646,7 +1645,7 @@ KMOD_EXPORT struct kmod_list *kmod_module_get_sections(const struct kmod_module 
 
 	d = opendir(dname);
 	if (d == NULL) {
-		ERR(mod->ctx, "could not open '%s': %s\n", dname, strerror(errno));
+		ERR(mod->ctx, "could not open '%s': %m\n", dname);
 		return NULL;
 	}
 

--- a/libkmod/libkmod-module.c
+++ b/libkmod/libkmod-module.c
@@ -662,10 +662,11 @@ static int do_init_module(struct kmod_module *mod, unsigned int flags, const cha
 			return err;
 		}
 
-		stripped = kmod_elf_strip(elf, flags);
-		if (stripped == NULL) {
-			ERR(mod->ctx, "Failed to strip version information: %m\n");
-			return -errno;
+		err = kmod_elf_strip(elf, flags, &stripped);
+		if (err) {
+			ERR(mod->ctx, "Failed to strip version information: %s\n",
+			    strerror(-err));
+			return err;
 		}
 		mem = stripped;
 	} else {

--- a/shared/util.c
+++ b/shared/util.c
@@ -274,7 +274,6 @@ int read_str_long(int fd, long *value, int base)
 	err = read_str_safe(fd, buf, sizeof(buf));
 	if (err < 0)
 		return err;
-	errno = 0;
 	v = strtol(buf, &end, base);
 	if (end == buf || !isspace(*end))
 		return -EINVAL;
@@ -293,7 +292,6 @@ int read_str_ulong(int fd, unsigned long *value, int base)
 	err = read_str_safe(fd, buf, sizeof(buf));
 	if (err < 0)
 		return err;
-	errno = 0;
 	v = strtoul(buf, &end, base);
 	if (end == buf || !isspace(*end))
 		return -EINVAL;

--- a/testsuite/delete_module.c
+++ b/testsuite/delete_module.c
@@ -137,8 +137,7 @@ static int remove_directory(const char *path)
 
 	dir = opendir(path);
 	if (!dir) {
-		ERR("Failed to open directory %s: %s (errno: %d)\n", path,
-		    strerror(errno), errno);
+		ERR("Failed to open directory %s: %m (errno: %d)\n", path, errno);
 		return -1;
 	}
 

--- a/testsuite/init_module.c
+++ b/testsuite/init_module.c
@@ -236,15 +236,14 @@ long init_module(void *mem, unsigned long len, const char *args)
 
 	elf = kmod_elf_new(mem, len);
 	if (elf == NULL)
-		return 0;
+		return -1;
 
 	err = kmod_elf_get_section(elf, ".gnu.linkonce.this_module", &off, &bufsize);
 	buf = (const char *)kmod_elf_get_memory(elf) + off;
 	kmod_elf_unref(elf);
 
-	/* We couldn't parse the ELF file. Just exit as if it was successful */
 	if (err < 0)
-		return 0;
+		return -1;
 
 	/* We need to open both 32 and 64 bits module - hack! */
 	class = elf_identify(mem);

--- a/testsuite/init_module.c
+++ b/testsuite/init_module.c
@@ -239,9 +239,11 @@ long init_module(void *mem, unsigned long len, const char *args)
 		return -1;
 	}
 
-	elf = kmod_elf_new(mem, len);
-	if (elf == NULL)
+	err = kmod_elf_new(mem, len, &elf);
+	if (err < 0) {
+		errno = -err;
 		return -1;
+	}
 
 	err = kmod_elf_get_section(elf, ".gnu.linkonce.this_module", &off, &bufsize);
 	buf = (const char *)kmod_elf_get_memory(elf) + off;

--- a/testsuite/init_module.c
+++ b/testsuite/init_module.c
@@ -234,6 +234,11 @@ long init_module(void *mem, unsigned long len, const char *args)
 
 	init_retcodes();
 
+	if (mem == NULL) {
+		errno = EFAULT;
+		return -1;
+	}
+
 	elf = kmod_elf_new(mem, len);
 	if (elf == NULL)
 		return -1;

--- a/tools/depmod.c
+++ b/tools/depmod.c
@@ -3001,7 +3001,7 @@ static int do_depmod(int argc, char *argv[])
 		optind++;
 	} else {
 		if (uname(&un) < 0) {
-			CRIT("uname() failed: %s\n", strerror(errno));
+			CRIT("uname() failed: %m\n");
 			goto cmdline_failed;
 		}
 		cfg.kversion = un.release;

--- a/tools/modinfo.c
+++ b/tools/modinfo.c
@@ -34,15 +34,13 @@ struct param {
 	int typelen;
 };
 
-static struct param *add_param(const char *name, size_t namelen, const char *param,
-			       size_t paramlen, const char *type, size_t typelen,
-			       struct param **list)
+static int add_param(const char *name, size_t namelen, const char *param, size_t paramlen,
+		     const char *type, size_t typelen, struct param **list)
 {
 	struct param *it;
 
 	if (namelen > INT_MAX || paramlen > INT_MAX || typelen > INT_MAX) {
-		errno = EINVAL;
-		return NULL;
+		return -EINVAL;
 	}
 
 	for (it = *list; it != NULL; it = it->next) {
@@ -53,7 +51,7 @@ static struct param *add_param(const char *name, size_t namelen, const char *par
 	if (it == NULL) {
 		it = malloc(sizeof(struct param));
 		if (it == NULL)
-			return NULL;
+			return -ENOMEM;
 		it->next = *list;
 		*list = it;
 		it->name = name;
@@ -74,15 +72,16 @@ static struct param *add_param(const char *name, size_t namelen, const char *par
 		it->typelen = typelen;
 	}
 
-	return it;
+	return 0;
 }
 
 static int process_parm(const char *key, const char *value, struct param **params)
 {
 	const char *name, *param, *type;
 	size_t namelen, paramlen, typelen;
-	struct param *it;
 	const char *colon = strchr(value, ':');
+	int ret;
+
 	if (colon == NULL) {
 		ERR("Found invalid \"%s=%s\": missing ':'\n", key, value);
 		return 0;
@@ -102,9 +101,9 @@ static int process_parm(const char *key, const char *value, struct param **param
 		typelen = strlen(type);
 	}
 
-	it = add_param(name, namelen, param, paramlen, type, typelen, params);
-	if (it == NULL) {
-		ERR("Unable to add parameter: %m\n");
+	ret = add_param(name, namelen, param, paramlen, type, typelen, params);
+	if (ret < 0) {
+		ERR("Unable to add parameter: %s\n", strerror(-ret));
 		return -ENOMEM;
 	}
 


### PR DESCRIPTION
Originally inspired by https://github.com/kmod-project/kmod/issues/244, with some commit (fragments) from https://github.com/kmod-project/kmod/pull/336 and https://github.com/kmod-project/kmod/pull/343

Tl:Dr: we no longer manually set `errno` but propagate the error code manually, iff needed. In addition most (but not all) of our `strerror()` usage is replaced by `%m`.

As a nice side-effect the size of libkmod.so (should also be applicable for the tools) has decreased:

   text    data     bss     dec     hex filename
 116099    2224       8  118331   1ce3b before//libkmod.so
 115685    2224       8  117917   1cc9d after/libkmod.so

NOTE: the PR also includes a few related bug fixes of varying severity. Happy to flesh them out into separate PR/PRs if that helps.