### PR TITLE
Make use of streq/strstartswith and strlen(string-literal)

### DIFF
--- a/libkmod/libkmod-config.c
+++ b/libkmod/libkmod-config.c
@@ -267,10 +267,9 @@ static int kmod_config_add_softdep(struct kmod_config *config, const char *modna
 		}
 		plen = s - p;
 
-		if (plen == strlen("pre:") && memcmp(p, "pre:", strlen("pre:")) == 0)
+		if (plen == strlen("pre:") && strstartswith(p, "pre:"))
 			mode = S_PRE;
-		else if (plen == strlen("post:") &&
-			 memcmp(p, "post:", strlen("post:")) == 0)
+		else if (plen == strlen("post:") && strstartswith(p, "post:"))
 			mode = S_POST;
 		else if (*s != '\0' || (*s == '\0' && !was_space)) {
 			if (mode == S_PRE) {
@@ -351,10 +350,9 @@ static int kmod_config_add_softdep(struct kmod_config *config, const char *modna
 		}
 		plen = s - p;
 
-		if (plen == strlen("pre:") && memcmp(p, "pre:", strlen("pre:")) == 0)
+		if (plen == strlen("pre:") && strstartswith(p, "pre:"))
 			mode = S_PRE;
-		else if (plen == strlen("post:") &&
-			 memcmp(p, "post:", strlen("post:")) == 0)
+		else if (plen == strlen("post:") && strstartswith(p, "post:"))
 			mode = S_POST;
 		else if (*s != '\0' || (*s == '\0' && !was_space)) {
 			if (mode == S_PRE) {

--- a/libkmod/libkmod-config.c
+++ b/libkmod/libkmod-config.c
@@ -267,11 +267,10 @@ static int kmod_config_add_softdep(struct kmod_config *config, const char *modna
 		}
 		plen = s - p;
 
-		if (plen == sizeof("pre:") - 1 &&
-		    memcmp(p, "pre:", sizeof("pre:") - 1) == 0)
+		if (plen == strlen("pre:") && memcmp(p, "pre:", strlen("pre:")) == 0)
 			mode = S_PRE;
-		else if (plen == sizeof("post:") - 1 &&
-			 memcmp(p, "post:", sizeof("post:") - 1) == 0)
+		else if (plen == strlen("post:") &&
+			 memcmp(p, "post:", strlen("post:")) == 0)
 			mode = S_POST;
 		else if (*s != '\0' || (*s == '\0' && !was_space)) {
 			if (mode == S_PRE) {
@@ -352,11 +351,10 @@ static int kmod_config_add_softdep(struct kmod_config *config, const char *modna
 		}
 		plen = s - p;
 
-		if (plen == sizeof("pre:") - 1 &&
-		    memcmp(p, "pre:", sizeof("pre:") - 1) == 0)
+		if (plen == strlen("pre:") && memcmp(p, "pre:", strlen("pre:")) == 0)
 			mode = S_PRE;
-		else if (plen == sizeof("post:") - 1 &&
-			 memcmp(p, "post:", sizeof("post:") - 1) == 0)
+		else if (plen == strlen("post:") &&
+			 memcmp(p, "post:", strlen("post:")) == 0)
 			mode = S_POST;
 		else if (*s != '\0' || (*s == '\0' && !was_space)) {
 			if (mode == S_PRE) {
@@ -506,8 +504,6 @@ static int kmod_config_add_weakdep(struct kmod_config *config, const char *modna
 
 static char *softdep_to_char(struct kmod_softdep *dep)
 {
-	const size_t sz_preprefix = sizeof("pre: ") - 1;
-	const size_t sz_postprefix = sizeof("post: ") - 1;
 	size_t sz = 1; /* at least '\0' */
 	size_t sz_pre, sz_post;
 	const char *start, *end;
@@ -521,7 +517,7 @@ static char *softdep_to_char(struct kmod_softdep *dep)
 		start = dep->pre[0];
 		end = dep->pre[dep->n_pre - 1] + strlen(dep->pre[dep->n_pre - 1]);
 		sz_pre = end - start;
-		sz += sz_pre + sz_preprefix;
+		sz += sz_pre + strlen("pre: ");
 	} else
 		sz_pre = 0;
 
@@ -529,7 +525,7 @@ static char *softdep_to_char(struct kmod_softdep *dep)
 		start = dep->post[0];
 		end = dep->post[dep->n_post - 1] + strlen(dep->post[dep->n_post - 1]);
 		sz_post = end - start;
-		sz += sz_post + sz_postprefix;
+		sz += sz_post + strlen("post: ");
 	} else
 		sz_post = 0;
 
@@ -540,8 +536,8 @@ static char *softdep_to_char(struct kmod_softdep *dep)
 	if (sz_pre) {
 		char *p;
 
-		memcpy(itr, "pre: ", sz_preprefix);
-		itr += sz_preprefix;
+		memcpy(itr, "pre: ", strlen("pre: "));
+		itr += strlen("pre: ");
 
 		/* include last '\0' */
 		memcpy(itr, dep->pre[0], sz_pre + 1);
@@ -555,8 +551,8 @@ static char *softdep_to_char(struct kmod_softdep *dep)
 	if (sz_post) {
 		char *p;
 
-		memcpy(itr, "post: ", sz_postprefix);
-		itr += sz_postprefix;
+		memcpy(itr, "post: ", strlen("post: "));
+		itr += strlen("post: ");
 
 		/* include last '\0' */
 		memcpy(itr, dep->post[0], sz_post + 1);

--- a/libkmod/libkmod-config.c
+++ b/libkmod/libkmod-config.c
@@ -617,7 +617,7 @@ static void kcmdline_parse_result(struct kmod_config *config, char *modname, cha
 
 	DBG(config->ctx, "%s %s\n", modname, param);
 
-	if (streq(modname, "modprobe") && !strncmp(param, "blacklist=", 10)) {
+	if (streq(modname, "modprobe") && strstartswith(param, "blacklist=")) {
 		for (;;) {
 			char *t = strsep(&value, ",");
 			if (t == NULL)

--- a/libkmod/libkmod-elf.c
+++ b/libkmod/libkmod-elf.c
@@ -643,7 +643,7 @@ static int elf_strip_vermagic(const struct kmod_elf *elf, uint8_t *changed)
 		len = sizeof("vermagic=") - 1;
 		if (i + len >= size)
 			continue;
-		if (strncmp(s, "vermagic=", len) != 0) {
+		if (!strstartswith(s, "vermagic=")) {
 			i += strlen(s);
 			continue;
 		}
@@ -873,7 +873,7 @@ int kmod_elf_get_symbols(const struct kmod_elf *elf, struct kmod_modversion **ar
 
 		name = elf_get_mem(elf, str_off + name_off);
 
-		if (strncmp(name, crc_str, crc_strlen) != 0)
+		if (!strstartswith(name, crc_str))
 			continue;
 		count++;
 	}
@@ -914,7 +914,7 @@ int kmod_elf_get_symbols(const struct kmod_elf *elf, struct kmod_modversion **ar
 		}
 #undef READV
 		name = elf_get_mem(elf, str_off + name_off);
-		if (strncmp(name, crc_str, crc_strlen) != 0)
+		if (!strstartswith(name, crc_str))
 			continue;
 		name += crc_strlen;
 

--- a/libkmod/libkmod-elf.c
+++ b/libkmod/libkmod-elf.c
@@ -640,8 +640,7 @@ static int elf_strip_vermagic(const struct kmod_elf *elf, uint8_t *changed)
 			continue;
 
 		s = strings + i;
-		len = sizeof("vermagic=") - 1;
-		if (i + len >= size)
+		if (i + strlen("vermagic=") >= size)
 			continue;
 		if (!strstartswith(s, "vermagic=")) {
 			i += strlen(s);

--- a/libkmod/libkmod-module.c
+++ b/libkmod/libkmod-module.c
@@ -819,7 +819,7 @@ static int module_do_install_commands(struct kmod_module *mod, const char *optio
 
 	options_len = strlen(options);
 	cmdlen = strlen(command);
-	varlen = sizeof("$CMDLINE_OPTS") - 1;
+	varlen = strlen("$CMDLINE_OPTS");
 
 	cmd = memdup(command, cmdlen + 1);
 	if (cmd == NULL)
@@ -1432,9 +1432,9 @@ KMOD_EXPORT int kmod_module_get_initstate(const struct kmod_module *mod)
 		err = -errno;
 		DBG(mod->ctx, "could not open '%s': %m\n", path);
 
-		if (pathlen > (int)sizeof("/initstate") - 1) {
+		if (pathlen > (int)strlen("/initstate")) {
 			struct stat st;
-			path[pathlen - (sizeof("/initstate") - 1)] = '\0';
+			path[pathlen - strlen("/initstate")] = '\0';
 			if (stat(path, &st) == 0 && S_ISDIR(st.st_mode))
 				return KMOD_MODULE_COMING;
 

--- a/libkmod/libkmod-signature.c
+++ b/libkmod/libkmod-signature.c
@@ -314,7 +314,7 @@ bool kmod_module_signature_info(const struct kmod_file *file,
 	if (size < (off_t)strlen(SIG_MAGIC))
 		return false;
 	size -= strlen(SIG_MAGIC);
-	if (memcmp(SIG_MAGIC, mem + size, strlen(SIG_MAGIC)) != 0)
+	if (!strstartswith(mem + size, SIG_MAGIC))
 		return false;
 
 	if (size < (off_t)sizeof(struct module_signature))

--- a/libkmod/libkmod.c
+++ b/libkmod/libkmod.c
@@ -153,11 +153,11 @@ static int log_priority(const char *priority)
 	prio = strtol(priority, &endptr, 10);
 	if (endptr[0] == '\0' || isspace(endptr[0]))
 		return prio;
-	if (strncmp(priority, "err", 3) == 0)
+	if (strstartswith(priority, "err"))
 		return LOG_ERR;
-	if (strncmp(priority, "info", 4) == 0)
+	if (strstartswith(priority, "info"))
 		return LOG_INFO;
-	if (strncmp(priority, "debug", 5) == 0)
+	if (strstartswith(priority, "debug"))
 		return LOG_DEBUG;
 	return 0;
 }

--- a/shared/util.c
+++ b/shared/util.c
@@ -26,15 +26,15 @@ static const struct kmod_ext {
 	const char *ext;
 	size_t len;
 } kmod_exts[] = {
-	{ KMOD_EXTENSION_UNCOMPRESSED, sizeof(KMOD_EXTENSION_UNCOMPRESSED) - 1 },
+	{ KMOD_EXTENSION_UNCOMPRESSED, strlen(KMOD_EXTENSION_UNCOMPRESSED) },
 #if ENABLE_ZLIB
-	{ ".ko.gz", sizeof(".ko.gz") - 1 },
+	{ ".ko.gz", strlen(".ko.gz") },
 #endif
 #if ENABLE_XZ
-	{ ".ko.xz", sizeof(".ko.xz") - 1 },
+	{ ".ko.xz", strlen(".ko.xz") },
 #endif
 #if ENABLE_ZSTD
-	{ ".ko.zst", sizeof(".ko.zst") - 1 },
+	{ ".ko.zst", strlen(".ko.zst") },
 #endif
 	{},
 };

--- a/testsuite/delete_module.c
+++ b/testsuite/delete_module.c
@@ -142,7 +142,7 @@ static int remove_directory(const char *path)
 	}
 
 	while ((entry = readdir(dir)) != NULL) {
-		if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
+		if (streq(entry->d_name, ".") || streq(entry->d_name, ".."))
 			continue;
 
 		snprintf(full_path, sizeof(full_path), "%s/%s", path, entry->d_name);

--- a/tools/depmod.c
+++ b/tools/depmod.c
@@ -2749,7 +2749,7 @@ static int depmod_load_system_map(struct depmod *depmod, const char *filename)
 			p++;
 
 		/* Covers gpl-only and normal symbols. */
-		if (strncmp(p, ksymstr, ksymstr_len) != 0)
+		if (!strstartswith(p, ksymstr))
 			continue;
 
 		end = strchr(p, '\n');

--- a/tools/depmod.c
+++ b/tools/depmod.c
@@ -2529,7 +2529,7 @@ static int output_devname(struct depmod *depmod, FILE *out)
 			unsigned int maj, min;
 
 			if (strstartswith(value, "devname:"))
-				devname = value + sizeof("devname:") - 1;
+				devname = value + strlen("devname:");
 			else if (sscanf(value, "char-major-%u-%u", &maj, &min) == 2) {
 				type = 'c';
 				major = maj;

--- a/tools/modprobe.c
+++ b/tools/modprobe.c
@@ -273,7 +273,7 @@ static int command_do(struct kmod_module *module, const char *type, const char *
 	if (cmd == NULL)
 		return -ENOMEM;
 	cmdlen = strlen(cmd);
-	varlen = sizeof("$CMDLINE_OPTS") - 1;
+	varlen = strlen("$CMDLINE_OPTS");
 	while ((p = strstr(cmd, "$CMDLINE_OPTS")) != NULL) {
 		size_t prefixlen = p - cmd;
 		size_t suffixlen = cmdlen - prefixlen - varlen;

--- a/tools/modprobe.c
+++ b/tools/modprobe.c
@@ -596,7 +596,7 @@ static int insmod(struct kmod_ctx *ctx, const char *alias, const char *extra_opt
 	struct kmod_module *mod = NULL;
 	int err, flags = 0;
 
-	if (strncmp(alias, "/", 1) == 0 || strncmp(alias, "./", 2) == 0) {
+	if (strstartswith(alias, "/") || strstartswith(alias, "./")) {
 		err = kmod_module_new_from_path(ctx, alias, &mod);
 		if (err < 0) {
 			LOG("Failed to get module from path %s: %s\n", alias,


### PR DESCRIPTION
Does exactly what it says on the tin.

Any `strncmp()` and `memcmp()` instances using a non-literal have not be converted to `strstartswith()` to avoid introducing (albeit negligible) perf changes.