### PR TITLE
testsuite: use exit() only when needed

### DIFF
--- a/testsuite/test-blacklist.c
+++ b/testsuite/test-blacklist.c
@@ -30,15 +30,14 @@ static int blacklist_1(void)
 	int err;
 	size_t len = 0;
 
-	static const char *const names[] = { "pcspkr", "pcspkr2", "floppy", "ext4", NULL};
-	const char **name;
+	static const char *const names[] = { "pcspkr", "pcspkr2", "floppy", "ext4" };
 
 	ctx = kmod_new(NULL, NULL);
 	if (ctx == NULL)
 		exit(EXIT_FAILURE);
 
-	for (name = names; *name; name++) {
-		err = kmod_module_new_from_name(ctx, *name, &mod);
+	for (size_t i = 0; i < ARRAY_SIZE(names); i++) {
+		err = kmod_module_new_from_name(ctx, names[i], &mod);
 		if (err < 0)
 			goto fail_lookup;
 		list = kmod_list_append(list, mod);

--- a/testsuite/test-blacklist.c
+++ b/testsuite/test-blacklist.c
@@ -34,7 +34,7 @@ static int blacklist_1(void)
 
 	ctx = kmod_new(NULL, NULL);
 	if (ctx == NULL)
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 
 	for (size_t i = 0; i < ARRAY_SIZE(names); i++) {
 		err = kmod_module_new_from_name(ctx, names[i], &mod);

--- a/testsuite/test-blacklist.c
+++ b/testsuite/test-blacklist.c
@@ -30,7 +30,7 @@ static int blacklist_1(void)
 	int err;
 	size_t len = 0;
 
-	const char *names[] = { "pcspkr", "pcspkr2", "floppy", "ext4", NULL };
+	static const char *const names[] = { "pcspkr", "pcspkr2", "floppy", "ext4", NULL};
 	const char **name;
 
 	ctx = kmod_new(NULL, NULL);

--- a/testsuite/test-dependencies.c
+++ b/testsuite/test-dependencies.c
@@ -18,7 +18,7 @@
 
 #define TEST_UNAME "4.0.20-kmod"
 
-static noreturn int test_dependencies(void)
+static int test_dependencies(void)
 {
 	struct kmod_ctx *ctx;
 	struct kmod_module *mod = NULL;
@@ -29,12 +29,12 @@ static noreturn int test_dependencies(void)
 
 	ctx = kmod_new(NULL, NULL);
 	if (ctx == NULL)
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 
 	err = kmod_module_new_from_name(ctx, "mod-foo", &mod);
 	if (err < 0 || mod == NULL) {
 		kmod_unref(ctx);
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 	}
 
 	list = kmod_module_get_dependencies(mod);
@@ -57,13 +57,13 @@ static noreturn int test_dependencies(void)
 
 	/* fooa, foob, fooc */
 	if (len != 3 || !fooa || !foob || !fooc)
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 
 	kmod_module_unref_list(list);
 	kmod_module_unref(mod);
 	kmod_unref(ctx);
 
-	exit(EXIT_SUCCESS);
+	return EXIT_SUCCESS;
 }
 DEFINE_TEST(test_dependencies,
 	    .description = "test if kmod_module_get_dependencies works",

--- a/testsuite/test-depmod.c
+++ b/testsuite/test-depmod.c
@@ -13,16 +13,12 @@
 
 #include "testsuite.h"
 
-#define EXEC_DEPMOD(...)                     \
-	test_spawn_prog(TOOLS_DIR "/depmod", \
-			(const char *[]){ TOOLS_DIR "/depmod", ##__VA_ARGS__, NULL })
-
 #define MODULES_UNAME "4.4.4"
 #define MODULES_ORDER_ROOTFS TESTSUITE_ROOTFS "test-depmod/modules-order-compressed"
 #define MODULES_ORDER_LIB_MODULES MODULES_ORDER_ROOTFS MODULE_DIRECTORY "/" MODULES_UNAME
 static noreturn int depmod_modules_order_for_compressed(void)
 {
-	EXEC_DEPMOD();
+	EXEC_TOOL(depmod);
 	exit(EXIT_FAILURE);
 }
 DEFINE_TEST(depmod_modules_order_for_compressed,
@@ -46,7 +42,7 @@ DEFINE_TEST(depmod_modules_order_for_compressed,
 	MODULES_OUTDIR_ROOTFS MODULE_DIRECTORY "/" MODULES_UNAME
 static noreturn int depmod_modules_outdir(void)
 {
-	EXEC_DEPMOD("--outdir", "/outdir/");
+	EXEC_TOOL(depmod, "--outdir", "/outdir/");
 	exit(EXIT_FAILURE);
 }
 DEFINE_TEST(depmod_modules_outdir,
@@ -70,7 +66,7 @@ DEFINE_TEST(depmod_modules_outdir,
 	SEARCH_ORDER_SIMPLE_ROOTFS MODULE_DIRECTORY "/" MODULES_UNAME
 static noreturn int depmod_search_order_simple(void)
 {
-	EXEC_DEPMOD();
+	EXEC_TOOL(depmod);
 	exit(EXIT_FAILURE);
 }
 DEFINE_TEST(depmod_search_order_simple,
@@ -92,12 +88,12 @@ DEFINE_TEST(depmod_search_order_simple,
 #define MODULES_ANOTHER_MODDIR_ROOTFS TESTSUITE_ROOTFS "test-depmod/another-moddir"
 static noreturn int depmod_another_moddir(void)
 {
-	EXEC_DEPMOD("-m", ANOTHER_MODDIR);
+	EXEC_TOOL(depmod, "-m", ANOTHER_MODDIR);
 	exit(EXIT_FAILURE);
 }
 static noreturn int depmod_another_moddir_relative(void)
 {
-	EXEC_DEPMOD("-m", RELATIVE_MODDIR);
+	EXEC_TOOL(depmod, "-m", RELATIVE_MODDIR);
 	exit(EXIT_FAILURE);
 }
 DEFINE_TEST(depmod_another_moddir,
@@ -133,7 +129,7 @@ DEFINE_TEST(depmod_another_moddir_relative,
 	SEARCH_ORDER_SAME_PREFIX_ROOTFS MODULE_DIRECTORY "/" MODULES_UNAME
 static noreturn int depmod_search_order_same_prefix(void)
 {
-	EXEC_DEPMOD();
+	EXEC_TOOL(depmod);
 	exit(EXIT_FAILURE);
 }
 DEFINE_TEST(depmod_search_order_same_prefix,
@@ -153,7 +149,7 @@ DEFINE_TEST(depmod_search_order_same_prefix,
 #define DETECT_LOOP_ROOTFS TESTSUITE_ROOTFS "test-depmod/detect-loop"
 static noreturn int depmod_detect_loop(void)
 {
-	EXEC_DEPMOD();
+	EXEC_TOOL(depmod);
 	exit(EXIT_FAILURE);
 }
 DEFINE_TEST(depmod_detect_loop,
@@ -173,7 +169,7 @@ DEFINE_TEST(depmod_detect_loop,
 	SEARCH_ORDER_EXTERNAL_FIRST_ROOTFS MODULE_DIRECTORY "/" MODULES_UNAME
 static noreturn int depmod_search_order_external_first(void)
 {
-	EXEC_DEPMOD();
+	EXEC_TOOL(depmod);
 	exit(EXIT_FAILURE);
 }
 DEFINE_TEST(depmod_search_order_external_first,
@@ -196,7 +192,7 @@ DEFINE_TEST(depmod_search_order_external_first,
 	SEARCH_ORDER_EXTERNAL_LAST_ROOTFS MODULE_DIRECTORY "/" MODULES_UNAME
 static noreturn int depmod_search_order_external_last(void)
 {
-	EXEC_DEPMOD();
+	EXEC_TOOL(depmod);
 	exit(EXIT_FAILURE);
 }
 DEFINE_TEST(depmod_search_order_external_last,
@@ -218,7 +214,7 @@ DEFINE_TEST(depmod_search_order_external_last,
 	SEARCH_ORDER_OVERRIDE_ROOTFS MODULE_DIRECTORY "/" MODULES_UNAME
 static noreturn int depmod_search_order_override(void)
 {
-	EXEC_DEPMOD();
+	EXEC_TOOL(depmod);
 	exit(EXIT_FAILURE);
 }
 DEFINE_TEST(depmod_search_order_override,
@@ -239,7 +235,7 @@ DEFINE_TEST(depmod_search_order_override,
 #define CHECK_WEAKDEP_LIB_MODULES CHECK_WEAKDEP_ROOTFS MODULE_DIRECTORY "/" MODULES_UNAME
 static noreturn int depmod_check_weakdep(void)
 {
-	EXEC_DEPMOD();
+	EXEC_TOOL(depmod);
 	exit(EXIT_FAILURE);
 }
 DEFINE_TEST(depmod_check_weakdep,

--- a/testsuite/test-depmod.c
+++ b/testsuite/test-depmod.c
@@ -16,10 +16,9 @@
 #define MODULES_UNAME "4.4.4"
 #define MODULES_ORDER_ROOTFS TESTSUITE_ROOTFS "test-depmod/modules-order-compressed"
 #define MODULES_ORDER_LIB_MODULES MODULES_ORDER_ROOTFS MODULE_DIRECTORY "/" MODULES_UNAME
-static noreturn int depmod_modules_order_for_compressed(void)
+static int depmod_modules_order_for_compressed(void)
 {
-	EXEC_TOOL(depmod);
-	exit(EXIT_FAILURE);
+	return EXEC_TOOL(depmod);
 }
 DEFINE_TEST(depmod_modules_order_for_compressed,
 	.description = "check if depmod let aliases in right order when using compressed modules",
@@ -40,10 +39,9 @@ DEFINE_TEST(depmod_modules_order_for_compressed,
 	MODULES_OUTDIR_ROOTFS "/outdir" MODULE_DIRECTORY "/" MODULES_UNAME
 #define MODULES_OUTDIR_LIB_MODULES_INPUT \
 	MODULES_OUTDIR_ROOTFS MODULE_DIRECTORY "/" MODULES_UNAME
-static noreturn int depmod_modules_outdir(void)
+static int depmod_modules_outdir(void)
 {
-	EXEC_TOOL(depmod, "--outdir", "/outdir/");
-	exit(EXIT_FAILURE);
+	return EXEC_TOOL(depmod, "--outdir", "/outdir/");
 }
 DEFINE_TEST(depmod_modules_outdir,
 	.description = "check if depmod honours the outdir option",
@@ -64,10 +62,9 @@ DEFINE_TEST(depmod_modules_outdir,
 #define SEARCH_ORDER_SIMPLE_ROOTFS TESTSUITE_ROOTFS "test-depmod/search-order-simple"
 #define SEARCH_ORDER_SIMPLE_LIB_MODULES \
 	SEARCH_ORDER_SIMPLE_ROOTFS MODULE_DIRECTORY "/" MODULES_UNAME
-static noreturn int depmod_search_order_simple(void)
+static int depmod_search_order_simple(void)
 {
-	EXEC_TOOL(depmod);
-	exit(EXIT_FAILURE);
+	return EXEC_TOOL(depmod);
 }
 DEFINE_TEST(depmod_search_order_simple,
 	.description = "check if depmod honor search order in config",
@@ -86,15 +83,13 @@ DEFINE_TEST(depmod_search_order_simple,
 #define ANOTHER_MODDIR "/foobar"
 #define RELATIVE_MODDIR "foobar2"
 #define MODULES_ANOTHER_MODDIR_ROOTFS TESTSUITE_ROOTFS "test-depmod/another-moddir"
-static noreturn int depmod_another_moddir(void)
+static int depmod_another_moddir(void)
 {
-	EXEC_TOOL(depmod, "-m", ANOTHER_MODDIR);
-	exit(EXIT_FAILURE);
+	return EXEC_TOOL(depmod, "-m", ANOTHER_MODDIR);
 }
-static noreturn int depmod_another_moddir_relative(void)
+static int depmod_another_moddir_relative(void)
 {
-	EXEC_TOOL(depmod, "-m", RELATIVE_MODDIR);
-	exit(EXIT_FAILURE);
+	return EXEC_TOOL(depmod, "-m", RELATIVE_MODDIR);
 }
 DEFINE_TEST(depmod_another_moddir,
 	.description = "check depmod -m flag",
@@ -127,10 +122,9 @@ DEFINE_TEST(depmod_another_moddir_relative,
 	TESTSUITE_ROOTFS "test-depmod/search-order-same-prefix"
 #define SEARCH_ORDER_SAME_PREFIX_LIB_MODULES \
 	SEARCH_ORDER_SAME_PREFIX_ROOTFS MODULE_DIRECTORY "/" MODULES_UNAME
-static noreturn int depmod_search_order_same_prefix(void)
+static int depmod_search_order_same_prefix(void)
 {
-	EXEC_TOOL(depmod);
-	exit(EXIT_FAILURE);
+	return EXEC_TOOL(depmod);
 }
 DEFINE_TEST(depmod_search_order_same_prefix,
 	.description = "check if depmod honor search order in config with same prefix",
@@ -147,10 +141,9 @@ DEFINE_TEST(depmod_search_order_same_prefix,
 	});
 
 #define DETECT_LOOP_ROOTFS TESTSUITE_ROOTFS "test-depmod/detect-loop"
-static noreturn int depmod_detect_loop(void)
+static int depmod_detect_loop(void)
 {
-	EXEC_TOOL(depmod);
-	exit(EXIT_FAILURE);
+	return EXEC_TOOL(depmod);
 }
 DEFINE_TEST(depmod_detect_loop,
 	.description = "check if depmod detects module loops correctly",
@@ -167,10 +160,9 @@ DEFINE_TEST(depmod_detect_loop,
 	TESTSUITE_ROOTFS "test-depmod/search-order-external-first"
 #define SEARCH_ORDER_EXTERNAL_FIRST_LIB_MODULES \
 	SEARCH_ORDER_EXTERNAL_FIRST_ROOTFS MODULE_DIRECTORY "/" MODULES_UNAME
-static noreturn int depmod_search_order_external_first(void)
+static int depmod_search_order_external_first(void)
 {
-	EXEC_TOOL(depmod);
-	exit(EXIT_FAILURE);
+	return EXEC_TOOL(depmod);
 }
 DEFINE_TEST(depmod_search_order_external_first,
 	.description = "check if depmod honor external keyword with higher priority",
@@ -190,10 +182,9 @@ DEFINE_TEST(depmod_search_order_external_first,
 	TESTSUITE_ROOTFS "test-depmod/search-order-external-last"
 #define SEARCH_ORDER_EXTERNAL_LAST_LIB_MODULES \
 	SEARCH_ORDER_EXTERNAL_LAST_ROOTFS MODULE_DIRECTORY "/" MODULES_UNAME
-static noreturn int depmod_search_order_external_last(void)
+static int depmod_search_order_external_last(void)
 {
-	EXEC_TOOL(depmod);
-	exit(EXIT_FAILURE);
+	return EXEC_TOOL(depmod);
 }
 DEFINE_TEST(depmod_search_order_external_last,
 	.description = "check if depmod honor external keyword with lower priority",
@@ -212,10 +203,9 @@ DEFINE_TEST(depmod_search_order_external_last,
 #define SEARCH_ORDER_OVERRIDE_ROOTFS TESTSUITE_ROOTFS "test-depmod/search-order-override"
 #define SEARCH_ORDER_OVERRIDE_LIB_MODULES \
 	SEARCH_ORDER_OVERRIDE_ROOTFS MODULE_DIRECTORY "/" MODULES_UNAME
-static noreturn int depmod_search_order_override(void)
+static int depmod_search_order_override(void)
 {
-	EXEC_TOOL(depmod);
-	exit(EXIT_FAILURE);
+	return EXEC_TOOL(depmod);
 }
 DEFINE_TEST(depmod_search_order_override,
 	.description = "check if depmod honor override keyword",
@@ -233,10 +223,9 @@ DEFINE_TEST(depmod_search_order_override,
 
 #define CHECK_WEAKDEP_ROOTFS TESTSUITE_ROOTFS "test-depmod/check-weakdep"
 #define CHECK_WEAKDEP_LIB_MODULES CHECK_WEAKDEP_ROOTFS MODULE_DIRECTORY "/" MODULES_UNAME
-static noreturn int depmod_check_weakdep(void)
+static int depmod_check_weakdep(void)
 {
-	EXEC_TOOL(depmod);
-	exit(EXIT_FAILURE);
+	return EXEC_TOOL(depmod);
 }
 DEFINE_TEST(depmod_check_weakdep,
 	.description = "check weakdep output",

--- a/testsuite/test-hash.c
+++ b/testsuite/test-hash.c
@@ -229,8 +229,8 @@ DEFINE_TEST(test_hash_free,
 
 static int test_hash_add_unique(void)
 {
-	const char *k[] = { "k1", "k2", "k3", "k4", "k5" };
-	const char *v[] = { "v1", "v2", "v3", "v4", "v5" };
+	static const char *const k[] = { "k1", "k2", "k3", "k4", "k5" };
+	static const char *const v[] = { "v1", "v2", "v3", "v4", "v5" };
 	unsigned int i, j, N;
 
 	N = ARRAY_SIZE(k);

--- a/testsuite/test-init.c
+++ b/testsuite/test-init.c
@@ -17,7 +17,7 @@
 
 #include "testsuite.h"
 
-static noreturn int test_load_resources(void)
+static int test_load_resources(void)
 {
 	struct kmod_ctx *ctx;
 	const char *null_config = NULL;
@@ -25,19 +25,19 @@ static noreturn int test_load_resources(void)
 
 	ctx = kmod_new(NULL, &null_config);
 	if (ctx == NULL)
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 
 	kmod_set_log_priority(ctx, 7);
 
 	err = kmod_load_resources(ctx);
 	if (err != 0) {
 		ERR("could not load libkmod resources: %s\n", strerror(-err));
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 	}
 
 	kmod_unref(ctx);
 
-	exit(EXIT_SUCCESS);
+	return EXIT_SUCCESS;
 }
 DEFINE_TEST_WITH_FUNC(
 	test_load_resource1, test_load_resources,
@@ -58,22 +58,22 @@ DEFINE_TEST_WITH_FUNC(
 		[TC_UNAME_R] = "5.6.0",
 	});
 
-static noreturn int test_initlib(void)
+static int test_initlib(void)
 {
 	struct kmod_ctx *ctx;
 	const char *null_config = NULL;
 
 	ctx = kmod_new(NULL, &null_config);
 	if (ctx == NULL)
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 
 	kmod_unref(ctx);
 
-	exit(EXIT_SUCCESS);
+	return EXIT_SUCCESS;
 }
 DEFINE_TEST(test_initlib, .description = "test if libkmod's init function work");
 
-static noreturn int test_insert(void)
+static int test_insert(void)
 {
 	struct kmod_ctx *ctx;
 	struct kmod_module *mod;
@@ -82,23 +82,23 @@ static noreturn int test_insert(void)
 
 	ctx = kmod_new(NULL, &null_config);
 	if (ctx == NULL)
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 
 	err = kmod_module_new_from_path(ctx, "/mod-simple.ko", &mod);
 	if (err != 0) {
 		ERR("could not create module from path: %s\n", strerror(-err));
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 	}
 
 	err = kmod_module_insert_module(mod, 0, NULL);
 	if (err != 0) {
 		ERR("could not insert module: %s\n", strerror(-err));
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 	}
 	kmod_module_unref(mod);
 	kmod_unref(ctx);
 
-	exit(EXIT_SUCCESS);
+	return EXIT_SUCCESS;
 }
 DEFINE_TEST(test_insert,
 	.description = "test if libkmod's insert_module returns ok",
@@ -108,7 +108,7 @@ DEFINE_TEST(test_insert,
 	},
 	.modules_loaded = "mod_simple");
 
-static noreturn int test_remove(void)
+static int test_remove(void)
 {
 	struct kmod_ctx *ctx;
 	struct kmod_module *mod_simple, *mod_bla;
@@ -117,37 +117,37 @@ static noreturn int test_remove(void)
 
 	ctx = kmod_new(NULL, &null_config);
 	if (ctx == NULL)
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 
 	err = kmod_module_new_from_name(ctx, "mod-simple", &mod_simple);
 	if (err != 0) {
 		ERR("could not create module from name: %s\n", strerror(-err));
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 	}
 
 	err = kmod_module_new_from_name(ctx, "bla", &mod_bla);
 	if (err != 0) {
 		ERR("could not create module from name: %s\n", strerror(-err));
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 	}
 
 	err = kmod_module_remove_module(mod_simple, 0);
 	if (err != 0) {
 		ERR("could not remove module: %s\n", strerror(-err));
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 	}
 
 	err = kmod_module_remove_module(mod_bla, 0);
 	if (err != -ENOENT) {
 		ERR("wrong return code for failure test: %d\n", err);
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 	}
 
 	kmod_module_unref(mod_bla);
 	kmod_module_unref(mod_simple);
 	kmod_unref(ctx);
 
-	exit(EXIT_SUCCESS);
+	return EXIT_SUCCESS;
 }
 DEFINE_TEST(
 	test_remove, .description = "test if libkmod's remove_module returns ok",

--- a/testsuite/test-init.c
+++ b/testsuite/test-init.c
@@ -95,6 +95,7 @@ static noreturn int test_insert(void)
 		ERR("could not insert module: %s\n", strerror(-err));
 		exit(EXIT_FAILURE);
 	}
+	kmod_module_unref(mod);
 	kmod_unref(ctx);
 
 	exit(EXIT_SUCCESS);
@@ -142,6 +143,8 @@ static noreturn int test_remove(void)
 		exit(EXIT_FAILURE);
 	}
 
+	kmod_module_unref(mod_bla);
+	kmod_module_unref(mod_simple);
 	kmod_unref(ctx);
 
 	exit(EXIT_SUCCESS);

--- a/testsuite/test-initstate.c
+++ b/testsuite/test-initstate.c
@@ -18,7 +18,7 @@
 
 #include "testsuite.h"
 
-static noreturn int test_initstate_from_lookup(void)
+static int test_initstate_from_lookup(void)
 {
 	struct kmod_ctx *ctx;
 	struct kmod_list *list = NULL;
@@ -28,17 +28,17 @@ static noreturn int test_initstate_from_lookup(void)
 
 	ctx = kmod_new(NULL, &null_config);
 	if (ctx == NULL)
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 
 	err = kmod_module_new_from_lookup(ctx, "fake-builtin", &list);
 	if (err < 0) {
 		ERR("could not create module from lookup: %s\n", strerror(-err));
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 	}
 
 	if (!list) {
 		ERR("could not create module from lookup: module not found: fake-builtin\n");
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 	}
 
 	mod = kmod_module_get_module(list);
@@ -47,14 +47,14 @@ static noreturn int test_initstate_from_lookup(void)
 	if (r != KMOD_MODULE_BUILTIN) {
 		ERR("module should have builtin state but is: %s\n",
 		    kmod_module_initstate_str(r));
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 	}
 
 	kmod_module_unref(mod);
 	kmod_module_unref_list(list);
 	kmod_unref(ctx);
 
-	exit(EXIT_SUCCESS);
+	return EXIT_SUCCESS;
 }
 DEFINE_TEST(
 	test_initstate_from_lookup,
@@ -65,7 +65,7 @@ DEFINE_TEST(
 		[TC_UNAME_R] = "4.4.4",
 	});
 
-static noreturn int test_initstate_from_name(void)
+static int test_initstate_from_name(void)
 {
 	struct kmod_ctx *ctx;
 	struct kmod_module *mod = NULL;
@@ -74,30 +74,30 @@ static noreturn int test_initstate_from_name(void)
 
 	ctx = kmod_new(NULL, &null_config);
 	if (ctx == NULL)
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 
 	err = kmod_module_new_from_name(ctx, "fake-builtin", &mod);
 	if (err != 0) {
 		ERR("could not create module from lookup: %s\n", strerror(-err));
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 	}
 
 	if (!mod) {
 		ERR("could not create module from lookup: module not found: fake-builtin\n");
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 	}
 
 	r = kmod_module_get_initstate(mod);
 	if (r != KMOD_MODULE_BUILTIN) {
 		ERR("module should have builtin state but is: %s\n",
 		    kmod_module_initstate_str(r));
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 	}
 
 	kmod_module_unref(mod);
 	kmod_unref(ctx);
 
-	exit(EXIT_SUCCESS);
+	return EXIT_SUCCESS;
 }
 DEFINE_TEST(test_initstate_from_name,
 	    .description =

--- a/testsuite/test-list.c
+++ b/testsuite/test-list.c
@@ -31,7 +31,7 @@ static int test_list_last(void)
 {
 	struct kmod_list *list = NULL, *last;
 	int i;
-	const char *v[] = { "v1", "v2", "v3", "v4", "v5" };
+	static const char *const v[] = { "v1", "v2", "v3", "v4", "v5" };
 	const int N = ARRAY_SIZE(v);
 
 	for (i = 0; i < N; i++)
@@ -51,7 +51,7 @@ static int test_list_prev(void)
 {
 	struct kmod_list *list = NULL, *l, *p;
 	int i;
-	const char *v[] = { "v1", "v2", "v3", "v4", "v5" };
+	static const char *const v[] = { "v1", "v2", "v3", "v4", "v5" };
 	const int N = ARRAY_SIZE(v);
 
 	l = kmod_list_prev(list, list);
@@ -80,7 +80,8 @@ static int test_list_remove_data(void)
 {
 	struct kmod_list *list = NULL, *l;
 	int i;
-	const char *v[] = { "v1", "v2", "v3", "v4", "v5" }, *removed;
+	static const char *const v[] = { "v1", "v2", "v3", "v4", "v5" };
+	const char *removed;
 	const int N = ARRAY_SIZE(v);
 
 	for (i = 0; i < N; i++)
@@ -104,7 +105,7 @@ static int test_list_append_list(void)
 {
 	struct kmod_list *a = NULL, *b = NULL, *c, *l;
 	int i;
-	const char *v[] = { "v1", "v2", "v3", "v4", "v5" };
+	static const char *const v[] = { "v1", "v2", "v3", "v4", "v5" };
 	const int N = ARRAY_SIZE(v), M = N / 2;
 
 	for (i = 0; i < M; i++)

--- a/testsuite/test-loaded.c
+++ b/testsuite/test-loaded.c
@@ -23,13 +23,13 @@ static int loaded_1(void)
 
 	ctx = kmod_new(NULL, &null_config);
 	if (ctx == NULL)
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 
 	err = kmod_module_new_from_loaded(ctx, &list);
 	if (err < 0) {
 		fprintf(stderr, "%s\n", strerror(-err));
 		kmod_unref(ctx);
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 	}
 
 	printf("Module                  Size  Used by\n");

--- a/testsuite/test-modinfo.c
+++ b/testsuite/test-modinfo.c
@@ -12,17 +12,12 @@
 
 #include "testsuite.h"
 
-static const char *progname = TOOLS_DIR "/modinfo";
-
-#define DEFINE_MODINFO_TEST(_field, _flavor, ...)                   \
-	static noreturn int test_modinfo_##_field(void)             \
-	{                                                           \
-		const char *const args[] = {                        \
-			progname, "-F", #_field, __VA_ARGS__, NULL, \
-		};                                                  \
-		test_spawn_prog(progname, args);                    \
-		exit(EXIT_FAILURE);                                 \
-	}                                                           \
+#define DEFINE_MODINFO_TEST(_field, _flavor, ...)               \
+	static noreturn int test_modinfo_##_field(void)         \
+	{                                                       \
+		EXEC_TOOL(modinfo, "-F", #_field, __VA_ARGS__); \
+		exit(EXIT_FAILURE);                             \
+	}                                                       \
 	DEFINE_TEST(test_modinfo_##_field, \
 	.description = "check " #_field " output of modinfo for different architectures", \
 	.config = { \
@@ -60,12 +55,7 @@ DEFINE_MODINFO_SIGN_TEST(sig_hashalgo);
 #if 0
 static noreturn int test_modinfo_signature(void)
 {
-	const char *const args[] = {
-		progname,
-		NULL,
-	};
-
-	test_spawn_prog(progname, args);
+	EXEC_TOOL(modinfo);
 	exit(EXIT_FAILURE);
 }
 DEFINE_TEST(test_modinfo_signature,
@@ -80,15 +70,7 @@ DEFINE_TEST(test_modinfo_signature,
 
 static noreturn int test_modinfo_external(void)
 {
-	const char *const args[] = {
-		// clang-format off
-		progname,
-		"-F", "filename",
-		"mod-simple",
-		NULL,
-		// clang-format on
-	};
-	test_spawn_prog(progname, args);
+	EXEC_TOOL(modinfo, "-F", "filename", "mod-simple");
 	exit(EXIT_FAILURE);
 }
 DEFINE_TEST(test_modinfo_external,
@@ -103,14 +85,7 @@ DEFINE_TEST(test_modinfo_external,
 
 static noreturn int test_modinfo_builtin(void)
 {
-	const char *const args[] = {
-		// clang-format off
-		progname,
-		"intel_uncore",
-		NULL,
-		// clang-format on
-	};
-	test_spawn_prog(progname, args);
+	EXEC_TOOL(modinfo, "intel_uncore");
 	exit(EXIT_FAILURE);
 }
 DEFINE_TEST(test_modinfo_builtin,

--- a/testsuite/test-modinfo.c
+++ b/testsuite/test-modinfo.c
@@ -12,12 +12,11 @@
 
 #include "testsuite.h"
 
-#define DEFINE_MODINFO_TEST(_field, _flavor, ...)               \
-	static noreturn int test_modinfo_##_field(void)         \
-	{                                                       \
-		EXEC_TOOL(modinfo, "-F", #_field, __VA_ARGS__); \
-		exit(EXIT_FAILURE);                             \
-	}                                                       \
+#define DEFINE_MODINFO_TEST(_field, _flavor, ...)                      \
+	static int test_modinfo_##_field(void)                         \
+	{                                                              \
+		return EXEC_TOOL(modinfo, "-F", #_field, __VA_ARGS__); \
+	}                                                              \
 	DEFINE_TEST(test_modinfo_##_field, \
 	.description = "check " #_field " output of modinfo for different architectures", \
 	.config = { \
@@ -53,10 +52,9 @@ DEFINE_MODINFO_SIGN_TEST(sig_key);
 DEFINE_MODINFO_SIGN_TEST(sig_hashalgo);
 
 #if 0
-static noreturn int test_modinfo_signature(void)
+static int test_modinfo_signature(void)
 {
-	EXEC_TOOL(modinfo);
-	exit(EXIT_FAILURE);
+	return EXEC_TOOL(modinfo);
 }
 DEFINE_TEST(test_modinfo_signature,
 	.description = "check signatures are correct for modinfo is correct for i686, ppc64, s390x and x86_64",
@@ -68,10 +66,9 @@ DEFINE_TEST(test_modinfo_signature,
 	});
 #endif
 
-static noreturn int test_modinfo_external(void)
+static int test_modinfo_external(void)
 {
-	EXEC_TOOL(modinfo, "-F", "filename", "mod-simple");
-	exit(EXIT_FAILURE);
+	return EXEC_TOOL(modinfo, "-F", "filename", "mod-simple");
 }
 DEFINE_TEST(test_modinfo_external,
 	.description = "check if modinfo finds external module",
@@ -83,10 +80,9 @@ DEFINE_TEST(test_modinfo_external,
 		.out = TESTSUITE_ROOTFS "test-modinfo/correct-external.txt",
 	});
 
-static noreturn int test_modinfo_builtin(void)
+static int test_modinfo_builtin(void)
 {
-	EXEC_TOOL(modinfo, "intel_uncore");
-	exit(EXIT_FAILURE);
+	return EXEC_TOOL(modinfo, "intel_uncore");
 }
 DEFINE_TEST(test_modinfo_builtin,
 	.description = "check if modinfo finds builtin module",

--- a/testsuite/test-modprobe.c
+++ b/testsuite/test-modprobe.c
@@ -13,10 +13,9 @@
 
 #include "testsuite.h"
 
-static noreturn int modprobe_show_depends(void)
+static int modprobe_show_depends(void)
 {
-	EXEC_TOOL(modprobe, "--show-depends", "mod-loop-a");
-	exit(EXIT_FAILURE);
+	return EXEC_TOOL(modprobe, "--show-depends", "mod-loop-a");
 }
 DEFINE_TEST(modprobe_show_depends,
 	.description = "check if output for modprobe --show-depends is correct for loaded modules",
@@ -28,10 +27,9 @@ DEFINE_TEST(modprobe_show_depends,
 		.out = TESTSUITE_ROOTFS "test-modprobe/show-depends/correct.txt",
 	});
 
-static noreturn int modprobe_show_depends2(void)
+static int modprobe_show_depends2(void)
 {
-	EXEC_TOOL(modprobe, "--show-depends", "mod-simple");
-	exit(EXIT_FAILURE);
+	return EXEC_TOOL(modprobe, "--show-depends", "mod-simple");
 }
 DEFINE_TEST(modprobe_show_depends2,
 	.description = "check if output for modprobe --show-depends is correct",
@@ -51,10 +49,9 @@ DEFINE_TEST_WITH_FUNC(modprobe_show_depends_no_load, modprobe_show_depends2,
 	.modules_loaded = "",
 	);
 
-static noreturn int modprobe_show_alias_to_none(void)
+static int modprobe_show_alias_to_none(void)
 {
-	EXEC_TOOL(modprobe, "--show-depends", "--ignore-install", "mod-simple");
-	exit(EXIT_FAILURE);
+	return EXEC_TOOL(modprobe, "--show-depends", "--ignore-install", "mod-simple");
 }
 DEFINE_TEST(modprobe_show_alias_to_none,
 	.description = "check if modprobe --show-depends doesn't explode with an alias to nothing",
@@ -68,10 +65,9 @@ DEFINE_TEST(modprobe_show_alias_to_none,
 	.modules_loaded = "",
 	);
 
-static noreturn int modprobe_show_exports(void)
+static int modprobe_show_exports(void)
 {
-	EXEC_TOOL(modprobe, "--show-exports", "/mod-loop-a.ko");
-	exit(EXIT_FAILURE);
+	return EXEC_TOOL(modprobe, "--show-exports", "/mod-loop-a.ko");
 }
 DEFINE_TEST(modprobe_show_exports,
 	.description = "check if modprobe --show-depends doesn't explode with an alias to nothing",
@@ -83,10 +79,9 @@ DEFINE_TEST(modprobe_show_exports,
 		.regex = true,
 	});
 
-static noreturn int modprobe_show_exports_module(void)
+static int modprobe_show_exports_module(void)
 {
-	EXEC_TOOL(modprobe, "--show-exports", "mod-loop-b");
-	exit(EXIT_FAILURE);
+	return EXEC_TOOL(modprobe, "--show-exports", "mod-loop-b");
 }
 DEFINE_TEST(modprobe_show_exports_module,
 	.description = "check if modprobe --show-depends also works with module names",
@@ -99,10 +94,9 @@ DEFINE_TEST(modprobe_show_exports_module,
 		.regex = true,
 	});
 
-static noreturn int modprobe_builtin(void)
+static int modprobe_builtin(void)
 {
-	EXEC_TOOL(modprobe, "unix");
-	exit(EXIT_FAILURE);
+	return EXEC_TOOL(modprobe, "unix");
 }
 DEFINE_TEST(modprobe_builtin, .description = "check if modprobe return 0 for builtin",
 	    .config = {
@@ -110,10 +104,9 @@ DEFINE_TEST(modprobe_builtin, .description = "check if modprobe return 0 for bui
 		    [TC_ROOTFS] = TESTSUITE_ROOTFS "test-modprobe/builtin",
 	    });
 
-static noreturn int modprobe_builtin_lookup_only(void)
+static int modprobe_builtin_lookup_only(void)
 {
-	EXEC_TOOL(modprobe, "-R", "unix");
-	exit(EXIT_FAILURE);
+	return EXEC_TOOL(modprobe, "-R", "unix");
 }
 DEFINE_TEST(modprobe_builtin_lookup_only,
 	.description = "check if modprobe -R correctly returns the builtin module",
@@ -125,10 +118,9 @@ DEFINE_TEST(modprobe_builtin_lookup_only,
 		.out = TESTSUITE_ROOTFS "test-modprobe/builtin/correct.txt",
 	});
 
-static noreturn int modprobe_softdep_loop(void)
+static int modprobe_softdep_loop(void)
 {
-	EXEC_TOOL(modprobe, "mod-loop-b");
-	exit(EXIT_FAILURE);
+	return EXEC_TOOL(modprobe, "mod-loop-b");
 }
 DEFINE_TEST(modprobe_softdep_loop,
 	.description = "check if modprobe breaks softdep loop",
@@ -140,10 +132,9 @@ DEFINE_TEST(modprobe_softdep_loop,
 	.modules_loaded = "mod-loop-a,mod-loop-b",
 	);
 
-static noreturn int modprobe_weakdep_loop(void)
+static int modprobe_weakdep_loop(void)
 {
-	EXEC_TOOL(modprobe, "mod-loop-b");
-	exit(EXIT_FAILURE);
+	return EXEC_TOOL(modprobe, "mod-loop-b");
 }
 DEFINE_TEST(modprobe_weakdep_loop,
 	.description = "check if modprobe breaks weakdep loop",
@@ -156,10 +147,9 @@ DEFINE_TEST(modprobe_weakdep_loop,
 	.modules_not_loaded = "mod-loop-a,mod-simple-c",
 	);
 
-static noreturn int modprobe_install_cmd_loop(void)
+static int modprobe_install_cmd_loop(void)
 {
-	EXEC_TOOL(modprobe, "mod-loop-a");
-	exit(EXIT_FAILURE);
+	return EXEC_TOOL(modprobe, "mod-loop-a");
 }
 DEFINE_TEST(modprobe_install_cmd_loop,
 	.description = "check if modprobe breaks install-commands loop",
@@ -175,10 +165,9 @@ DEFINE_TEST(modprobe_install_cmd_loop,
 	.modules_loaded = "mod-loop-b,mod-loop-a",
 	);
 
-static noreturn int modprobe_param_kcmdline_show_deps(void)
+static int modprobe_param_kcmdline_show_deps(void)
 {
-	EXEC_TOOL(modprobe, "--show-depends", "mod-simple");
-	exit(EXIT_FAILURE);
+	return EXEC_TOOL(modprobe, "--show-depends", "mod-simple");
 }
 DEFINE_TEST(modprobe_param_kcmdline_show_deps,
 	.description = "check if params from kcmdline are passed to (f)init_module call",
@@ -190,10 +179,9 @@ DEFINE_TEST(modprobe_param_kcmdline_show_deps,
 		.out = TESTSUITE_ROOTFS "test-modprobe/module-param-kcmdline/correct.txt",
 	});
 
-static noreturn int modprobe_param_kcmdline(void)
+static int modprobe_param_kcmdline(void)
 {
-	EXEC_TOOL(modprobe, "-c");
-	exit(EXIT_FAILURE);
+	return EXEC_TOOL(modprobe, "-c");
 }
 DEFINE_TEST_WITH_FUNC(modprobe_param_kcmdline2, modprobe_param_kcmdline,
 	.description = "check if params with no value are parsed correctly from kcmdline",
@@ -277,10 +265,9 @@ DEFINE_TEST_WITH_FUNC(modprobe_param_kcmdline9, modprobe_param_kcmdline,
 		.out = TESTSUITE_ROOTFS "test-modprobe/module-param-kcmdline9/correct.txt",
 	});
 
-static noreturn int modprobe_force(void)
+static int modprobe_force(void)
 {
-	EXEC_TOOL(modprobe, "--force", "mod-simple");
-	exit(EXIT_FAILURE);
+	return EXEC_TOOL(modprobe, "--force", "mod-simple");
 }
 DEFINE_TEST(modprobe_force,
 	.description = "check modprobe --force",
@@ -292,10 +279,9 @@ DEFINE_TEST(modprobe_force,
 	.modules_loaded = "mod-simple",
 	);
 
-static noreturn int modprobe_force_modversion(void)
+static int modprobe_force_modversion(void)
 {
-	EXEC_TOOL(modprobe, "--force-modversion", "mod-simple");
-	exit(EXIT_FAILURE);
+	return EXEC_TOOL(modprobe, "--force-modversion", "mod-simple");
 }
 DEFINE_TEST(modprobe_force_modversion,
 	.description = "check modprobe --force-modversion",
@@ -307,10 +293,9 @@ DEFINE_TEST(modprobe_force_modversion,
 	.modules_loaded = "mod-simple",
 	);
 
-static noreturn int modprobe_force_vermagic(void)
+static int modprobe_force_vermagic(void)
 {
-	EXEC_TOOL(modprobe, "--force-vermagic", "mod-simple");
-	exit(EXIT_FAILURE);
+	return EXEC_TOOL(modprobe, "--force-vermagic", "mod-simple");
 }
 DEFINE_TEST(modprobe_force_vermagic,
 	.description = "check modprobe --force-vermagic",
@@ -322,10 +307,9 @@ DEFINE_TEST(modprobe_force_vermagic,
 	.modules_loaded = "mod-simple",
 	);
 
-static noreturn int modprobe_oldkernel(void)
+static int modprobe_oldkernel(void)
 {
-	EXEC_TOOL(modprobe, "mod-simple");
-	exit(EXIT_FAILURE);
+	return EXEC_TOOL(modprobe, "mod-simple");
 }
 DEFINE_TEST(modprobe_oldkernel,
 	.description = "check modprobe with kernel without finit_module()",
@@ -337,10 +321,9 @@ DEFINE_TEST(modprobe_oldkernel,
 	.modules_loaded = "mod-simple",
 	);
 
-static noreturn int modprobe_oldkernel_force(void)
+static int modprobe_oldkernel_force(void)
 {
-	EXEC_TOOL(modprobe, "--force", "mod-simple");
-	exit(EXIT_FAILURE);
+	return EXEC_TOOL(modprobe, "--force", "mod-simple");
 }
 DEFINE_TEST(modprobe_oldkernel_force,
 	.description = "check modprobe --force with kernel without finit_module()",
@@ -352,10 +335,9 @@ DEFINE_TEST(modprobe_oldkernel_force,
 	.modules_loaded = "mod-simple",
 	);
 
-static noreturn int modprobe_oldkernel_force_modversion(void)
+static int modprobe_oldkernel_force_modversion(void)
 {
-	EXEC_TOOL(modprobe, "--force-modversion", "mod-simple");
-	exit(EXIT_FAILURE);
+	return EXEC_TOOL(modprobe, "--force-modversion", "mod-simple");
 }
 DEFINE_TEST(modprobe_oldkernel_force_modversion,
 	.description = "check modprobe --force-modversion with kernel without finit_module()",
@@ -367,10 +349,9 @@ DEFINE_TEST(modprobe_oldkernel_force_modversion,
 	.modules_loaded = "mod-simple",
 	);
 
-static noreturn int modprobe_oldkernel_force_vermagic(void)
+static int modprobe_oldkernel_force_vermagic(void)
 {
-	EXEC_TOOL(modprobe, "--force-vermagic", "mod-simple");
-	exit(EXIT_FAILURE);
+	return EXEC_TOOL(modprobe, "--force-vermagic", "mod-simple");
 }
 DEFINE_TEST(modprobe_oldkernel_force_vermagic,
 	.description = "check modprobe --force-vermagic with kernel without finit_module()",
@@ -382,10 +363,9 @@ DEFINE_TEST(modprobe_oldkernel_force_vermagic,
 	.modules_loaded = "mod-simple",
 	);
 
-static noreturn int modprobe_external(void)
+static int modprobe_external(void)
 {
-	EXEC_TOOL(modprobe, "mod-simple");
-	exit(EXIT_FAILURE);
+	return EXEC_TOOL(modprobe, "mod-simple");
 }
 DEFINE_TEST(modprobe_external,
 	.description = "check modprobe able to load external module",
@@ -397,10 +377,9 @@ DEFINE_TEST(modprobe_external,
 	.modules_loaded = "mod-simple",
 	);
 
-static noreturn int modprobe_module_from_abspath(void)
+static int modprobe_module_from_abspath(void)
 {
-	EXEC_TOOL(modprobe, "/home/foo/mod-simple.ko");
-	exit(EXIT_FAILURE);
+	return EXEC_TOOL(modprobe, "/home/foo/mod-simple.ko");
 }
 DEFINE_TEST(modprobe_module_from_abspath,
 	.description = "check modprobe able to load module given as an absolute path",
@@ -412,15 +391,13 @@ DEFINE_TEST(modprobe_module_from_abspath,
 	.modules_loaded = "mod-simple",
 	);
 
-static noreturn int modprobe_module_from_relpath(void)
+static int modprobe_module_from_relpath(void)
 {
 	if (chdir("/home/foo") != 0) {
 		perror("failed to change into /home/foo");
-		exit(EXIT_FAILURE);
 	}
 
-	EXEC_TOOL(modprobe, "./mod-simple.ko");
-	exit(EXIT_FAILURE);
+	return EXEC_TOOL(modprobe, "./mod-simple.ko");
 }
 DEFINE_TEST(modprobe_module_from_relpath,
 	.description = "check modprobe able to load module given as a relative path",

--- a/testsuite/test-modprobe.c
+++ b/testsuite/test-modprobe.c
@@ -13,13 +13,9 @@
 
 #include "testsuite.h"
 
-#define EXEC_MODPROBE(...)                     \
-	test_spawn_prog(TOOLS_DIR "/modprobe", \
-			(const char *[]){ TOOLS_DIR "/modprobe", ##__VA_ARGS__, NULL })
-
 static noreturn int modprobe_show_depends(void)
 {
-	EXEC_MODPROBE("--show-depends", "mod-loop-a");
+	EXEC_TOOL(modprobe, "--show-depends", "mod-loop-a");
 	exit(EXIT_FAILURE);
 }
 DEFINE_TEST(modprobe_show_depends,
@@ -34,7 +30,7 @@ DEFINE_TEST(modprobe_show_depends,
 
 static noreturn int modprobe_show_depends2(void)
 {
-	EXEC_MODPROBE("--show-depends", "mod-simple");
+	EXEC_TOOL(modprobe, "--show-depends", "mod-simple");
 	exit(EXIT_FAILURE);
 }
 DEFINE_TEST(modprobe_show_depends2,
@@ -57,7 +53,7 @@ DEFINE_TEST_WITH_FUNC(modprobe_show_depends_no_load, modprobe_show_depends2,
 
 static noreturn int modprobe_show_alias_to_none(void)
 {
-	EXEC_MODPROBE("--show-depends", "--ignore-install", "mod-simple");
+	EXEC_TOOL(modprobe, "--show-depends", "--ignore-install", "mod-simple");
 	exit(EXIT_FAILURE);
 }
 DEFINE_TEST(modprobe_show_alias_to_none,
@@ -74,7 +70,7 @@ DEFINE_TEST(modprobe_show_alias_to_none,
 
 static noreturn int modprobe_show_exports(void)
 {
-	EXEC_MODPROBE("--show-exports", "/mod-loop-a.ko");
+	EXEC_TOOL(modprobe, "--show-exports", "/mod-loop-a.ko");
 	exit(EXIT_FAILURE);
 }
 DEFINE_TEST(modprobe_show_exports,
@@ -89,7 +85,7 @@ DEFINE_TEST(modprobe_show_exports,
 
 static noreturn int modprobe_show_exports_module(void)
 {
-	EXEC_MODPROBE("--show-exports", "mod-loop-b");
+	EXEC_TOOL(modprobe, "--show-exports", "mod-loop-b");
 	exit(EXIT_FAILURE);
 }
 DEFINE_TEST(modprobe_show_exports_module,
@@ -105,7 +101,7 @@ DEFINE_TEST(modprobe_show_exports_module,
 
 static noreturn int modprobe_builtin(void)
 {
-	EXEC_MODPROBE("unix");
+	EXEC_TOOL(modprobe, "unix");
 	exit(EXIT_FAILURE);
 }
 DEFINE_TEST(modprobe_builtin, .description = "check if modprobe return 0 for builtin",
@@ -116,7 +112,7 @@ DEFINE_TEST(modprobe_builtin, .description = "check if modprobe return 0 for bui
 
 static noreturn int modprobe_builtin_lookup_only(void)
 {
-	EXEC_MODPROBE("-R", "unix");
+	EXEC_TOOL(modprobe, "-R", "unix");
 	exit(EXIT_FAILURE);
 }
 DEFINE_TEST(modprobe_builtin_lookup_only,
@@ -131,7 +127,7 @@ DEFINE_TEST(modprobe_builtin_lookup_only,
 
 static noreturn int modprobe_softdep_loop(void)
 {
-	EXEC_MODPROBE("mod-loop-b");
+	EXEC_TOOL(modprobe, "mod-loop-b");
 	exit(EXIT_FAILURE);
 }
 DEFINE_TEST(modprobe_softdep_loop,
@@ -146,7 +142,7 @@ DEFINE_TEST(modprobe_softdep_loop,
 
 static noreturn int modprobe_weakdep_loop(void)
 {
-	EXEC_MODPROBE("mod-loop-b");
+	EXEC_TOOL(modprobe, "mod-loop-b");
 	exit(EXIT_FAILURE);
 }
 DEFINE_TEST(modprobe_weakdep_loop,
@@ -162,7 +158,7 @@ DEFINE_TEST(modprobe_weakdep_loop,
 
 static noreturn int modprobe_install_cmd_loop(void)
 {
-	EXEC_MODPROBE("mod-loop-a");
+	EXEC_TOOL(modprobe, "mod-loop-a");
 	exit(EXIT_FAILURE);
 }
 DEFINE_TEST(modprobe_install_cmd_loop,
@@ -181,7 +177,7 @@ DEFINE_TEST(modprobe_install_cmd_loop,
 
 static noreturn int modprobe_param_kcmdline_show_deps(void)
 {
-	EXEC_MODPROBE("--show-depends", "mod-simple");
+	EXEC_TOOL(modprobe, "--show-depends", "mod-simple");
 	exit(EXIT_FAILURE);
 }
 DEFINE_TEST(modprobe_param_kcmdline_show_deps,
@@ -196,7 +192,7 @@ DEFINE_TEST(modprobe_param_kcmdline_show_deps,
 
 static noreturn int modprobe_param_kcmdline(void)
 {
-	EXEC_MODPROBE("-c");
+	EXEC_TOOL(modprobe, "-c");
 	exit(EXIT_FAILURE);
 }
 DEFINE_TEST_WITH_FUNC(modprobe_param_kcmdline2, modprobe_param_kcmdline,
@@ -283,7 +279,7 @@ DEFINE_TEST_WITH_FUNC(modprobe_param_kcmdline9, modprobe_param_kcmdline,
 
 static noreturn int modprobe_force(void)
 {
-	EXEC_MODPROBE("--force", "mod-simple");
+	EXEC_TOOL(modprobe, "--force", "mod-simple");
 	exit(EXIT_FAILURE);
 }
 DEFINE_TEST(modprobe_force,
@@ -298,7 +294,7 @@ DEFINE_TEST(modprobe_force,
 
 static noreturn int modprobe_force_modversion(void)
 {
-	EXEC_MODPROBE("--force-modversion", "mod-simple");
+	EXEC_TOOL(modprobe, "--force-modversion", "mod-simple");
 	exit(EXIT_FAILURE);
 }
 DEFINE_TEST(modprobe_force_modversion,
@@ -313,7 +309,7 @@ DEFINE_TEST(modprobe_force_modversion,
 
 static noreturn int modprobe_force_vermagic(void)
 {
-	EXEC_MODPROBE("--force-vermagic", "mod-simple");
+	EXEC_TOOL(modprobe, "--force-vermagic", "mod-simple");
 	exit(EXIT_FAILURE);
 }
 DEFINE_TEST(modprobe_force_vermagic,
@@ -328,7 +324,7 @@ DEFINE_TEST(modprobe_force_vermagic,
 
 static noreturn int modprobe_oldkernel(void)
 {
-	EXEC_MODPROBE("mod-simple");
+	EXEC_TOOL(modprobe, "mod-simple");
 	exit(EXIT_FAILURE);
 }
 DEFINE_TEST(modprobe_oldkernel,
@@ -343,7 +339,7 @@ DEFINE_TEST(modprobe_oldkernel,
 
 static noreturn int modprobe_oldkernel_force(void)
 {
-	EXEC_MODPROBE("--force", "mod-simple");
+	EXEC_TOOL(modprobe, "--force", "mod-simple");
 	exit(EXIT_FAILURE);
 }
 DEFINE_TEST(modprobe_oldkernel_force,
@@ -358,7 +354,7 @@ DEFINE_TEST(modprobe_oldkernel_force,
 
 static noreturn int modprobe_oldkernel_force_modversion(void)
 {
-	EXEC_MODPROBE("--force-modversion", "mod-simple");
+	EXEC_TOOL(modprobe, "--force-modversion", "mod-simple");
 	exit(EXIT_FAILURE);
 }
 DEFINE_TEST(modprobe_oldkernel_force_modversion,
@@ -373,7 +369,7 @@ DEFINE_TEST(modprobe_oldkernel_force_modversion,
 
 static noreturn int modprobe_oldkernel_force_vermagic(void)
 {
-	EXEC_MODPROBE("--force-vermagic", "mod-simple");
+	EXEC_TOOL(modprobe, "--force-vermagic", "mod-simple");
 	exit(EXIT_FAILURE);
 }
 DEFINE_TEST(modprobe_oldkernel_force_vermagic,
@@ -388,7 +384,7 @@ DEFINE_TEST(modprobe_oldkernel_force_vermagic,
 
 static noreturn int modprobe_external(void)
 {
-	EXEC_MODPROBE("mod-simple");
+	EXEC_TOOL(modprobe, "mod-simple");
 	exit(EXIT_FAILURE);
 }
 DEFINE_TEST(modprobe_external,
@@ -403,7 +399,7 @@ DEFINE_TEST(modprobe_external,
 
 static noreturn int modprobe_module_from_abspath(void)
 {
-	EXEC_MODPROBE("/home/foo/mod-simple.ko");
+	EXEC_TOOL(modprobe, "/home/foo/mod-simple.ko");
 	exit(EXIT_FAILURE);
 }
 DEFINE_TEST(modprobe_module_from_abspath,
@@ -423,7 +419,7 @@ static noreturn int modprobe_module_from_relpath(void)
 		exit(EXIT_FAILURE);
 	}
 
-	EXEC_MODPROBE("./mod-simple.ko");
+	EXEC_TOOL(modprobe, "./mod-simple.ko");
 	exit(EXIT_FAILURE);
 }
 DEFINE_TEST(modprobe_module_from_relpath,

--- a/testsuite/test-multi-softdep.c
+++ b/testsuite/test-multi-softdep.c
@@ -79,7 +79,7 @@ static int multi_softdep(void)
 
 	ctx = kmod_new(NULL, NULL);
 	if (ctx == NULL)
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 
 	for (mod_index = 0; mod_index < ARRAY_SIZE(test_modules); mod_index++) {
 		modname = test_modules[mod_index].modname;

--- a/testsuite/test-new-module.c
+++ b/testsuite/test-new-module.c
@@ -32,12 +32,12 @@ static int from_name(void)
 
 	ctx = kmod_new(NULL, &null_config);
 	if (ctx == NULL)
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 
 	for (size_t i = 0; i < ARRAY_SIZE(modnames); i++) {
 		err = kmod_module_new_from_name(ctx, modnames[i], &mod);
 		if (err < 0)
-			exit(EXIT_FAILURE);
+			return EXIT_FAILURE;
 
 		printf("modname: %s\n", kmod_module_get_name(mod));
 		kmod_module_unref(mod);
@@ -66,14 +66,14 @@ static int from_alias(void)
 
 	ctx = kmod_new(NULL, NULL);
 	if (ctx == NULL)
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 
 	for (size_t i = 0; i < ARRAY_SIZE(modnames); i++) {
 		struct kmod_list *l, *list = NULL;
 
 		err = kmod_module_new_from_lookup(ctx, modnames[i], &list);
 		if (err < 0)
-			exit(EXIT_FAILURE);
+			return EXIT_FAILURE;
 
 		kmod_list_foreach(l, list) {
 			struct kmod_module *m;

--- a/testsuite/test-new-module.c
+++ b/testsuite/test-new-module.c
@@ -23,10 +23,8 @@ static int from_name(void)
 		"snd-hda-intel",
 		"snd-timer",
 		"iTCO_wdt",
-		NULL,
 		// clang-format on
 	};
-	const char *const *p;
 	struct kmod_ctx *ctx;
 	struct kmod_module *mod;
 	const char *null_config = NULL;
@@ -36,10 +34,10 @@ static int from_name(void)
 	if (ctx == NULL)
 		exit(EXIT_FAILURE);
 
-	for (p = modnames; p != NULL; p++) {
-		err = kmod_module_new_from_name(ctx, *p, &mod);
+	for (size_t i = 0; i < ARRAY_SIZE(modnames); i++) {
+		err = kmod_module_new_from_name(ctx, modnames[i], &mod);
 		if (err < 0)
-			exit(EXIT_SUCCESS);
+			exit(EXIT_FAILURE);
 
 		printf("modname: %s\n", kmod_module_get_name(mod));
 		kmod_module_unref(mod);
@@ -62,9 +60,7 @@ static int from_alias(void)
 {
 	static const char *const modnames[] = {
 		"ext4.*",
-		NULL,
 	};
-	const char *const *p;
 	struct kmod_ctx *ctx;
 	int err;
 
@@ -72,12 +68,12 @@ static int from_alias(void)
 	if (ctx == NULL)
 		exit(EXIT_FAILURE);
 
-	for (p = modnames; p != NULL; p++) {
+	for (size_t i = 0; i < ARRAY_SIZE(modnames); i++) {
 		struct kmod_list *l, *list = NULL;
 
-		err = kmod_module_new_from_lookup(ctx, *p, &list);
+		err = kmod_module_new_from_lookup(ctx, modnames[i], &list);
 		if (err < 0)
-			exit(EXIT_SUCCESS);
+			exit(EXIT_FAILURE);
 
 		kmod_list_foreach(l, list) {
 			struct kmod_module *m;

--- a/testsuite/test-remove.c
+++ b/testsuite/test-remove.c
@@ -17,7 +17,7 @@
 
 #include "testsuite.h"
 
-static noreturn int test_remove(void)
+static int test_remove(void)
 {
 	struct kmod_ctx *ctx;
 	struct kmod_module *mod;
@@ -27,34 +27,34 @@ static noreturn int test_remove(void)
 
 	ctx = kmod_new(NULL, &null_config);
 	if (ctx == NULL)
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 
 	err = kmod_module_new_from_path(ctx, "/mod-simple.ko", &mod);
 	if (err != 0) {
 		ERR("could not create module from path: %s\n", strerror(-err));
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 	}
 
 	err = kmod_module_insert_module(mod, 0, NULL);
 	if (err != 0) {
 		ERR("could not insert module: %s\n", strerror(-err));
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 	}
 
 	err = kmod_module_remove_module(mod, 0);
 	if (err != 0) {
 		ERR("could not remove module: %s\n", strerror(-err));
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 	}
 
 	if (stat("/sys/module/mod_simple", &st) == 0 && S_ISDIR(st.st_mode)) {
 		ERR("could not remove module directory.\n");
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 	}
 	kmod_module_unref(mod);
 	kmod_unref(ctx);
 
-	exit(EXIT_SUCCESS);
+	return EXIT_SUCCESS;
 }
 DEFINE_TEST(test_remove,
 	    .description = "test if libkmod's delete_module removes module directory",

--- a/testsuite/test-remove.c
+++ b/testsuite/test-remove.c
@@ -51,6 +51,7 @@ static noreturn int test_remove(void)
 		ERR("could not remove module directory.\n");
 		exit(EXIT_FAILURE);
 	}
+	kmod_module_unref(mod);
 	kmod_unref(ctx);
 
 	exit(EXIT_SUCCESS);

--- a/testsuite/test-testsuite.c
+++ b/testsuite/test-testsuite.c
@@ -21,22 +21,22 @@
 #include "testsuite.h"
 
 #define TEST_UNAME "4.0.20-kmod"
-static noreturn int testsuite_uname(void)
+static int testsuite_uname(void)
 {
 	struct utsname u;
 	int err = uname(&u);
 
 	if (err < 0)
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 
 	if (!streq(u.release, TEST_UNAME)) {
 		const char *ldpreload = getenv("LD_PRELOAD");
 		ERR("u.release=%s should be %s\n", u.release, TEST_UNAME);
 		ERR("LD_PRELOAD=%s\n", ldpreload);
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 	}
 
-	exit(EXIT_SUCCESS);
+	return EXIT_SUCCESS;
 }
 DEFINE_TEST(testsuite_uname, .description = "test if trap to uname() works",
 	    .config = {

--- a/testsuite/test-util.c
+++ b/testsuite/test-util.c
@@ -104,23 +104,25 @@ DEFINE_TEST(test_strchr_replace,
 
 static int test_underscores(void)
 {
-	struct teststr {
-		char *val;
+	static const struct teststr {
+		const char *val;
 		const char *res;
 	} teststr[] = {
-		{ strdup("aa-bb-cc_"), "aa_bb_cc_" },
-		{ strdup("-aa-bb-cc-"), "_aa_bb_cc_" },
-		{ strdup("-aa[-bb-]cc-"), "_aa[-bb-]cc_" },
-		{ strdup("-aa-[bb]-cc-"), "_aa_[bb]_cc_" },
-		{ strdup("-aa-[b-b]-cc-"), "_aa_[b-b]_cc_" },
-		{ strdup("-aa-b[-]b-cc"), "_aa_b[-]b_cc" },
-		{ },
-	}, *iter;
+		// clang-format off
+		{ "aa-bb-cc_", "aa_bb_cc_" },
+		{ "-aa-bb-cc-", "_aa_bb_cc_" },
+		{ "-aa[-bb-]cc-", "_aa[-bb-]cc_" },
+		{ "-aa-[bb]-cc-", "_aa_[bb]_cc_" },
+		{ "-aa-[b-b]-cc-", "_aa_[b-b]_cc_" },
+		{ "-aa-b[-]b-cc", "_aa_b[-]b_cc" },
+		// clang-format on
+	};
 
-	for (iter = &teststr[0]; iter->val != NULL; iter++) {
-		_cleanup_free_ char *val = iter->val;
+	for (size_t i = 0; i < ARRAY_SIZE(teststr); i++) {
+		_cleanup_free_ char *val = strdup(teststr[i].val);
+		assert_return(val != NULL, EXIT_FAILURE);
 		assert_return(!underscores(val), EXIT_FAILURE);
-		assert_return(streq(val, iter->res), EXIT_FAILURE);
+		assert_return(streq(val, teststr[i].res), EXIT_FAILURE);
 	}
 
 	return EXIT_SUCCESS;
@@ -129,7 +131,7 @@ DEFINE_TEST(test_underscores, .description = "check implementation of underscore
 
 static int test_path_ends_with_kmod_ext(void)
 {
-	struct teststr {
+	static const struct teststr {
 		const char *val;
 		bool res;
 	} teststr[] = {

--- a/testsuite/test-util.c
+++ b/testsuite/test-util.c
@@ -19,26 +19,24 @@
 
 static int alias_1(void)
 {
-	static const char *const input[] = {
+	static const char *const aliases[] = {
 		// clang-format off
 		"test1234",
 		"test[abcfoobar]2211",
 		"bar[aaa][bbbb]sss",
 		"kmod[p.b]lib",
 		"[az]1234[AZ]",
-		NULL,
 		// clang-format on
 	};
 
 	char buf[PATH_MAX];
 	size_t len;
-	const char *const *alias;
 
-	for (alias = input; *alias != NULL; alias++) {
+	for (size_t i = 0; i < ARRAY_SIZE(aliases); i++) {
 		int ret;
 
-		ret = alias_normalize(*alias, buf, &len);
-		printf("input   %s\n", *alias);
+		ret = alias_normalize(aliases[i], buf, &len);
+		printf("input   %s\n", aliases[i]);
 		printf("return  %d\n", ret);
 
 		if (ret == 0) {
@@ -135,6 +133,7 @@ static int test_path_ends_with_kmod_ext(void)
 		const char *val;
 		bool res;
 	} teststr[] = {
+		// clang-format off
 		{ "/bla.ko", true },
 #if ENABLE_ZLIB
 		{ "/bla.ko.gz", true },
@@ -149,12 +148,13 @@ static int test_path_ends_with_kmod_ext(void)
 		{ "/bla.ko.", false },
 		{ "/bla.koz", false },
 		{ "/b", false },
-		{ },
-	}, *iter;
+		// clang-format on
+	};
 
-	for (iter = &teststr[0]; iter->val != NULL; iter++) {
-		assert_return(path_ends_with_kmod_ext(iter->val, strlen(iter->val)) ==
-				      iter->res,
+	for (size_t i = 0; i < ARRAY_SIZE(teststr); i++) {
+		assert_return(path_ends_with_kmod_ext(teststr[i].val,
+						      strlen(teststr[i].val)) ==
+				      teststr[i].res,
 			      EXIT_FAILURE);
 	}
 

--- a/testsuite/test-weakdep.c
+++ b/testsuite/test-weakdep.c
@@ -14,10 +14,6 @@
 
 #include "testsuite.h"
 
-#define EXEC_MODPROBE(...)                     \
-	test_spawn_prog(TOOLS_DIR "/modprobe", \
-			(const char *[]){ TOOLS_DIR "/modprobe", ##__VA_ARGS__, NULL })
-
 static int test_weakdep(void)
 {
 	static const char *const mod_name[] = {
@@ -85,7 +81,7 @@ DEFINE_TEST(test_weakdep,
 
 static noreturn int modprobe_config(void)
 {
-	EXEC_MODPROBE("-c");
+	EXEC_TOOL(modprobe, "-c");
 	exit(EXIT_FAILURE);
 }
 DEFINE_TEST(modprobe_config,

--- a/testsuite/test-weakdep.c
+++ b/testsuite/test-weakdep.c
@@ -79,10 +79,9 @@ DEFINE_TEST(test_weakdep,
 		.out = TESTSUITE_ROOTFS "test-weakdep/correct-weakdep.txt",
 	});
 
-static noreturn int modprobe_config(void)
+static int modprobe_config(void)
 {
-	EXEC_TOOL(modprobe, "-c");
-	exit(EXIT_FAILURE);
+	return EXEC_TOOL(modprobe, "-c");
 }
 DEFINE_TEST(modprobe_config,
 	.description = "check modprobe config parsing with weakdep",

--- a/testsuite/test-weakdep.c
+++ b/testsuite/test-weakdep.c
@@ -25,7 +25,7 @@ static int test_weakdep(void)
 
 	ctx = kmod_new(NULL, NULL);
 	if (ctx == NULL)
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 
 	for (size_t i = 0; i < ARRAY_SIZE(mod_name); i++) {
 		struct kmod_list *list = NULL;
@@ -38,7 +38,7 @@ static int test_weakdep(void)
 		if (list == NULL || err < 0) {
 			fprintf(stderr, "module %s not found in directory %s\n",
 				mod_name[i], ctx ? kmod_get_dirname(ctx) : "(missing)");
-			exit(EXIT_FAILURE);
+			return EXIT_FAILURE;
 		}
 
 		mod = kmod_module_get_module(list);
@@ -47,7 +47,7 @@ static int test_weakdep(void)
 		if (err) {
 			fprintf(stderr, "weak dependencies can not be read for %s (%d)\n",
 				mod_name[i], err);
-			exit(EXIT_FAILURE);
+			return EXIT_FAILURE;
 		}
 
 		kmod_list_foreach(itr, mod_list) {

--- a/testsuite/test-weakdep.c
+++ b/testsuite/test-weakdep.c
@@ -18,34 +18,30 @@
 	test_spawn_prog(TOOLS_DIR "/modprobe", \
 			(const char *[]){ TOOLS_DIR "/modprobe", ##__VA_ARGS__, NULL })
 
-static const char *const mod_name[] = {
-	"mod-loop-b",
-	"mod-weakdep",
-	NULL,
-};
-
 static int test_weakdep(void)
 {
+	static const char *const mod_name[] = {
+		"mod-loop-b",
+		"mod-weakdep",
+	};
 	struct kmod_ctx *ctx;
-	int mod_name_index = 0;
 	int err;
 
 	ctx = kmod_new(NULL, NULL);
 	if (ctx == NULL)
 		exit(EXIT_FAILURE);
 
-	while (mod_name[mod_name_index]) {
+	for (size_t i = 0; i < ARRAY_SIZE(mod_name); i++) {
 		struct kmod_list *list = NULL;
 		struct kmod_module *mod = NULL;
 		struct kmod_list *mod_list = NULL;
 		struct kmod_list *itr = NULL;
 
-		printf("%s:", mod_name[mod_name_index]);
-		err = kmod_module_new_from_lookup(ctx, mod_name[mod_name_index], &list);
+		printf("%s:", mod_name[i]);
+		err = kmod_module_new_from_lookup(ctx, mod_name[i], &list);
 		if (list == NULL || err < 0) {
 			fprintf(stderr, "module %s not found in directory %s\n",
-				mod_name[mod_name_index],
-				ctx ? kmod_get_dirname(ctx) : "(missing)");
+				mod_name[i], ctx ? kmod_get_dirname(ctx) : "(missing)");
 			exit(EXIT_FAILURE);
 		}
 
@@ -54,7 +50,7 @@ static int test_weakdep(void)
 		err = kmod_module_get_weakdeps(mod, &mod_list);
 		if (err) {
 			fprintf(stderr, "weak dependencies can not be read for %s (%d)\n",
-				mod_name[mod_name_index], err);
+				mod_name[i], err);
 			exit(EXIT_FAILURE);
 		}
 
@@ -70,8 +66,6 @@ static int test_weakdep(void)
 		kmod_module_unref_list(mod_list);
 		kmod_module_unref(mod);
 		kmod_module_unref_list(list);
-
-		mod_name_index++;
 	}
 
 	kmod_unref(ctx);

--- a/testsuite/testsuite.c
+++ b/testsuite/testsuite.c
@@ -140,12 +140,9 @@ static int test_spawn_test(const struct test *t)
 	return EXIT_FAILURE;
 }
 
-static int test_run_spawned(const struct test *t)
+static noreturn int test_run_spawned(const struct test *t)
 {
-	int err = t->func();
-	exit(err);
-
-	return EXIT_FAILURE;
+	exit(t->func());
 }
 
 int test_spawn_prog(const char *prog, const char *const args[])
@@ -218,8 +215,8 @@ static void test_export_environ(const struct test *t)
 		setenv(env->key, env->val, 1);
 }
 
-static inline int test_run_child(const struct test *t, int fdout[2], int fderr[2],
-				 int fdmonitor[2])
+static noreturn inline int test_run_child(const struct test *t, int fdout[2],
+					  int fderr[2], int fdmonitor[2])
 {
 	/* kill child if parent dies */
 	prctl(PR_SET_PDEATHSIG, SIGTERM);
@@ -267,7 +264,7 @@ static inline int test_run_child(const struct test *t, int fdout[2], int fderr[2
 		}
 	}
 
-	return test_spawn_test(t);
+	exit(test_spawn_test(t));
 }
 
 #define BUFSZ 4096
@@ -1185,5 +1182,5 @@ int test_run(const struct test *t)
 	if (pid > 0)
 		return test_run_parent(t, fdout, fderr, fdmonitor, pid);
 
-	return test_run_child(t, fdout, fderr, fdmonitor);
+	test_run_child(t, fdout, fderr, fdmonitor);
 }

--- a/testsuite/testsuite.h
+++ b/testsuite/testsuite.h
@@ -161,7 +161,7 @@ int test_run(const struct test *t);
 			t = test_find(__start_kmod_tests, __stop_kmod_tests, argv[arg]); \
 			if (t == NULL) {                                                 \
 				fprintf(stderr, "could not find test %s\n", argv[arg]);  \
-				exit(EXIT_FAILURE);                                      \
+				return EXIT_FAILURE;                                     \
 			}                                                                \
                                                                                          \
 			return test_run(t);                                              \
@@ -172,5 +172,5 @@ int test_run(const struct test *t);
 				ret = EXIT_FAILURE;                                      \
 		}                                                                        \
                                                                                          \
-		exit(ret);                                                               \
+		return ret;                                                              \
 	}

--- a/testsuite/testsuite.h
+++ b/testsuite/testsuite.h
@@ -108,6 +108,10 @@ const struct test *test_find(const struct test *start, const struct test *stop,
 int test_spawn_prog(const char *prog, const char *const args[]);
 int test_run(const struct test *t);
 
+#define EXEC_TOOL(tool, ...)                 \
+	test_spawn_prog(TOOLS_DIR "/" #tool, \
+			(const char *[]){ TOOLS_DIR "/" #tool, ##__VA_ARGS__, NULL })
+
 #define TS_EXPORT __attribute__((visibility("default")))
 
 #define _LOG(prefix, fmt, ...) printf("TESTSUITE: " prefix fmt, ##__VA_ARGS__)


### PR DESCRIPTION
Currently we have a somewhat confusing (IMHO) and inconsistent codeflow. In that a number of places call `exit()` where they don't need to and a few which should call `exit()` but do not.

This series, resolves that by having `exit()` only in `test_run_child()` and `test_run_spawned()`. Thus, we have less boilerplate from our tests \o/

This PR builds onto the "modprobe from any" since there are some minor conflicts, although I can respin on top of master if that helps.

P.S. My next tests PR will uniformly handle the actual test/assert_return handling

