### PR TITLE
Remove ifdef's and other autotools w/a

### DIFF
--- a/libkmod/libkmod-internal.h
+++ b/libkmod/libkmod-internal.h
@@ -27,7 +27,7 @@
 
 #define KCMD_LINE_SIZE 4096
 
-#ifndef HAVE_SECURE_GETENV
+#if !HAVE_SECURE_GETENV
 #warning secure_getenv is not available
 #define secure_getenv getenv
 #endif

--- a/meson.build
+++ b/meson.build
@@ -27,8 +27,6 @@ cc = meson.get_compiler('c')
 # We rely on the glibc variant of basename, et al.
 cdata.set10('_GNU_SOURCE', true)
 
-# TODO: Once meson-only, adjust all #ifdef X to if X and convert .set to .set10
-
 ################################################################################
 # Function and structure checks
 ################################################################################
@@ -38,9 +36,7 @@ _funcs = [
   'secure_getenv',
 ]
 foreach func : _funcs
-  if cc.has_function(func, args : '-D_GNU_SOURCE')
-    cdata.set('HAVE_@0@'.format(func.to_upper()), true)
-  endif
+  cdata.set10('HAVE_@0@'.format(func.to_upper()), cc.has_function(func, args : '-D_GNU_SOURCE'))
 endforeach
 
 # Meson has some amount of support for finding builtins by passing the symbol
@@ -94,17 +90,8 @@ foreach tuple : _decls
   cdata.set10('HAVE_DECL_@0@'.format(decl.to_upper()), have)
 endforeach
 
-if cc.compiles('_Static_assert(1, "Test");', name : '_Static_assert')
-  cdata.set('HAVE_STATIC_ASSERT', true)
-endif
-
-if cc.compiles('''
-    #include <stdlib.h>
-    _Noreturn int foo(void) { exit(0); }
-    ''',
-    name : '_Noreturn')
-  cdata.set('HAVE_NORETURN', true)
-endif
+cdata.set10('HAVE_STATIC_ASSERT', cc.compiles('_Static_assert(1, "Test");', name : '_Static_assert'))
+cdata.set10('HAVE_NORETURN', cc.compiles('#include <stdlib.h>; _Noreturn int foo(void) { exit(0); }', name : '_Noreturn'))
 
 ################################################################################
 # Default CFLAGS and LDFLAGS

--- a/scripts/setup-modules.sh
+++ b/scripts/setup-modules.sh
@@ -3,14 +3,10 @@
 set -euo pipefail
 
 SRCDIR=$1
-BUILDDIR=$2
-MODULE_PLAYGROUND=$3
+MODULE_PLAYGROUND=$2
 
-# TODO: meson allows only out of tree builds
-if test "$SRCDIR" != "$BUILDDIR"; then
-    mkdir -p "$MODULE_PLAYGROUND"
-    cp --archive "$SRCDIR/$MODULE_PLAYGROUND/"* "$MODULE_PLAYGROUND/"
-fi
+mkdir -p "$MODULE_PLAYGROUND"
+cp --archive "$SRCDIR/$MODULE_PLAYGROUND/"* "$MODULE_PLAYGROUND/"
 
 export MAKEFLAGS=${MAKEFLAGS-"-j$(nproc)"}
 "${MAKE-make}" -C "$PWD/$MODULE_PLAYGROUND" modules

--- a/shared/macro.h
+++ b/shared/macro.h
@@ -6,7 +6,7 @@
 
 #include <stddef.h>
 
-#if defined(HAVE_STATIC_ASSERT)
+#if HAVE_STATIC_ASSERT
 #define assert_cc(expr) _Static_assert((expr), #expr)
 #else
 #define assert_cc(expr)                              \
@@ -73,7 +73,7 @@ static inline void freep(void *p)
 /* Define C11 noreturn without <stdnoreturn.h> and even on older gcc
  * compiler versions */
 #ifndef noreturn
-#if defined(HAVE_NORETURN)
+#if HAVE_NORETURN
 #define noreturn _Noreturn
 #else
 #define noreturn __attribute__((noreturn))

--- a/testsuite/meson.build
+++ b/testsuite/meson.build
@@ -7,7 +7,6 @@ build_module_playground = custom_target(
   command : [
     setup_modules,
     meson.project_source_root(),
-    meson.project_build_root(),
     'testsuite/module-playground', # do not prepend source/build root
   ],
   # The command ensures we don't do extra work, so the missing output token file

--- a/testsuite/path.c
+++ b/testsuite/path.c
@@ -175,19 +175,19 @@ WRAP_2ARGS(int, -1, stat, struct stat *);
 
 WRAP_OPEN();
 
-#ifdef HAVE_FOPEN64
+#if HAVE_FOPEN64
 WRAP_2ARGS(FILE *, NULL, fopen64, const char *);
 #endif
-#ifdef HAVE_STAT64
+#if HAVE_STAT64
 WRAP_2ARGS(int, -1, stat64, struct stat64 *);
 #endif
 
-#ifdef HAVE___STAT64_TIME64
+#if HAVE___STAT64_TIME64
 extern int __stat64_time64(const char *file, void *buf);
 WRAP_2ARGS(int, -1, __stat64_time64, void *);
 #endif
 
-#ifdef HAVE_OPEN64
+#if HAVE_OPEN64
 WRAP_OPEN(64);
 #endif
 


### PR DESCRIPTION
~~As the title suggests this is a bit of a mix and match PR, where one commit led to the other and ... Let's just say it grew organically, into this unexpected shape.~~

~~See individual commits for details and let me know if it helps to split things into separate PRs.~~

Edit: remove unrelated commits, keep only autotools related workarounds

For a while we've been converging on `if HAVE` - both at pre-coprocessor and compiler level. There were a few instances remaining, required by the autotools macros/helpers that we used. With autotools gone, we can convert those.

While here, we can also remove another autotools workaround - support for in-tree builds. Meson mandates out-of-tree builds. 