### PR TITLE
ci: install curl in Ubuntu container

### DIFF
--- a/.github/actions/setup-os/setup-ubuntu.sh
+++ b/.github/actions/setup-os/setup-ubuntu.sh
@@ -9,6 +9,7 @@ export TZ=Etc/UTC
 apt-get update
 apt-get install --yes \
     build-essential \
+    curl \
     clang \
     gcc-multilib \
     gcovr \


### PR DESCRIPTION
With codecov v5, the script/action requires curl (and maybe more) although the documentation wasn't updated. Furthermore, the missing program will be reported in the logs, while the action will report overall success :facepalm:

NOTE: apart from this PR, we might want to also land the update to 5.4.2 (https://github.com/kmod-project/kmod/pull/342) which includes a coverage upload regression.