### PR TITLE
CI reorg - run multiple builds in same checkout

### DIFF
--- a/.github/actions/setup-os/setup-debian.sh
+++ b/.github/actions/setup-os/setup-debian.sh
@@ -17,6 +17,7 @@ fi
 
 apt-get update
 apt-get install --yes \
+    bash \
     build-essential \
     clang \
     gcc-multilib \

--- a/.github/actions/setup-os/setup-ubuntu.sh
+++ b/.github/actions/setup-os/setup-ubuntu.sh
@@ -8,6 +8,7 @@ export DEBIAN_FRONTEND=noninteractive
 export TZ=Etc/UTC
 apt-get update
 apt-get install --yes \
+    bash \
     build-essential \
     curl \
     clang \

--- a/.github/functions.sh
+++ b/.github/functions.sh
@@ -2,23 +2,26 @@
 # Allowed values are 32, 64 and help.
 
 #
-# Simple helper executing the given function for all bit combinations
+# Simple helper executing the given function for all compiler/bit combinations
 #
 for_each_config() {
-    [[ -n $1 ]] && bits="$1" || bits="32 64"
-    [[ -n $2 ]] && suffix="-$2" || suffix=""
-    meson_cmd=$3
+    [[ -n $1 ]] && compilers="$1" || compilers="gcc clang"
+    [[ -n $2 ]] && bits="$2" || bits="32 64"
+    [[ -n $3 ]] && suffix="-$3" || suffix=""
+    meson_cmd=$4
 
-    for bit in ${bits[@]}; do
-        echo "::group::$bit bit"
-        builddir="builddir-$bit$suffix/"
+    for compiler in ${compilers[@]}; do
+        for bit in ${bits[@]}; do
+            echo "::group::$compiler, $bit bit"
+            builddir="builddir-$compiler-$bit$suffix/"
 
-        if [[ "$bit" == "32" ]]; then
-            CC="$CC -m32" $meson_cmd "$builddir" "$bit"
-        else
-            $meson_cmd "$builddir" "$bit"
-        fi
+            if [[ "$bit" == "32" ]]; then
+                CC="$compiler -m32" $meson_cmd "$builddir" "$bit"
+            else
+                CC=$compiler $meson_cmd "$builddir" "$bit"
+            fi
 
-        echo "::endgroup::"
+            echo "::endgroup::"
+        done
     done
 }

--- a/.github/functions.sh
+++ b/.github/functions.sh
@@ -1,0 +1,24 @@
+# TODO: add helper to validate only_bits and skip_test
+# Allowed values are 32, 64 and help.
+
+#
+# Simple helper executing the given function for all bit combinations
+#
+for_each_config() {
+    [[ -n $1 ]] && bits="$1" || bits="32 64"
+    [[ -n $2 ]] && suffix="-$2" || suffix=""
+    meson_cmd=$3
+
+    for bit in ${bits[@]}; do
+        echo "::group::$bit bit"
+        builddir="builddir-$bit$suffix/"
+
+        if [[ "$bit" == "32" ]]; then
+            CC="$CC -m32" $meson_cmd "$builddir" "$bit"
+        else
+            $meson_cmd "$builddir" "$bit"
+        fi
+
+        echo "::endgroup::"
+    done
+}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -53,9 +53,8 @@ jobs:
 
       - name: Build
         run: |
-          mkdir build && cd build
-          meson setup --native-file ../build-dev.ini ${{ matrix.meson_setup }} . ..
-          meson compile
+          meson setup --native-file build-dev.ini ${{ matrix.meson_setup }} builddir/
+          meson compile -C builddir/
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@28deaeda66b76a05916b6923827895f2b14ab387 # v3.28.16
@@ -68,7 +67,7 @@ jobs:
         uses: advanced-security/filter-sarif@f3b8118a9349d88f7b1c0c488476411145b6270d # v1.0.1
         with:
           patterns: |
-            -build/meson-private/**/testfile.c
+            -builddir/meson-private/**/testfile.c
           input: sarif-results/cpp.sarif
           output: sarif-results/cpp.sarif
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -44,14 +44,13 @@ jobs:
 
       - name: Build
         run: |
-          mkdir build && cd build
-          meson setup --native-file ../build-dev.ini ${{ matrix.meson_setup }} . ..
-          meson compile
-          meson test
-          ninja coverage-xml
+          meson setup --native-file build-dev.ini ${{ matrix.meson_setup }} builddir/
+          meson compile -C builddir/
+          meson test -C builddir/
+          ninja -C builddir/ coverage-xml
 
       - name: Upload Coverage
         uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d # v5.4.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: build/meson-logs/coverage.xml
+          file: builddir/meson-logs/coverage.xml

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,8 +29,8 @@ jobs:
 
       - name: Build docs
         run: |
-          meson setup -Ddocs=true build .
-          meson compile -C build
+          meson setup -Ddocs=true builddir/
+          meson compile -C builddir/
 
       - name: Extract docs version
         shell: bash
@@ -50,7 +50,7 @@ jobs:
         env:
           API_TOKEN_GITHUB: ${{ secrets.KMOD_DOCS }}
         with:
-          source-directory: 'build/libkmod/docs/html'
+          source-directory: 'builddir/libkmod/docs/html'
           destination-github-username: '${{ github.repository_owner }}'
           destination-repository-name: 'kmod-project.github.io'
           user-name: 'github-actions[bot]'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -173,17 +173,17 @@ jobs:
             export CC_LD="${{ matrix.linker }}"
           fi
 
-          meson setup --native-file build-dev.ini $setup_options build
+          meson setup --native-file build-dev.ini $setup_options builddir/
 
       - name: build
-        run: cd build && meson compile
+        run: meson compile -C builddir/
 
       - name: test
         if: ${{ matrix.skip_test != 'true' }}
-        run: cd build && meson test || meson test --verbose
+        run: meson test -C builddir/ || meson test -C builddir/ --verbose
 
       - name: install
-        run: cd build && DESTDIR=$PWD/inst meson install
+        run: DESTDIR=$PWD/inst meson install -C builddir/
 
       - name: distcheck
-        run: cd build && meson dist
+        run: meson dist -C builddir/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,101 +22,57 @@ defaults:
 
 jobs:
   build:
-    env:
-      CC: ${{ matrix.compiler }}
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
         include:
-          - compiler: 'gcc'
-            container: 'alpine:latest'
+          - container: 'alpine:latest'
             meson_setup: '-Ddocs=false -Db_sanitize=none'
             only_bits: '64'
-          - compiler: 'gcc'
-            container: 'archlinux:multilib-devel'
+          - container: 'archlinux:multilib-devel'
             skip_test: '32'
-          - compiler: 'gcc'
-            container: 'debian:bullseye-slim'
+          - container: 'debian:bullseye-slim'
             meson_setup: '-Dzstd=disabled -Dxz=disabled -Dzlib=disabled -Dopenssl=enabled -Dtools=true'
+            only_compiler: 'gcc'
             skip_test: '32'
-          - compiler: 'gcc'
-            container: 'debian:unstable'
+          - container: 'debian:unstable'
             skip_test: '32'
-          - compiler: 'gcc'
-            container: 'fedora:latest'
+          - container: 'fedora:latest'
             only_bits: '64'
-          - compiler: 'gcc'
-            container: 'fedora:latest'
+          - container: 'fedora:latest'
             meson_setup: '-Dxz=disabled -Ddlopen=all'
             only_bits: '64'
             custom: 'no-xz-dlopen-all'
-          - compiler: 'gcc'
-            container: 'ubuntu:22.04'
+          - container: 'ubuntu:22.04'
             skip_test: '32'
-          - compiler: 'gcc'
-            container: 'ubuntu:22.04'
+          - container: 'ubuntu:22.04'
             meson_setup: '-Ddlopen=zstd,zlib'
             only_bits: '64'
             custom: 'dlopen-zstd-zlib'
-          - compiler: 'gcc'
-            container: 'ubuntu:24.04'
-            skip_test: '32'
-
-          # clang variations of the same builds
-
-          - compiler: 'clang'
-            container: 'alpine:latest'
-            meson_setup: '-Ddocs=false -Db_sanitize=none'
-            only_bits: '64'
-          - compiler: 'clang'
-            container: 'archlinux:multilib-devel'
-            skip_test: '32'
-          - compiler: 'clang'
-            container: 'debian:unstable'
-            skip_test: '32'
-          # Disabled because it doesn't work
-          # - compiler: 'clang'
-          #   container: 'debian:bullseye-slim'
-          #   meson_setup: '-Dzstd=disabled -Dxz=disabled -Dzlib=disabled -Dopenssl=enabled -Dtools=true'
-          #   skip_test: '32'
-          - compiler: 'clang'
-            container: 'fedora:latest'
-            only_bits: '64'
-          - compiler: 'clang'
-            container: 'fedora:latest'
-            meson_setup: '-Dxz=disabled -Ddlopen=all'
-            only_bits: '64'
-            custom: 'no-xz-dlopen-all'
-          - compiler: 'clang'
-            container: 'ubuntu:22.04'
-            skip_test: '32'
-          - compiler: 'clang'
-            container: 'ubuntu:22.04'
-            meson_setup: '-Ddlopen=zstd,zlib'
-            only_bits: '64'
-            custom: 'dlopen-zstd-zlib'
-          - compiler: 'clang'
-            container: 'ubuntu:24.04'
+          - container: 'ubuntu:24.04'
             skip_test: '32'
 
           # Special configurations
 
           # Variant with lld as linker
-          - compiler: 'clang'
-            container: 'archlinux:multilib-devel'
+          - container: 'archlinux:multilib-devel'
             only_bits: '64'
+            only_compiler: 'clang'
+            custom: 'ldd-as-linker'
             linker: 'lld'
 
           # Variants with moduledir
-          - compiler: 'gcc'
-            container: 'archlinux:multilib-devel'
+          - container: 'archlinux:multilib-devel'
             meson_setup: '-Dmoduledir=/usr/lib/modules'
             only_bits: '64'
-          - compiler: 'gcc'
-            container: 'archlinux:multilib-devel'
+            only_compiler: 'gcc'
+            custom: 'usr-moduledir'
+          - container: 'archlinux:multilib-devel'
             meson_setup: '-Dmoduledir=/kernel-modules'
             only_bits: '64'
+            only_compiler: 'gcc'
+            custom: 'custom-moduledir'
 
     container:
       image: ${{ matrix.container }}
@@ -182,7 +138,7 @@ jobs:
           }
 
           source .github/functions.sh
-          for_each_config "${{ matrix.only_bits }}" "${{ matrix.custom }}" do_setup
+          for_each_config "${{ matrix.only_compiler }}" "${{ matrix.only_bits }}" "${{ matrix.custom }}" do_setup
 
       - name: build
         run: |
@@ -190,7 +146,7 @@ jobs:
             meson compile -C "$1"
           }
           source .github/functions.sh
-          for_each_config "${{ matrix.only_bits }}" "${{ matrix.custom }}" do_build
+          for_each_config "${{ matrix.only_compiler }}" "${{ matrix.only_bits }}" "${{ matrix.custom }}" do_build
 
       - name: test
         run: |
@@ -202,7 +158,7 @@ jobs:
             meson test -C "$1" || meson test -C "$1" --verbose
           }
           source .github/functions.sh
-          for_each_config "${{ matrix.only_bits }}" "${{ matrix.custom }}" do_test
+          for_each_config "${{ matrix.only_compiler }}" "${{ matrix.only_bits }}" "${{ matrix.custom }}" do_test
 
       - name: install
         run: |
@@ -210,7 +166,7 @@ jobs:
             DESTDIR=$PWD/inst meson install -C "$1"
           }
           source .github/functions.sh
-          for_each_config "${{ matrix.only_bits }}" "${{ matrix.custom }}" do_install
+          for_each_config "${{ matrix.only_compiler }}" "${{ matrix.only_bits }}" "${{ matrix.custom }}" do_install
 
       - name: distcheck
         run: |
@@ -222,4 +178,4 @@ jobs:
             meson dist -C "$1"
           }
           source .github/functions.sh
-          for_each_config "${{ matrix.only_bits }}" "${{ matrix.custom }}" do_distcheck
+          for_each_config "${{ matrix.only_compiler }}" "${{ matrix.only_bits }}" "${{ matrix.custom }}" do_distcheck

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,10 @@ on:
 permissions:
   contents: read
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build:
     env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,89 +32,91 @@ jobs:
           - compiler: 'gcc'
             container: 'alpine:latest'
             meson_setup: '-Ddocs=false -Db_sanitize=none'
+            only_bits: '64'
           - compiler: 'gcc'
             container: 'archlinux:multilib-devel'
+            skip_test: '32'
           - compiler: 'gcc'
             container: 'debian:bullseye-slim'
             meson_setup: '-Dzstd=disabled -Dxz=disabled -Dzlib=disabled -Dopenssl=enabled -Dtools=true'
+            skip_test: '32'
           - compiler: 'gcc'
             container: 'debian:unstable'
+            skip_test: '32'
           - compiler: 'gcc'
             container: 'fedora:latest'
+            only_bits: '64'
           - compiler: 'gcc'
             container: 'fedora:latest'
             meson_setup: '-Dxz=disabled -Ddlopen=all'
+            only_bits: '64'
+            custom: 'no-xz-dlopen-all'
           - compiler: 'gcc'
             container: 'ubuntu:22.04'
+            skip_test: '32'
           - compiler: 'gcc'
             container: 'ubuntu:22.04'
             meson_setup: '-Ddlopen=zstd,zlib'
+            only_bits: '64'
+            custom: 'dlopen-zstd-zlib'
           - compiler: 'gcc'
             container: 'ubuntu:24.04'
+            skip_test: '32'
 
           # clang variations of the same builds
 
           - compiler: 'clang'
             container: 'alpine:latest'
             meson_setup: '-Ddocs=false -Db_sanitize=none'
+            only_bits: '64'
           - compiler: 'clang'
             container: 'archlinux:multilib-devel'
+            skip_test: '32'
           - compiler: 'clang'
             container: 'debian:unstable'
+            skip_test: '32'
           # Disabled because it doesn't work
           # - compiler: 'clang'
           #   container: 'debian:bullseye-slim'
           #   meson_setup: '-Dzstd=disabled -Dxz=disabled -Dzlib=disabled -Dopenssl=enabled -Dtools=true'
+          #   skip_test: '32'
           - compiler: 'clang'
             container: 'fedora:latest'
+            only_bits: '64'
           - compiler: 'clang'
             container: 'fedora:latest'
             meson_setup: '-Dxz=disabled -Ddlopen=all'
+            only_bits: '64'
+            custom: 'no-xz-dlopen-all'
           - compiler: 'clang'
             container: 'ubuntu:22.04'
+            skip_test: '32'
           - compiler: 'clang'
             container: 'ubuntu:22.04'
             meson_setup: '-Ddlopen=zstd,zlib'
+            only_bits: '64'
+            custom: 'dlopen-zstd-zlib'
           - compiler: 'clang'
             container: 'ubuntu:24.04'
-
-          # Test some configurations with 32bits
-
-          - compiler: 'gcc'
-            container: 'archlinux:multilib-devel'
-            x32: 'true'
-            meson_setup: '-Dzstd=disabled -Dxz=disabled -Dzlib=disabled -Dopenssl=disabled'
-            # fails on LD_PRELOAD
-            skip_test: 'true'
-          - compiler: 'gcc'
-            container: 'ubuntu:24.04'
-            x32: 'true'
-            meson_setup: '-Dzstd=disabled -Dxz=disabled -Dzlib=disabled -Dopenssl=disabled'
-          - compiler: 'clang'
-            container: 'archlinux:multilib-devel'
-            x32: 'true'
-            meson_setup: '-Dzstd=disabled -Dxz=disabled -Dzlib=disabled -Dopenssl=disabled'
-            # fails on LD_PRELOAD
-            skip_test: 'true'
-          - compiler: 'clang'
-            container: 'ubuntu:24.04'
-            x32: 'true'
-            meson_setup: '-Dzstd=disabled -Dxz=disabled -Dzlib=disabled -Dopenssl=disabled'
+            skip_test: '32'
 
           # Special configurations
 
           # Variant with lld as linker
           - compiler: 'clang'
             container: 'archlinux:multilib-devel'
+            only_bits: '64'
             linker: 'lld'
 
           # Variants with moduledir
           - compiler: 'gcc'
             container: 'archlinux:multilib-devel'
             meson_setup: '-Dmoduledir=/usr/lib/modules'
+            only_bits: '64'
           - compiler: 'gcc'
             container: 'archlinux:multilib-devel'
             meson_setup: '-Dmoduledir=/kernel-modules'
+            only_bits: '64'
 
     container:
       image: ${{ matrix.container }}
@@ -167,27 +169,57 @@ jobs:
 
       - name: configure
         run: |
-          setup_options="${{ matrix.meson_setup }}"
+          do_setup() {
+            setup_options="${{ matrix.meson_setup }}"
 
-          if [[ "${{ matrix.x32 }}" == "true" ]]; then
-            export CC="$CC -m32"
-          fi
+            if [[ "$2" == "32" ]]; then
+              echo "::notice::TODO fix and reuse the original options."
+              setup_options="$setup_options -Dzstd=disabled -Dxz=disabled -Dzlib=disabled -Dopenssl=disabled"
+            fi
 
-          if [[ -n "${{ matrix.linker }}" ]]; then
-            export CC_LD="${{ matrix.linker }}"
-          fi
+            [[ -n "${{ matrix.linker }}" ]] && export CC_LD="${{ matrix.linker }}"
+            meson setup --native-file build-dev.ini $setup_options "$1"
+          }
 
-          meson setup --native-file build-dev.ini $setup_options builddir/
+          source .github/functions.sh
+          for_each_config "${{ matrix.only_bits }}" "${{ matrix.custom }}" do_setup
 
       - name: build
-        run: meson compile -C builddir/
+        run: |
+          do_build() {
+            meson compile -C "$1"
+          }
+          source .github/functions.sh
+          for_each_config "${{ matrix.only_bits }}" "${{ matrix.custom }}" do_build
 
       - name: test
-        if: ${{ matrix.skip_test != 'true' }}
-        run: meson test -C builddir/ || meson test -C builddir/ --verbose
+        run: |
+          do_test() {
+            if [[ -n "${{ matrix.skip_test }}" && "${{ matrix.skip_test }}" == "$2" ]]; then
+              echo "::notice::Skipping tests"
+              return 0
+            fi
+            meson test -C "$1" || meson test -C "$1" --verbose
+          }
+          source .github/functions.sh
+          for_each_config "${{ matrix.only_bits }}" "${{ matrix.custom }}" do_test
 
       - name: install
-        run: DESTDIR=$PWD/inst meson install -C builddir/
+        run: |
+          do_install() {
+            DESTDIR=$PWD/inst meson install -C "$1"
+          }
+          source .github/functions.sh
+          for_each_config "${{ matrix.only_bits }}" "${{ matrix.custom }}" do_install
 
       - name: distcheck
-        run: meson dist -C builddir/
+        run: |
+          do_distcheck() {
+            if [[ "$2" == "32" ]]; then
+              echo "::notice::Skipping 32bit distcheck"
+              return 0
+            fi
+            meson dist -C "$1"
+          }
+          source .github/functions.sh
+          for_each_config "${{ matrix.only_bits }}" "${{ matrix.custom }}" do_distcheck


### PR DESCRIPTION
A quick and dirty attempt of my ideas at https://github.com/kmod-project/kmod/issues/320#issuecomment-2919024212

Note, this is _far_ from complete, but I'm posting for early feedback. Also I'm not a huge fan of the duplicated boilerplate in each step - a few possible solutions:
 - create separate jobs (as opposed to one) annotate dependencies - 32bit gcc test, needs 32bit gcc build, etc
 - make the boilerplate a function, store that in GITHUB_ENV and reuse

Any ideas and feedback are appreciated o/