### PR TITLE
libkmod: Fix dependency count in kmod_module_parse_depline()

### DIFF
--- a/libkmod/libkmod-module.c
+++ b/libkmod/libkmod-module.c
@@ -172,6 +172,7 @@ void kmod_module_parse_depline(struct kmod_module *mod, char *line)
 			goto fail;
 		}
 		list = l_new;
+		n++;
 	}
 
 	DBG(ctx, "%zu dependencies for %s\n", n, mod->name);


### PR DESCRIPTION
The variable n is intended to track the number of dependencies for mod. However, it is only initialized and not incremented during dependency parsing.

Fix it.