### PR TITLE
Standardize compiler/C runtime requirements, use nsec granularity in depmod

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Links
 Compilation and installation
 ============================
 
-In order to compile the source code you need the following software packages:
-- GCC/CLANG compiler
+In order to compile the source code you need:
+- C11 compiler, supporting a range of GNU extensions - GCC 8+, Clang 6+
 - GNU C library / musl / uClibc
 
 Optional dependencies, required with the default build configuration:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Compilation and installation
 
 In order to compile the source code you need:
 - C11 compiler, supporting a range of GNU extensions - GCC 8+, Clang 6+
-- GNU C library / musl / uClibc
+- POSIX.1-2008 C runtime library - Bionic, GNU C library, musl
 
 Optional dependencies, required with the default build configuration:
 - ZLIB library

--- a/meson.build
+++ b/meson.build
@@ -69,18 +69,6 @@ foreach tuple : _builtins
   cdata.set10('HAVE_@0@'.format(builtin.to_upper()), have)
 endforeach
 
-# dietlibc doesn't have st.st_mtim struct member
-# XXX: we use both st_mtim and st_mtime ... unify and test
-foreach tuple : [['struct stat', 'st_mtim', '#include <sys/stat.h>']]
-  struct = tuple[0]
-  member = tuple[1]
-  prefix = tuple[2]
-  if cc.has_member(struct, member, prefix : prefix, args : '-D_GNU_SOURCE')
-    cdata.set('HAVE_@0@_@1@'.format(struct.underscorify().to_upper(),
-                                    member.to_upper()), true)
-  endif
-endforeach
-
 # basename may be only available in libgen.h with the POSIX behavior,
 # not desired here
 _decls = [

--- a/shared/util.c
+++ b/shared/util.c
@@ -497,7 +497,7 @@ int fd_lookup_path(int fd, char *path, size_t pathlen)
 	return len;
 }
 
-static unsigned long long ts_usec(const struct timespec *ts)
+unsigned long long ts_usec(const struct timespec *ts)
 {
 	return (unsigned long long)ts->tv_sec * USEC_PER_SEC +
 	       (unsigned long long)ts->tv_nsec / NSEC_PER_USEC;

--- a/shared/util.c
+++ b/shared/util.c
@@ -576,11 +576,7 @@ unsigned long long now_msec(void)
 
 unsigned long long stat_mstamp(const struct stat *st)
 {
-#ifdef HAVE_STRUCT_STAT_ST_MTIM
 	return ts_usec(&st->st_mtim);
-#else
-	return (unsigned long long)st->st_mtime;
-#endif
 }
 
 static int dlsym_manyv(void *dl, va_list ap)

--- a/shared/util.h
+++ b/shared/util.h
@@ -63,6 +63,7 @@ _nonnull_all_ int fd_lookup_path(int fd, char *path, size_t pathlen);
 #define MSEC_PER_SEC 1000ULL
 #define NSEC_PER_MSEC 1000000ULL
 
+unsigned long long ts_usec(const struct timespec *ts);
 unsigned long long now_usec(void);
 unsigned long long now_msec(void);
 int sleep_until_msec(unsigned long long msec);


### PR DESCRIPTION
This series writes the (unwritten) minimum requirements wrt compiler and C runtime. It also removes a few quirks to be true to what it's written.

As result:
 - uClibc mention was removed from README - EOL for 10+ years 
 - dietlibc workaround was removed - 3 releases last 12 years, site cert is expired, uses CVS
 - with the ^^ w/a removed, we can add nsec granularity in depmod

Note: support for uClibc(-ng), dietlibc and others is pretty much welcome. Since my time is limited (to manually check) a CI action to confirm them working would be appreciated.