### PR TITLE
Test wrapper nitpicks

### DIFF
--- a/testsuite/init_module.c
+++ b/testsuite/init_module.c
@@ -349,16 +349,10 @@ TS_EXPORT long int syscall(long int __sysno, ...)
 	}
 
 	if (__sysno == __NR_gettid) {
-		static void *nextlib = NULL;
 		static long (*nextlib_syscall)(long number, ...);
 
 		if (nextlib_syscall == NULL) {
-#ifdef RTLD_NEXT
-			nextlib = RTLD_NEXT;
-#else
-			nextlib = dlopen("libc.so.6", RTLD_LAZY);
-#endif
-			nextlib_syscall = dlsym(nextlib, "syscall");
+			nextlib_syscall = dlsym(RTLD_NEXT, "syscall");
 			if (nextlib_syscall == NULL) {
 				fprintf(stderr,
 					"FIXME FIXME FIXME: could not load syscall symbol: %s\n",

--- a/testsuite/path.c
+++ b/testsuite/path.c
@@ -103,7 +103,8 @@ static void *get_libc_func(const char *f)
                                                      \
 		if (!get_rootpath(__func__))         \
 			return failret;              \
-		_fn = get_libc_func(#name);          \
+		if (_fn == NULL)                     \
+			_fn = get_libc_func(#name);  \
 		p = trap_path(path, buf);            \
 		if (p == NULL)                       \
 			return failret;              \
@@ -120,7 +121,8 @@ static void *get_libc_func(const char *f)
                                                                  \
 		if (!get_rootpath(__func__))                     \
 			return failret;                          \
-		_fn = get_libc_func(#name);                      \
+		if (_fn == NULL)                                 \
+			_fn = get_libc_func(#name);              \
 		p = trap_path(path, buf);                        \
 		if (p == NULL)                                   \
 			return failret;                          \
@@ -137,7 +139,8 @@ static void *get_libc_func(const char *f)
                                                                      \
 		if (!get_rootpath(__func__))                         \
 			return -1;                                   \
-		_fn = get_libc_func("open" #suffix);                 \
+		if (_fn == NULL)                                     \
+			_fn = get_libc_func("open" #suffix);         \
 		p = trap_path(path, buf);                            \
 		if (p == NULL)                                       \
 			return -1;                                   \
@@ -162,7 +165,8 @@ static void *get_libc_func(const char *f)
 		const char *p;                                                       \
 		char buf[PATH_MAX * 2];                                              \
 		static int (*_fn)(int ver, const char *path, struct stat##suffix *); \
-		_fn = get_libc_func(#prefix "stat" #suffix);                         \
+		if (_fn == NULL)                                                     \
+			_fn = get_libc_func(#prefix "stat" #suffix);                 \
                                                                                      \
 		if (!get_rootpath(__func__))                                         \
 			return -1;                                                   \

--- a/testsuite/path.c
+++ b/testsuite/path.c
@@ -103,11 +103,12 @@ static void *get_libc_func(const char *f)
                                                      \
 		if (!get_rootpath(__func__))         \
 			return failret;              \
-		if (_fn == NULL)                     \
-			_fn = get_libc_func(#name);  \
 		p = trap_path(path, buf);            \
 		if (p == NULL)                       \
 			return failret;              \
+                                                     \
+		if (_fn == NULL)                     \
+			_fn = get_libc_func(#name);  \
 		return (*_fn)(p);                    \
 	}
 
@@ -121,11 +122,12 @@ static void *get_libc_func(const char *f)
                                                                  \
 		if (!get_rootpath(__func__))                     \
 			return failret;                          \
-		if (_fn == NULL)                                 \
-			_fn = get_libc_func(#name);              \
 		p = trap_path(path, buf);                        \
 		if (p == NULL)                                   \
 			return failret;                          \
+                                                                 \
+		if (_fn == NULL)                                 \
+			_fn = get_libc_func(#name);              \
 		return (*_fn)(p, arg2);                          \
 	}
 
@@ -139,12 +141,12 @@ static void *get_libc_func(const char *f)
                                                                      \
 		if (!get_rootpath(__func__))                         \
 			return -1;                                   \
-		if (_fn == NULL)                                     \
-			_fn = get_libc_func("open" #suffix);         \
 		p = trap_path(path, buf);                            \
 		if (p == NULL)                                       \
 			return -1;                                   \
                                                                      \
+		if (_fn == NULL)                                     \
+			_fn = get_libc_func("open" #suffix);         \
 		if (flags & O_CREAT) {                               \
 			mode_t mode;                                 \
 			va_list ap;                                  \
@@ -165,8 +167,6 @@ static void *get_libc_func(const char *f)
 		const char *p;                                                       \
 		char buf[PATH_MAX * 2];                                              \
 		static int (*_fn)(int ver, const char *path, struct stat##suffix *); \
-		if (_fn == NULL)                                                     \
-			_fn = get_libc_func(#prefix "stat" #suffix);                 \
                                                                                      \
 		if (!get_rootpath(__func__))                                         \
 			return -1;                                                   \
@@ -174,6 +174,8 @@ static void *get_libc_func(const char *f)
 		if (p == NULL)                                                       \
 			return -1;                                                   \
                                                                                      \
+		if (_fn == NULL)                                                     \
+			_fn = get_libc_func(#prefix "stat" #suffix);                 \
 		return _fn(ver, p, st);                                              \
 	}
 

--- a/testsuite/path.c
+++ b/testsuite/path.c
@@ -84,7 +84,11 @@ static void *get_libc_func(const char *f)
 	void *fp;
 
 	fp = dlsym(RTLD_NEXT, f);
-	assert(fp);
+	if (fp == NULL) {
+		fprintf(stderr, "FIXME FIXME FIXME: could not load %s symbol: %s\n", f,
+			dlerror());
+		abort();
+	}
 
 	return fp;
 }

--- a/testsuite/path.c
+++ b/testsuite/path.c
@@ -26,7 +26,6 @@
 
 #include "testsuite.h"
 
-static void *nextlib;
 static const char *rootpath;
 static size_t rootpathlen;
 
@@ -84,15 +83,7 @@ static void *get_libc_func(const char *f)
 {
 	void *fp;
 
-	if (nextlib == NULL) {
-#ifdef RTLD_NEXT
-		nextlib = RTLD_NEXT;
-#else
-		nextlib = dlopen("libc.so.6", RTLD_LAZY);
-#endif
-	}
-
-	fp = dlsym(nextlib, f);
+	fp = dlsym(RTLD_NEXT, f);
 	assert(fp);
 
 	return fp;

--- a/testsuite/uname.c
+++ b/testsuite/uname.c
@@ -20,8 +20,15 @@ TS_EXPORT int uname(struct utsname *u)
 	int err;
 	size_t sz;
 
-	if (nextlib_uname == NULL)
+	if (nextlib_uname == NULL) {
 		nextlib_uname = dlsym(RTLD_NEXT, "uname");
+		if (nextlib_uname == NULL) {
+			fprintf(stderr,
+				"FIXME FIXME FIXME: could not load uname symbol: %s\n",
+				dlerror());
+			abort();
+		}
+	}
 
 	err = nextlib_uname(u);
 	if (err < 0)

--- a/testsuite/uname.c
+++ b/testsuite/uname.c
@@ -15,20 +15,13 @@
 
 TS_EXPORT int uname(struct utsname *u)
 {
-	static void *nextlib = NULL;
 	static int (*nextlib_uname)(struct utsname *u);
 	const char *release;
 	int err;
 	size_t sz;
 
-	if (nextlib == NULL) {
-#ifdef RTLD_NEXT
-		nextlib = RTLD_NEXT;
-#else
-		nextlib = dlopen("libc.so.6", RTLD_LAZY);
-#endif
-		nextlib_uname = dlsym(nextlib, "uname");
-	}
+	if (nextlib_uname == NULL)
+		nextlib_uname = dlsym(RTLD_NEXT, "uname");
 
 	err = nextlib_uname(u);
 	if (err < 0)


### PR DESCRIPTION
While looking at re-enabling the tests on 32bit Arch a few nits picks stood up. Namely the 3 LD_PRELOAD libraries are fairly inconsistent around their dlsym handling.

This series resolves that, starting off with the removal of non RTLD_NEXT aware platforms. Our targets - glibc, musl and bionic support it.

If other C runtimes are found to need this we can reintroduce it alongside a CI action to keep things in check.