### PR TITLE
scripts/sanitizer-env.sh: remove incorrect $CC quotes

### DIFF
--- a/scripts/sanitizer-env.sh
+++ b/scripts/sanitizer-env.sh
@@ -3,12 +3,12 @@
 # set -euo pipefail # don't set these, since this script is sourced
 
 if [[ ${CC-} == *gcc* ]]; then
-    OUR_PRELOAD=$("$CC" -print-file-name=libasan.so)
+    OUR_PRELOAD=$($CC -print-file-name=libasan.so)
 elif [[ ${CC-} == *clang* ]]; then
     # With v19, the library lacks the CPU arch in its name
-    OUR_PRELOAD=$("$CC" -print-file-name=libclang_rt.asan.so)
+    OUR_PRELOAD=$($CC -print-file-name=libclang_rt.asan.so)
     if ! test -f "$OUR_PRELOAD"; then
-       OUR_PRELOAD=$("$CC" -print-file-name=libclang_rt.asan-x86_64.so)
+       OUR_PRELOAD=$($CC -print-file-name=libclang_rt.asan-x86_64.so)
     fi
 else
     cat <<- EOF >&2


### PR DESCRIPTION
On Arch (at least) the shell chokes when the CC variable contains space, for the given construct - $("$CC" foobar).

Since we variable is likely to contain the executable and arguments, the quotation is wrong. Drop it and ultimately resolve the LD_PRELOAD issues... That said, the tests still fail over here, segfault-ing in (or due to) the LD_PRELOAD library init-modules.so.