### PR TITLE
Annotate variables as static et al

### DIFF
--- a/libkmod/libkmod-file-xz.c
+++ b/libkmod/libkmod-file-xz.c
@@ -33,7 +33,7 @@ static int dlopen_lzma(void)
 #if !DLSYM_LOCALLY_ENABLED
 	return 0;
 #else
-	static void *dl = NULL;
+	static void *dl;
 
 	ELF_NOTE_DLOPEN("xz", "Support for uncompressing xz-compressed modules",
 			ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED, "liblzma.so.5");

--- a/libkmod/libkmod-file-zlib.c
+++ b/libkmod/libkmod-file-zlib.c
@@ -36,7 +36,7 @@ static int dlopen_zlib(void)
 #if !DLSYM_LOCALLY_ENABLED
 	return 0;
 #else
-	static void *dl = NULL;
+	static void *dl;
 
 	ELF_NOTE_DLOPEN("zlib", "Support for uncompressing zlib-compressed modules",
 			ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED, "libz.so.1");

--- a/libkmod/libkmod-file-zstd.c
+++ b/libkmod/libkmod-file-zstd.c
@@ -35,7 +35,7 @@ static int dlopen_zstd(void)
 #if !DLSYM_LOCALLY_ENABLED
 	return 0;
 #else
-	static void *dl = NULL;
+	static void *dl;
 
 	ELF_NOTE_DLOPEN("zstd", "Support for uncompressing zstd-compressed modules",
 			ELF_NOTE_DLOPEN_PRIORITY_RECOMMENDED, "libzstd.so.1");

--- a/libkmod/libkmod-internal.h
+++ b/libkmod/libkmod-internal.h
@@ -107,7 +107,7 @@ struct kmod_config {
 	struct kmod_list *paths;
 };
 
-_nonnull_all_ int kmod_config_new(struct kmod_ctx *ctx, struct kmod_config **config, const char * const *config_paths);
+_nonnull_all_ int kmod_config_new(struct kmod_ctx *ctx, struct kmod_config **config, const char *const *config_paths);
 _nonnull_all_ void kmod_config_free(struct kmod_config *config);
 _nonnull_all_ const char *kmod_blacklist_get_modname(const struct kmod_list *l);
 _nonnull_all_ const char *kmod_alias_get_name(const struct kmod_list *l);
@@ -118,11 +118,11 @@ _nonnull_all_ const char *kmod_command_get_command(const struct kmod_list *l);
 _nonnull_all_ const char *kmod_command_get_modname(const struct kmod_list *l);
 
 _nonnull_all_ const char *kmod_softdep_get_name(const struct kmod_list *l);
-_nonnull_all_ const char * const *kmod_softdep_get_pre(const struct kmod_list *l, unsigned int *count);
-const char * const *kmod_softdep_get_post(const struct kmod_list *l, unsigned int *count);
+_nonnull_all_ const char *const *kmod_softdep_get_pre(const struct kmod_list *l, unsigned int *count);
+const char *const *kmod_softdep_get_post(const struct kmod_list *l, unsigned int *count);
 
 _nonnull_all_ const char * kmod_weakdep_get_name(const struct kmod_list *l);
-_nonnull_all_ const char * const *kmod_weakdep_get_weak(const struct kmod_list *l, unsigned int *count);
+_nonnull_all_ const char *const *kmod_weakdep_get_weak(const struct kmod_list *l, unsigned int *count);
 
 /* libkmod-module.c */
 int kmod_module_new_from_alias(struct kmod_ctx *ctx, const char *alias, const char *name, struct kmod_module **mod);

--- a/shared/util.h
+++ b/shared/util.h
@@ -187,7 +187,7 @@ _sentinel_ int dlsym_many(void **dlp, const char *filename, ...);
 #define DLSYM_ARG(symbol__) &sym_##symbol__, STRINGIFY(symbol__),
 
 /* For symbols being dynamically loaded */
-#define DECLARE_DLSYM(symbol) static typeof(symbol) *sym_##symbol = NULL
+#define DECLARE_DLSYM(symbol) static typeof(symbol) *sym_##symbol
 
 /* Pointer indirection to support linking directly */
 #define DECLARE_PTRSYM(symbol) static typeof(symbol) *sym_##symbol = symbol

--- a/shared/util.h
+++ b/shared/util.h
@@ -187,10 +187,10 @@ _sentinel_ int dlsym_many(void **dlp, const char *filename, ...);
 #define DLSYM_ARG(symbol__) &sym_##symbol__, STRINGIFY(symbol__),
 
 /* For symbols being dynamically loaded */
-#define DECLARE_DLSYM(symbol) typeof(symbol) *sym_##symbol = NULL
+#define DECLARE_DLSYM(symbol) static typeof(symbol) *sym_##symbol = NULL
 
 /* Pointer indirection to support linking directly */
-#define DECLARE_PTRSYM(symbol) typeof(symbol) *sym_##symbol = symbol
+#define DECLARE_PTRSYM(symbol) static typeof(symbol) *sym_##symbol = symbol
 
 /*
  * Helper defines, to be done locally before including this header to switch between

--- a/testsuite/testsuite.c
+++ b/testsuite/testsuite.c
@@ -31,7 +31,7 @@ static const char *ANSI_HIGHLIGHT_RED_ON = "\x1B[1;31m";
 static const char *ANSI_HIGHLIGHT_OFF = "\x1B[0m";
 
 static const char *progname;
-static int oneshot = 0;
+static int oneshot;
 static const char options_short[] = "lhn";
 static const struct option options[] = {
 	{ "list", no_argument, 0, 'l' },

--- a/tools/depmod.c
+++ b/tools/depmod.c
@@ -2585,9 +2585,6 @@ static int depmod_output(struct depmod *depmod, FILE *out)
 	};
 	const char *dname = depmod->cfg->outdirname;
 	int dfd, err = 0;
-	struct timeval tv;
-
-	gettimeofday(&tv, NULL);
 
 	if (out != NULL)
 		dfd = -1;

--- a/tools/kmod.c
+++ b/tools/kmod.c
@@ -25,13 +25,13 @@ static const struct option options[] = {
 
 static const struct kmod_cmd kmod_cmd_help;
 
-static const struct kmod_cmd *kmod_cmds[] = {
+static const struct kmod_cmd *const kmod_cmds[] = {
 	&kmod_cmd_help,
 	&kmod_cmd_list,
 	&kmod_cmd_static_nodes,
 };
 
-static const struct kmod_cmd *kmod_compat_cmds[] = {
+static const struct kmod_cmd *const kmod_compat_cmds[] = {
 	// clang-format off
 	&kmod_cmd_compat_lsmod,
 	&kmod_cmd_compat_rmmod,

--- a/tools/modinfo.c
+++ b/tools/modinfo.c
@@ -22,7 +22,7 @@
 #include "kmod.h"
 
 static char separator = '\n';
-static const char *field = NULL;
+static const char *field;
 
 struct param {
 	struct param *next;

--- a/tools/modprobe.c
+++ b/tools/modprobe.c
@@ -32,19 +32,19 @@ static int log_priority = LOG_CRIT;
 
 #define DEFAULT_VERBOSE LOG_WARNING
 static int verbose = DEFAULT_VERBOSE;
-static int do_show = 0;
-static int dry_run = 0;
-static int ignore_loaded = 0;
-static int lookup_only = 0;
-static int first_time = 0;
-static int ignore_commands = 0;
-static int use_blacklist = 0;
-static int force = 0;
-static int strip_modversion = 0;
-static int strip_vermagic = 0;
-static int remove_holders = 0;
-static unsigned long long wait_msec = 0;
-static int quiet_inuse = 0;
+static int do_show;
+static int dry_run;
+static int ignore_loaded;
+static int lookup_only;
+static int first_time;
+static int ignore_commands;
+static int use_blacklist;
+static int force;
+static int strip_modversion;
+static int strip_vermagic;
+static int remove_holders;
+static unsigned long long wait_msec;
+static int quiet_inuse;
 
 static const char cmdopts_s[] = "arw:RibfDcnC:d:S:sqvVh";
 static const struct option cmdopts[] = {

--- a/tools/static-nodes.c
+++ b/tools/static-nodes.c
@@ -33,7 +33,7 @@ static const struct static_nodes_format static_nodes_format_human;
 static const struct static_nodes_format static_nodes_format_tmpfiles;
 static const struct static_nodes_format static_nodes_format_devname;
 
-static const struct static_nodes_format *static_nodes_formats[] = {
+static const struct static_nodes_format *const static_nodes_formats[] = {
 	&static_nodes_format_human,
 	&static_nodes_format_tmpfiles,
 	&static_nodes_format_devname,


### PR DESCRIPTION
This series annotates a handful of variables as static and removes the unnecessary default initializer. It also includes a couple of benign semi-related changes.

As result the binaries are ~3k smaller:

```
   text    data     bss     dec     hex filename
1314006  746968    1168 2062142  1f773e before/kmod
1312318  745456    1160 2058934  1f6ab6 after/kmod

   text    data     bss     dec     hex filename
 850358  485152      16 1335526  1460e6 before/libkmod.so
 848694  483640       8 1332342  145476 after/libkmod.so
```