### PR TITLE
ci: remove Alpine -Ddocs=false WA

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         include:
           - container: 'alpine:latest'
-            meson_setup: '-Ddocs=false -Db_sanitize=none'
+            meson_setup: '-Db_sanitize=none'
             only_bits: '64'
           - container: 'archlinux:multilib-devel'
             skip_test: '32'


### PR DESCRIPTION
A while ago the Alpine gtk-doc tool chain was having issues building our docs. That got resolved at some point over the past months, so we can drop this local workaround.