### PR TITLE
Rework the assert_return() macro

### DIFF
--- a/testsuite/test-array.c
+++ b/testsuite/test-array.c
@@ -20,8 +20,8 @@ static int test_array_append1(void)
 
 	array_init(&array, 2);
 	array_append(&array, c1);
-	assert_return(array.count == 1, EXIT_FAILURE);
-	assert_return(array.array[0] == c1, EXIT_FAILURE);
+	TS_ASSERT(array.count == 1);
+	TS_ASSERT(array.array[0] == c1);
 	array_free_array(&array);
 
 	return 0;
@@ -39,10 +39,10 @@ static int test_array_append2(void)
 	array_append(&array, c1);
 	array_append(&array, c2);
 	array_append(&array, c3);
-	assert_return(array.count == 3, EXIT_FAILURE);
-	assert_return(array.array[0] == c1, EXIT_FAILURE);
-	assert_return(array.array[1] == c2, EXIT_FAILURE);
-	assert_return(array.array[2] == c3, EXIT_FAILURE);
+	TS_ASSERT(array.count == 3);
+	TS_ASSERT(array.array[0] == c1);
+	TS_ASSERT(array.array[1] == c2);
+	TS_ASSERT(array.array[2] == c3);
 	array_free_array(&array);
 
 	return 0;
@@ -63,10 +63,10 @@ static int test_array_append_unique(void)
 	array_append_unique(&array, c3);
 	array_append_unique(&array, c2);
 	array_append_unique(&array, c1);
-	assert_return(array.count == 3, EXIT_FAILURE);
-	assert_return(array.array[0] == c1, EXIT_FAILURE);
-	assert_return(array.array[1] == c2, EXIT_FAILURE);
-	assert_return(array.array[2] == c3, EXIT_FAILURE);
+	TS_ASSERT(array.count == 3);
+	TS_ASSERT(array.array[0] == c1);
+	TS_ASSERT(array.array[1] == c2);
+	TS_ASSERT(array.array[2] == c3);
 	array_free_array(&array);
 
 	return 0;
@@ -96,13 +96,13 @@ static int test_array_sort(void)
 	array_append(&array, c3);
 	array_append(&array, c1);
 	array_sort(&array, strptrcmp);
-	assert_return(array.count == 6, EXIT_FAILURE);
-	assert_return(array.array[0] == c1, EXIT_FAILURE);
-	assert_return(array.array[1] == c1, EXIT_FAILURE);
-	assert_return(array.array[2] == c2, EXIT_FAILURE);
-	assert_return(array.array[3] == c2, EXIT_FAILURE);
-	assert_return(array.array[4] == c3, EXIT_FAILURE);
-	assert_return(array.array[5] == c3, EXIT_FAILURE);
+	TS_ASSERT(array.count == 6);
+	TS_ASSERT(array.array[0] == c1);
+	TS_ASSERT(array.array[1] == c1);
+	TS_ASSERT(array.array[2] == c2);
+	TS_ASSERT(array.array[3] == c2);
+	TS_ASSERT(array.array[4] == c3);
+	TS_ASSERT(array.array[5] == c3);
 	array_free_array(&array);
 
 	return 0;
@@ -122,29 +122,29 @@ static int test_array_remove_at(void)
 	array_append(&array, c3);
 
 	array_remove_at(&array, 2);
-	assert_return(array.count == 2, EXIT_FAILURE);
-	assert_return(array.array[0] == c1, EXIT_FAILURE);
-	assert_return(array.array[1] == c2, EXIT_FAILURE);
-	assert_return(array.total == 4, EXIT_FAILURE);
+	TS_ASSERT(array.count == 2);
+	TS_ASSERT(array.array[0] == c1);
+	TS_ASSERT(array.array[1] == c2);
+	TS_ASSERT(array.total == 4);
 
 	array_remove_at(&array, 0);
-	assert_return(array.count == 1, EXIT_FAILURE);
-	assert_return(array.array[0] == c2, EXIT_FAILURE);
-	assert_return(array.total == 2, EXIT_FAILURE);
+	TS_ASSERT(array.count == 1);
+	TS_ASSERT(array.array[0] == c2);
+	TS_ASSERT(array.total == 2);
 
 	array_remove_at(&array, 0);
-	assert_return(array.count == 0, EXIT_FAILURE);
-	assert_return(array.total == 2, EXIT_FAILURE);
+	TS_ASSERT(array.count == 0);
+	TS_ASSERT(array.total == 2);
 
 	array_append(&array, c1);
 	array_append(&array, c2);
 	array_append(&array, c3);
 
 	array_remove_at(&array, 1);
-	assert_return(array.count == 2, EXIT_FAILURE);
-	assert_return(array.array[0] == c1, EXIT_FAILURE);
-	assert_return(array.array[1] == c3, EXIT_FAILURE);
-	assert_return(array.total == 4, EXIT_FAILURE);
+	TS_ASSERT(array.count == 2);
+	TS_ASSERT(array.array[0] == c1);
+	TS_ASSERT(array.array[1] == c3);
+	TS_ASSERT(array.total == 4);
 
 	array_free_array(&array);
 
@@ -166,18 +166,18 @@ static int test_array_pop(void)
 
 	array_pop(&array);
 
-	assert_return(array.count == 2, EXIT_FAILURE);
-	assert_return(array.array[0] == c1, EXIT_FAILURE);
-	assert_return(array.array[1] == c2, EXIT_FAILURE);
+	TS_ASSERT(array.count == 2);
+	TS_ASSERT(array.array[0] == c1);
+	TS_ASSERT(array.array[1] == c2);
 
 	array_pop(&array);
 	array_pop(&array);
 
-	assert_return(array.count == 0, EXIT_FAILURE);
+	TS_ASSERT(array.count == 0);
 
 	array_pop(&array);
 
-	assert_return(array.count == 0, EXIT_FAILURE);
+	TS_ASSERT(array.count == 0);
 
 	array_free_array(&array);
 

--- a/testsuite/test-blacklist.c
+++ b/testsuite/test-blacklist.c
@@ -60,7 +60,7 @@ static int blacklist_1(void)
 	kmod_module_unref_list(list);
 	kmod_unref(ctx);
 
-	return EXIT_SUCCESS;
+	return 0;
 }
 
 DEFINE_TEST(blacklist_1, .description = "check if modules are correctly blacklisted",

--- a/testsuite/test-blacklist.c
+++ b/testsuite/test-blacklist.c
@@ -33,50 +33,34 @@ static int blacklist_1(void)
 	static const char *const names[] = { "pcspkr", "pcspkr2", "floppy", "ext4" };
 
 	ctx = kmod_new(NULL, NULL);
-	if (ctx == NULL)
-		return EXIT_FAILURE;
+	TS_ASSERT(ctx != NULL);
 
 	for (size_t i = 0; i < ARRAY_SIZE(names); i++) {
 		err = kmod_module_new_from_name(ctx, names[i], &mod);
-		if (err < 0)
-			goto fail_lookup;
+		TS_ASSERT(err == 0);
 		list = kmod_list_append(list, mod);
 	}
 
 	err = kmod_module_apply_filter(ctx, KMOD_FILTER_BLACKLIST, list, &filtered);
-	if (err < 0) {
-		ERR("Could not filter: %s\n", strerror(-err));
-		goto fail;
-	}
-	if (filtered == NULL) {
-		ERR("All modules were filtered out!\n");
-		goto fail;
-	}
+	TS_ASSERT(err == 0);
+	TS_ASSERT(filtered != NULL);
 
 	kmod_list_foreach(l, filtered) {
 		const char *modname;
 		mod = kmod_module_get_module(l);
 		modname = kmod_module_get_name(mod);
-		if (streq("pcspkr", modname) || streq("floppy", modname))
-			goto fail;
+		TS_ASSERT(!streq("pcspkr", modname) && !streq("floppy", modname));
 		len++;
 		kmod_module_unref(mod);
 	}
 
-	if (len != 2)
-		goto fail;
+	TS_ASSERT(len == 2);
 
 	kmod_module_unref_list(filtered);
 	kmod_module_unref_list(list);
 	kmod_unref(ctx);
 
 	return EXIT_SUCCESS;
-
-fail:
-	kmod_module_unref_list(list);
-fail_lookup:
-	kmod_unref(ctx);
-	return EXIT_FAILURE;
 }
 
 DEFINE_TEST(blacklist_1, .description = "check if modules are correctly blacklisted",

--- a/testsuite/test-dependencies.c
+++ b/testsuite/test-dependencies.c
@@ -58,7 +58,7 @@ static int test_dependencies(void)
 	kmod_module_unref(mod);
 	kmod_unref(ctx);
 
-	return EXIT_SUCCESS;
+	return 0;
 }
 DEFINE_TEST(test_dependencies,
 	    .description = "test if kmod_module_get_dependencies works",

--- a/testsuite/test-dependencies.c
+++ b/testsuite/test-dependencies.c
@@ -28,14 +28,10 @@ static int test_dependencies(void)
 	int fooa = 0, foob = 0, fooc = 0;
 
 	ctx = kmod_new(NULL, NULL);
-	if (ctx == NULL)
-		return EXIT_FAILURE;
+	TS_ASSERT(ctx != NULL);
 
 	err = kmod_module_new_from_name(ctx, "mod-foo", &mod);
-	if (err < 0 || mod == NULL) {
-		kmod_unref(ctx);
-		return EXIT_FAILURE;
-	}
+	TS_ASSERT(err == 0 && mod != NULL);
 
 	list = kmod_module_get_dependencies(mod);
 
@@ -56,8 +52,7 @@ static int test_dependencies(void)
 	}
 
 	/* fooa, foob, fooc */
-	if (len != 3 || !fooa || !foob || !fooc)
-		return EXIT_FAILURE;
+	TS_ASSERT(len == 3 && fooa && foob && fooc);
 
 	kmod_module_unref_list(list);
 	kmod_module_unref(mod);

--- a/testsuite/test-hash.c
+++ b/testsuite/test-hash.c
@@ -25,7 +25,7 @@ static void countfreecalls(_maybe_unused_ void *v)
 static int test_hash_new(void)
 {
 	struct hash *h = hash_new(8, NULL);
-	assert_return(h != NULL, EXIT_FAILURE);
+	TS_ASSERT(h != NULL);
 	hash_free(h);
 	return 0;
 }
@@ -41,7 +41,7 @@ static int test_hash_get_count(void)
 	hash_add(h, k2, v2);
 	hash_add(h, k3, v3);
 
-	assert_return(hash_get_count(h) == 3, EXIT_FAILURE);
+	TS_ASSERT(hash_get_count(h) == 3);
 
 	hash_free(h);
 	return 0;
@@ -63,13 +63,13 @@ static int test_hash_replace(void)
 	/* replace v1 */
 	r |= hash_add(h, k1, v4);
 
-	assert_return(r == 0, EXIT_FAILURE);
-	assert_return(hash_get_count(h) == 3, EXIT_FAILURE);
+	TS_ASSERT(r == 0);
+	TS_ASSERT(hash_get_count(h) == 3);
 
 	v = hash_find(h, "k1");
-	assert_return(streq(v, v4), EXIT_FAILURE);
+	TS_ASSERT(streq(v, v4));
 
-	assert_return(freecount == 1, EXIT_FAILURE);
+	TS_ASSERT(freecount == 1);
 
 	hash_free(h);
 	return 0;
@@ -88,17 +88,17 @@ static int test_hash_replace_failing(void)
 	r |= hash_add(h, k2, v2);
 	r |= hash_add(h, k3, v3);
 
-	assert_return(r == 0, EXIT_FAILURE);
+	TS_ASSERT(r == 0);
 
 	/* replace v1 */
 	r = hash_add_unique(h, k1, v4);
-	assert_return(r != 0, EXIT_FAILURE);
-	assert_return(hash_get_count(h) == 3, EXIT_FAILURE);
+	TS_ASSERT(r != 0);
+	TS_ASSERT(hash_get_count(h) == 3);
 
 	v = hash_find(h, "k1");
-	assert_return(streq(v, v1), EXIT_FAILURE);
+	TS_ASSERT(streq(v, v1));
 
-	assert_return(freecount == 0, EXIT_FAILURE);
+	TS_ASSERT(freecount == 0);
 
 	hash_free(h);
 	return 0;
@@ -124,12 +124,12 @@ static int test_hash_iter(void)
 
 	for (hash_iter_init(h, &iter); hash_iter_next(&iter, &k, (const void **)&v);) {
 		v2 = hash_find(h2, k);
-		assert_return(v2 != NULL, EXIT_FAILURE);
+		TS_ASSERT(v2 != NULL);
 		hash_del(h2, k);
 	}
 
-	assert_return(hash_get_count(h) == 3, EXIT_FAILURE);
-	assert_return(hash_get_count(h2) == 0, EXIT_FAILURE);
+	TS_ASSERT(hash_get_count(h) == 3);
+	TS_ASSERT(hash_get_count(h2) == 0);
 
 	hash_free(h);
 	hash_free(h2);
@@ -157,12 +157,12 @@ static int test_hash_iter_after_del(void)
 
 	for (hash_iter_init(h, &iter); hash_iter_next(&iter, &k, (const void **)&v);) {
 		v2 = hash_find(h2, k);
-		assert_return(v2 != NULL, EXIT_FAILURE);
+		TS_ASSERT(v2 != NULL);
 		hash_del(h2, k);
 	}
 
-	assert_return(hash_get_count(h) == 2, EXIT_FAILURE);
-	assert_return(hash_get_count(h2) == 1, EXIT_FAILURE);
+	TS_ASSERT(hash_get_count(h) == 2);
+	TS_ASSERT(hash_get_count(h2) == 1);
 
 	hash_free(h);
 	hash_free(h2);
@@ -193,7 +193,7 @@ static int test_hash_del_nonexistent(void)
 	int rc;
 
 	rc = hash_del(h, k1);
-	assert_return(rc == -ENOENT, EXIT_FAILURE);
+	TS_ASSERT(rc == -ENOENT);
 
 	hash_free(h);
 
@@ -214,13 +214,13 @@ static int test_hash_free(void)
 
 	hash_del(h, k1);
 
-	assert_return(freecount == 1, EXIT_FAILURE);
+	TS_ASSERT(freecount == 1);
 
-	assert_return(hash_get_count(h) == 2, EXIT_FAILURE);
+	TS_ASSERT(hash_get_count(h) == 2);
 
 	hash_free(h);
 
-	assert_return(freecount == 3, EXIT_FAILURE);
+	TS_ASSERT(freecount == 3);
 
 	return 0;
 }
@@ -244,7 +244,7 @@ static int test_hash_add_unique(void)
 			hash_add_unique(h, k[idx], v[idx]);
 		}
 
-		assert_return(hash_get_count(h) == N, EXIT_FAILURE);
+		TS_ASSERT(hash_get_count(h) == N);
 		hash_free(h);
 	}
 	return 0;
@@ -268,7 +268,7 @@ static int test_hash_massive_add_del(void)
 		k += 8;
 	}
 
-	assert_return(hash_get_count(h) == N, EXIT_FAILURE);
+	TS_ASSERT(hash_get_count(h) == N);
 
 	k = &buf[0];
 	for (i = 0; i < N; i++) {
@@ -276,7 +276,7 @@ static int test_hash_massive_add_del(void)
 		k += 8;
 	}
 
-	assert_return(hash_get_count(h) == 0, EXIT_FAILURE);
+	TS_ASSERT(hash_get_count(h) == 0);
 
 	hash_free(h);
 	return 0;

--- a/testsuite/test-init.c
+++ b/testsuite/test-init.c
@@ -33,7 +33,7 @@ static int test_load_resources(void)
 
 	kmod_unref(ctx);
 
-	return EXIT_SUCCESS;
+	return 0;
 }
 DEFINE_TEST_WITH_FUNC(
 	test_load_resource1, test_load_resources,
@@ -64,7 +64,7 @@ static int test_initlib(void)
 
 	kmod_unref(ctx);
 
-	return EXIT_SUCCESS;
+	return 0;
 }
 DEFINE_TEST(test_initlib, .description = "test if libkmod's init function work");
 
@@ -87,7 +87,7 @@ static int test_insert(void)
 	kmod_module_unref(mod);
 	kmod_unref(ctx);
 
-	return EXIT_SUCCESS;
+	return 0;
 }
 DEFINE_TEST(test_insert,
 	.description = "test if libkmod's insert_module returns ok",
@@ -123,7 +123,7 @@ static int test_remove(void)
 	kmod_module_unref(mod_simple);
 	kmod_unref(ctx);
 
-	return EXIT_SUCCESS;
+	return 0;
 }
 DEFINE_TEST(
 	test_remove, .description = "test if libkmod's remove_module returns ok",

--- a/testsuite/test-init.c
+++ b/testsuite/test-init.c
@@ -24,16 +24,12 @@ static int test_load_resources(void)
 	int err;
 
 	ctx = kmod_new(NULL, &null_config);
-	if (ctx == NULL)
-		return EXIT_FAILURE;
+	TS_ASSERT(ctx != NULL);
 
 	kmod_set_log_priority(ctx, 7);
 
 	err = kmod_load_resources(ctx);
-	if (err != 0) {
-		ERR("could not load libkmod resources: %s\n", strerror(-err));
-		return EXIT_FAILURE;
-	}
+	TS_ASSERT(err == 0);
 
 	kmod_unref(ctx);
 
@@ -64,8 +60,7 @@ static int test_initlib(void)
 	const char *null_config = NULL;
 
 	ctx = kmod_new(NULL, &null_config);
-	if (ctx == NULL)
-		return EXIT_FAILURE;
+	TS_ASSERT(ctx != NULL);
 
 	kmod_unref(ctx);
 
@@ -81,20 +76,14 @@ static int test_insert(void)
 	int err;
 
 	ctx = kmod_new(NULL, &null_config);
-	if (ctx == NULL)
-		return EXIT_FAILURE;
+	TS_ASSERT(ctx != NULL);
 
 	err = kmod_module_new_from_path(ctx, "/mod-simple.ko", &mod);
-	if (err != 0) {
-		ERR("could not create module from path: %s\n", strerror(-err));
-		return EXIT_FAILURE;
-	}
+	TS_ASSERT(err == 0);
 
 	err = kmod_module_insert_module(mod, 0, NULL);
-	if (err != 0) {
-		ERR("could not insert module: %s\n", strerror(-err));
-		return EXIT_FAILURE;
-	}
+	TS_ASSERT(err == 0);
+
 	kmod_module_unref(mod);
 	kmod_unref(ctx);
 
@@ -116,32 +105,19 @@ static int test_remove(void)
 	int err;
 
 	ctx = kmod_new(NULL, &null_config);
-	if (ctx == NULL)
-		return EXIT_FAILURE;
+	TS_ASSERT(ctx != NULL);
 
 	err = kmod_module_new_from_name(ctx, "mod-simple", &mod_simple);
-	if (err != 0) {
-		ERR("could not create module from name: %s\n", strerror(-err));
-		return EXIT_FAILURE;
-	}
+	TS_ASSERT(err == 0);
 
 	err = kmod_module_new_from_name(ctx, "bla", &mod_bla);
-	if (err != 0) {
-		ERR("could not create module from name: %s\n", strerror(-err));
-		return EXIT_FAILURE;
-	}
+	TS_ASSERT(err == 0);
 
 	err = kmod_module_remove_module(mod_simple, 0);
-	if (err != 0) {
-		ERR("could not remove module: %s\n", strerror(-err));
-		return EXIT_FAILURE;
-	}
+	TS_ASSERT(err == 0);
 
 	err = kmod_module_remove_module(mod_bla, 0);
-	if (err != -ENOENT) {
-		ERR("wrong return code for failure test: %d\n", err);
-		return EXIT_FAILURE;
-	}
+	TS_ASSERT(err == -ENOENT);
 
 	kmod_module_unref(mod_bla);
 	kmod_module_unref(mod_simple);

--- a/testsuite/test-initstate.c
+++ b/testsuite/test-initstate.c
@@ -42,7 +42,7 @@ static int test_initstate_from_lookup(void)
 	kmod_module_unref_list(list);
 	kmod_unref(ctx);
 
-	return EXIT_SUCCESS;
+	return 0;
 }
 DEFINE_TEST(
 	test_initstate_from_lookup,
@@ -73,7 +73,7 @@ static int test_initstate_from_name(void)
 	kmod_module_unref(mod);
 	kmod_unref(ctx);
 
-	return EXIT_SUCCESS;
+	return 0;
 }
 DEFINE_TEST(test_initstate_from_name,
 	    .description =

--- a/testsuite/test-initstate.c
+++ b/testsuite/test-initstate.c
@@ -27,28 +27,16 @@ static int test_initstate_from_lookup(void)
 	int err, r;
 
 	ctx = kmod_new(NULL, &null_config);
-	if (ctx == NULL)
-		return EXIT_FAILURE;
+	TS_ASSERT(ctx != NULL);
 
 	err = kmod_module_new_from_lookup(ctx, "fake-builtin", &list);
-	if (err < 0) {
-		ERR("could not create module from lookup: %s\n", strerror(-err));
-		return EXIT_FAILURE;
-	}
-
-	if (!list) {
-		ERR("could not create module from lookup: module not found: fake-builtin\n");
-		return EXIT_FAILURE;
-	}
+	TS_ASSERT(err == 0);
+	TS_ASSERT(list != NULL);
 
 	mod = kmod_module_get_module(list);
 
 	r = kmod_module_get_initstate(mod);
-	if (r != KMOD_MODULE_BUILTIN) {
-		ERR("module should have builtin state but is: %s\n",
-		    kmod_module_initstate_str(r));
-		return EXIT_FAILURE;
-	}
+	TS_ASSERT(r == KMOD_MODULE_BUILTIN);
 
 	kmod_module_unref(mod);
 	kmod_module_unref_list(list);
@@ -73,26 +61,14 @@ static int test_initstate_from_name(void)
 	int err, r;
 
 	ctx = kmod_new(NULL, &null_config);
-	if (ctx == NULL)
-		return EXIT_FAILURE;
+	TS_ASSERT(ctx != NULL);
 
 	err = kmod_module_new_from_name(ctx, "fake-builtin", &mod);
-	if (err != 0) {
-		ERR("could not create module from lookup: %s\n", strerror(-err));
-		return EXIT_FAILURE;
-	}
-
-	if (!mod) {
-		ERR("could not create module from lookup: module not found: fake-builtin\n");
-		return EXIT_FAILURE;
-	}
+	TS_ASSERT(err == 0);
+	TS_ASSERT(mod != NULL);
 
 	r = kmod_module_get_initstate(mod);
-	if (r != KMOD_MODULE_BUILTIN) {
-		ERR("module should have builtin state but is: %s\n",
-		    kmod_module_initstate_str(r));
-		return EXIT_FAILURE;
-	}
+	TS_ASSERT(r == KMOD_MODULE_BUILTIN);
 
 	kmod_module_unref(mod);
 	kmod_unref(ctx);

--- a/testsuite/test-list.c
+++ b/testsuite/test-list.c
@@ -36,10 +36,10 @@ static int test_list_last(void)
 
 	for (i = 0; i < N; i++)
 		list = kmod_list_append(list, v[i]);
-	assert_return(len(list) == N, EXIT_FAILURE);
+	TS_ASSERT(len(list) == N);
 
 	last = kmod_list_last(list);
-	assert_return(last->data == v[N - 1], EXIT_FAILURE);
+	TS_ASSERT(last->data == v[N - 1]);
 
 	kmod_list_remove_all(list);
 
@@ -55,19 +55,19 @@ static int test_list_prev(void)
 	const int N = ARRAY_SIZE(v);
 
 	l = kmod_list_prev(list, list);
-	assert_return(l == NULL, EXIT_FAILURE);
+	TS_ASSERT(l == NULL);
 
 	for (i = 0; i < N; i++)
 		list = kmod_list_append(list, v[i]);
 
 	l = kmod_list_prev(list, list);
-	assert_return(l == NULL, EXIT_FAILURE);
+	TS_ASSERT(l == NULL);
 
 	l = list;
 	for (i = 0; i < N - 1; i++) {
 		l = kmod_list_next(list, l);
 		p = kmod_list_prev(list, l);
-		assert_return(p->data == v[i], EXIT_FAILURE);
+		TS_ASSERT(p->data == v[i]);
 	}
 
 	kmod_list_remove_all(list);
@@ -89,10 +89,10 @@ static int test_list_remove_data(void)
 
 	removed = v[N / 2];
 	list = kmod_list_remove_data(list, removed);
-	assert_return(len(list) == N - 1, EXIT_FAILURE);
+	TS_ASSERT(len(list) == N - 1);
 
 	kmod_list_foreach(l, list)
-		assert_return(l->data != removed, EXIT_FAILURE);
+		TS_ASSERT(l->data != removed);
 
 	kmod_list_remove_all(list);
 
@@ -110,24 +110,24 @@ static int test_list_append_list(void)
 
 	for (i = 0; i < M; i++)
 		a = kmod_list_append(a, v[i]);
-	assert_return(len(a) == M, EXIT_FAILURE);
+	TS_ASSERT(len(a) == M);
 
 	for (i = M; i < N; i++)
 		b = kmod_list_append(b, v[i]);
-	assert_return(len(b) == N - M, EXIT_FAILURE);
+	TS_ASSERT(len(b) == N - M);
 
 	a = kmod_list_append_list(a, NULL);
-	assert_return(len(a) == M, EXIT_FAILURE);
+	TS_ASSERT(len(a) == M);
 
 	b = kmod_list_append_list(NULL, b);
-	assert_return(len(b) == N - M, EXIT_FAILURE);
+	TS_ASSERT(len(b) == N - M);
 
 	c = kmod_list_append_list(a, b);
-	assert_return(len(c) == N, EXIT_FAILURE);
+	TS_ASSERT(len(c) == N);
 
 	i = 0;
 	kmod_list_foreach(l, c) {
-		assert_return(l->data == v[i], EXIT_FAILURE);
+		TS_ASSERT(l->data == v[i]);
 		i++;
 	}
 
@@ -144,27 +144,27 @@ static int test_list_insert_before(void)
 	const char *v1 = "v1", *v2 = "v2", *v3 = "v3", *vx = "vx";
 
 	list = kmod_list_insert_before(list, v3);
-	assert_return(len(list) == 1, EXIT_FAILURE);
+	TS_ASSERT(len(list) == 1);
 
 	list = kmod_list_insert_before(list, v2);
 	list = kmod_list_insert_before(list, v1);
-	assert_return(len(list) == 3, EXIT_FAILURE);
+	TS_ASSERT(len(list) == 3);
 
 	l = list;
-	assert_return(l->data == v1, EXIT_FAILURE);
+	TS_ASSERT(l->data == v1);
 
 	l = kmod_list_next(list, l);
-	assert_return(l->data == v2, EXIT_FAILURE);
+	TS_ASSERT(l->data == v2);
 
 	l = kmod_list_insert_before(l, vx);
-	assert_return(len(list) == 4, EXIT_FAILURE);
-	assert_return(l->data == vx, EXIT_FAILURE);
+	TS_ASSERT(len(list) == 4);
+	TS_ASSERT(l->data == vx);
 
 	l = kmod_list_next(list, l);
-	assert_return(l->data == v2, EXIT_FAILURE);
+	TS_ASSERT(l->data == v2);
 
 	l = kmod_list_next(list, l);
-	assert_return(l->data == v3, EXIT_FAILURE);
+	TS_ASSERT(l->data == v3);
 
 	kmod_list_remove_all(list);
 
@@ -179,27 +179,27 @@ static int test_list_insert_after(void)
 	const char *v1 = "v1", *v2 = "v2", *v3 = "v3", *vx = "vx";
 
 	list = kmod_list_insert_after(list, v1);
-	assert_return(len(list) == 1, EXIT_FAILURE);
+	TS_ASSERT(len(list) == 1);
 
 	list = kmod_list_insert_after(list, v3);
 	list = kmod_list_insert_after(list, v2);
-	assert_return(len(list) == 3, EXIT_FAILURE);
+	TS_ASSERT(len(list) == 3);
 
 	l = list;
-	assert_return(l->data == v1, EXIT_FAILURE);
+	TS_ASSERT(l->data == v1);
 
 	l = kmod_list_insert_after(l, vx);
-	assert_return(len(list) == 4, EXIT_FAILURE);
-	assert_return(l->data == v1, EXIT_FAILURE);
+	TS_ASSERT(len(list) == 4);
+	TS_ASSERT(l->data == v1);
 
 	l = kmod_list_next(list, l);
-	assert_return(l->data == vx, EXIT_FAILURE);
+	TS_ASSERT(l->data == vx);
 
 	l = kmod_list_next(list, l);
-	assert_return(l->data == v2, EXIT_FAILURE);
+	TS_ASSERT(l->data == v2);
 
 	l = kmod_list_next(list, l);
-	assert_return(l->data == v3, EXIT_FAILURE);
+	TS_ASSERT(l->data == v3);
 
 	kmod_list_remove_all(list);
 

--- a/testsuite/test-loaded.c
+++ b/testsuite/test-loaded.c
@@ -58,7 +58,7 @@ static int loaded_1(void)
 
 	kmod_unref(ctx);
 
-	return EXIT_SUCCESS;
+	return 0;
 }
 DEFINE_TEST(loaded_1,
 	.description = "check if list of module is created",

--- a/testsuite/test-loaded.c
+++ b/testsuite/test-loaded.c
@@ -22,15 +22,10 @@ static int loaded_1(void)
 	int err;
 
 	ctx = kmod_new(NULL, &null_config);
-	if (ctx == NULL)
-		return EXIT_FAILURE;
+	TS_ASSERT(ctx != NULL);
 
 	err = kmod_module_new_from_loaded(ctx, &list);
-	if (err < 0) {
-		fprintf(stderr, "%s\n", strerror(-err));
-		kmod_unref(ctx);
-		return EXIT_FAILURE;
-	}
+	TS_ASSERT(err == 0);
 
 	printf("Module                  Size  Used by\n");
 

--- a/testsuite/test-modprobe.c
+++ b/testsuite/test-modprobe.c
@@ -393,10 +393,7 @@ DEFINE_TEST(modprobe_module_from_abspath,
 
 static int modprobe_module_from_relpath(void)
 {
-	if (chdir("/home/foo") != 0) {
-		perror("failed to change into /home/foo");
-		return EXIT_FAILURE;
-	}
+	TS_ASSERT(chdir("/home/foo") == 0);
 
 	return EXEC_TOOL(modprobe, "./mod-simple.ko");
 }

--- a/testsuite/test-multi-softdep.c
+++ b/testsuite/test-multi-softdep.c
@@ -36,7 +36,6 @@ static int check_dependencies(const char *const *modnames,
 	const struct kmod_list *itr;
 	bool visited[MAX_SOFTDEP_N] = {};
 	int mod_index;
-	bool all_loaded = true;
 
 	kmod_list_foreach(itr, mod_list) {
 		struct kmod_module *softdep_mod = kmod_module_get_module(itr);
@@ -56,15 +55,9 @@ static int check_dependencies(const char *const *modnames,
 	for (mod_index = 0; mod_index < MAX_SOFTDEP_N; mod_index++) {
 		if (!modnames[mod_index])
 			break;
-		if (!visited[mod_index]) {
-			ERR("softdep %s not loaded\n", modnames[mod_index]);
-			all_loaded = false;
-		}
+		TS_ASSERT(visited[mod_index]);
 	}
-	if (all_loaded)
-		return 0;
-	else
-		return -1;
+	return 0;
 }
 
 static int multi_softdep(void)
@@ -78,32 +71,26 @@ static int multi_softdep(void)
 	int err;
 
 	ctx = kmod_new(NULL, NULL);
-	if (ctx == NULL)
-		return EXIT_FAILURE;
+	TS_ASSERT(ctx != NULL);
 
 	for (mod_index = 0; mod_index < ARRAY_SIZE(test_modules); mod_index++) {
 		modname = test_modules[mod_index].modname;
 		printf("module %s:\n", modname);
 		err = kmod_module_new_from_name(ctx, modname, &mod);
-		if (err < 0)
-			goto fail;
+		TS_ASSERT(err == 0);
+
 		pre = NULL;
 		post = NULL;
 		err = kmod_module_get_softdeps(mod, &pre, &post);
-		if (err < 0) {
-			ERR("could not get softdeps of '%s': %s\n", modname,
-			    strerror(-err));
-			goto fail;
-		}
+		TS_ASSERT(err == 0);
 
 		printf("pre: ");
 		err = check_dependencies(test_modules[mod_index].pre, pre);
-		if (err < 0)
-			goto fail;
+		TS_ASSERT(err == 0);
+
 		printf("post: ");
 		err = check_dependencies(test_modules[mod_index].post, post);
-		if (err < 0)
-			goto fail;
+		TS_ASSERT(err == 0);
 
 		kmod_module_unref_list(pre);
 		kmod_module_unref_list(post);
@@ -111,13 +98,6 @@ static int multi_softdep(void)
 	}
 	kmod_unref(ctx);
 	return EXIT_SUCCESS;
-
-fail:
-	kmod_module_unref_list(pre);
-	kmod_module_unref_list(post);
-	kmod_module_unref(mod);
-	kmod_unref(ctx);
-	return EXIT_FAILURE;
 }
 
 /*

--- a/testsuite/test-multi-softdep.c
+++ b/testsuite/test-multi-softdep.c
@@ -97,7 +97,7 @@ static int multi_softdep(void)
 		kmod_module_unref(mod);
 	}
 	kmod_unref(ctx);
-	return EXIT_SUCCESS;
+	return 0;
 }
 
 /*

--- a/testsuite/test-new-module.c
+++ b/testsuite/test-new-module.c
@@ -31,13 +31,11 @@ static int from_name(void)
 	int err;
 
 	ctx = kmod_new(NULL, &null_config);
-	if (ctx == NULL)
-		return EXIT_FAILURE;
+	TS_ASSERT(ctx != NULL);
 
 	for (size_t i = 0; i < ARRAY_SIZE(modnames); i++) {
 		err = kmod_module_new_from_name(ctx, modnames[i], &mod);
-		if (err < 0)
-			return EXIT_FAILURE;
+		TS_ASSERT(err == 0);
 
 		printf("modname: %s\n", kmod_module_get_name(mod));
 		kmod_module_unref(mod);
@@ -65,15 +63,13 @@ static int from_alias(void)
 	int err;
 
 	ctx = kmod_new(NULL, NULL);
-	if (ctx == NULL)
-		return EXIT_FAILURE;
+	TS_ASSERT(ctx != NULL);
 
 	for (size_t i = 0; i < ARRAY_SIZE(modnames); i++) {
 		struct kmod_list *l, *list = NULL;
 
 		err = kmod_module_new_from_lookup(ctx, modnames[i], &list);
-		if (err < 0)
-			return EXIT_FAILURE;
+		TS_ASSERT(err == 0);
 
 		kmod_list_foreach(l, list) {
 			struct kmod_module *m;

--- a/testsuite/test-new-module.c
+++ b/testsuite/test-new-module.c
@@ -43,7 +43,7 @@ static int from_name(void)
 
 	kmod_unref(ctx);
 
-	return EXIT_SUCCESS;
+	return 0;
 }
 DEFINE_TEST(from_name,
 	.description = "check if module names are parsed correctly",
@@ -83,7 +83,7 @@ static int from_alias(void)
 
 	kmod_unref(ctx);
 
-	return EXIT_SUCCESS;
+	return 0;
 }
 DEFINE_TEST(from_alias,
 	.description = "check if aliases are parsed correctly",

--- a/testsuite/test-remove.c
+++ b/testsuite/test-remove.c
@@ -26,31 +26,19 @@ static int test_remove(void)
 	struct stat st;
 
 	ctx = kmod_new(NULL, &null_config);
-	if (ctx == NULL)
-		return EXIT_FAILURE;
+	TS_ASSERT(ctx != NULL);
 
 	err = kmod_module_new_from_path(ctx, "/mod-simple.ko", &mod);
-	if (err != 0) {
-		ERR("could not create module from path: %s\n", strerror(-err));
-		return EXIT_FAILURE;
-	}
+	TS_ASSERT(err == 0);
 
 	err = kmod_module_insert_module(mod, 0, NULL);
-	if (err != 0) {
-		ERR("could not insert module: %s\n", strerror(-err));
-		return EXIT_FAILURE;
-	}
+	TS_ASSERT(err == 0);
 
 	err = kmod_module_remove_module(mod, 0);
-	if (err != 0) {
-		ERR("could not remove module: %s\n", strerror(-err));
-		return EXIT_FAILURE;
-	}
+	TS_ASSERT(err == 0);
 
-	if (stat("/sys/module/mod_simple", &st) == 0 && S_ISDIR(st.st_mode)) {
-		ERR("could not remove module directory.\n");
-		return EXIT_FAILURE;
-	}
+	TS_ASSERT(stat("/sys/module/mod_simple", &st) != 0 || !S_ISDIR(st.st_mode));
+
 	kmod_module_unref(mod);
 	kmod_unref(ctx);
 

--- a/testsuite/test-remove.c
+++ b/testsuite/test-remove.c
@@ -42,7 +42,7 @@ static int test_remove(void)
 	kmod_module_unref(mod);
 	kmod_unref(ctx);
 
-	return EXIT_SUCCESS;
+	return 0;
 }
 DEFINE_TEST(test_remove,
 	    .description = "test if libkmod's delete_module removes module directory",

--- a/testsuite/test-strbuf.c
+++ b/testsuite/test-strbuf.c
@@ -29,8 +29,8 @@ static int test_strbuf_pushchar(void)
 		strbuf_pushchar(&buf, *c);
 
 	result = strbuf_str(&buf);
-	assert_return(result == buf.bytes, EXIT_FAILURE);
-	assert_return(streq(result, TEXT), EXIT_FAILURE);
+	TS_ASSERT(result == buf.bytes);
+	TS_ASSERT(streq(result, TEXT));
 
 	return 0;
 }
@@ -60,15 +60,14 @@ static int test_strbuf_pushchars(void)
 	 */
 	strbuf_popchar(&buf);
 	result = strbuf_str(&buf);
-	assert_return(result == buf.bytes, EXIT_FAILURE);
-	assert_return(streq(result, TEXT), EXIT_FAILURE);
+	TS_ASSERT(result == buf.bytes);
+	TS_ASSERT(streq(result, TEXT));
 
 	strbuf_popchars(&buf, lastwordlen);
 	result = strbuf_str(&buf);
-	assert_return(!streq(TEXT, result), EXIT_FAILURE);
-	assert_return(strncmp(TEXT, result, strlen(TEXT) - lastwordlen) == 0,
-		      EXIT_FAILURE);
-	assert_return(result[strlen(TEXT) - lastwordlen] == '\0', EXIT_FAILURE);
+	TS_ASSERT(!streq(TEXT, result));
+	TS_ASSERT(strncmp(TEXT, result, strlen(TEXT) - lastwordlen) == 0);
+	TS_ASSERT(result[strlen(TEXT) - lastwordlen] == '\0');
 
 	free(str);
 
@@ -87,15 +86,15 @@ static int test_strbuf_with_stack(void)
 	DECLARE_STRBUF_WITH_STACK(buf3, sizeof(test) + 1);
 
 	strbuf_pushchars(&buf, test);
-	assert_return(streq(test, strbuf_str(&buf)), EXIT_FAILURE);
+	TS_ASSERT(streq(test, strbuf_str(&buf)));
 	p = strbuf_str(&buf);
-	assert_return(streq(test, p), EXIT_FAILURE);
+	TS_ASSERT(streq(test, p));
 
 	strbuf_pushchars(&buf2, test);
-	assert_return(streq(test, strbuf_str(&buf2)), EXIT_FAILURE);
+	TS_ASSERT(streq(test, strbuf_str(&buf2)));
 	/* It fits on stack, but when we steal, we get a copy on heap */
 	p = strbuf_str(&buf2);
-	assert_return(streq(test, p), EXIT_FAILURE);
+	TS_ASSERT(streq(test, p));
 
 	/*
 	 * Check assumption about buffer being on stack vs heap is indeed valid.
@@ -104,13 +103,13 @@ static int test_strbuf_with_stack(void)
 	strbuf_clear(&buf3);
 	stack_buf = buf3.bytes;
 	strbuf_pushchars(&buf3, test);
-	assert_return(stack_buf == buf3.bytes, EXIT_FAILURE);
+	TS_ASSERT(stack_buf == buf3.bytes);
 
-	assert_return(streq(test, strbuf_str(&buf3)), EXIT_FAILURE);
-	assert_return(stack_buf == buf3.bytes, EXIT_FAILURE);
+	TS_ASSERT(streq(test, strbuf_str(&buf3)));
+	TS_ASSERT(stack_buf == buf3.bytes);
 
 	strbuf_pushchars(&buf3, "-overflow");
-	assert_return(stack_buf != buf3.bytes, EXIT_FAILURE);
+	TS_ASSERT(stack_buf != buf3.bytes);
 
 	return 0;
 }
@@ -120,13 +119,13 @@ static int test_strbuf_with_heap(void)
 {
 	DECLARE_STRBUF(heapbuf);
 
-	assert_return(heapbuf.bytes == NULL, EXIT_FAILURE);
-	assert_return(heapbuf.size == 0, EXIT_FAILURE);
-	assert_return(heapbuf.used == 0, EXIT_FAILURE);
+	TS_ASSERT(heapbuf.bytes == NULL);
+	TS_ASSERT(heapbuf.size == 0);
+	TS_ASSERT(heapbuf.used == 0);
 	strbuf_pushchars(&heapbuf, "-overflow");
-	assert_return(heapbuf.bytes != NULL, EXIT_FAILURE);
-	assert_return(heapbuf.size != 0, EXIT_FAILURE);
-	assert_return(heapbuf.used != 0, EXIT_FAILURE);
+	TS_ASSERT(heapbuf.bytes != NULL);
+	TS_ASSERT(heapbuf.size != 0);
+	TS_ASSERT(heapbuf.used != 0);
 
 	return 0;
 }
@@ -140,7 +139,7 @@ static int test_strbuf_pushmem(void)
 	strbuf_pushmem(&buf, "", 0);
 	strbuf_pushmem(&buf, TEXT, strlen(TEXT) + 1);
 
-	assert_return(streq(TEXT, strbuf_str(&buf)), EXIT_FAILURE);
+	TS_ASSERT(streq(TEXT, strbuf_str(&buf)));
 
 	return 0;
 }
@@ -151,21 +150,21 @@ static int test_strbuf_used(void)
 	_cleanup_strbuf_ struct strbuf buf;
 
 	strbuf_init(&buf);
-	assert_return(strbuf_used(&buf) == 0, EXIT_FAILURE);
+	TS_ASSERT(strbuf_used(&buf) == 0);
 
 	strbuf_pushchars(&buf, TEXT);
-	assert_return(strbuf_used(&buf) == strlen(TEXT), EXIT_FAILURE);
+	TS_ASSERT(strbuf_used(&buf) == strlen(TEXT));
 
 	strbuf_pushchar(&buf, 'a');
 	strbuf_popchar(&buf);
-	assert_return(strbuf_used(&buf) == strlen(TEXT), EXIT_FAILURE);
+	TS_ASSERT(strbuf_used(&buf) == strlen(TEXT));
 
-	assert_return(streq(TEXT, strbuf_str(&buf)), EXIT_FAILURE);
-	assert_return(strbuf_used(&buf) == strlen(TEXT), EXIT_FAILURE);
+	TS_ASSERT(streq(TEXT, strbuf_str(&buf)));
+	TS_ASSERT(strbuf_used(&buf) == strlen(TEXT));
 
 	strbuf_pushchar(&buf, '\0');
-	assert_return(streq(TEXT, strbuf_str(&buf)), EXIT_FAILURE);
-	assert_return(strbuf_used(&buf) == strlen(TEXT) + 1, EXIT_FAILURE);
+	TS_ASSERT(streq(TEXT, strbuf_str(&buf)));
+	TS_ASSERT(strbuf_used(&buf) == strlen(TEXT) + 1);
 
 	return 0;
 }
@@ -177,11 +176,11 @@ static int test_strbuf_shrink_to(void)
 
 	strbuf_init(&buf);
 	strbuf_shrink_to(&buf, 0);
-	assert_return(strbuf_used(&buf) == 0, EXIT_FAILURE);
+	TS_ASSERT(strbuf_used(&buf) == 0);
 
 	strbuf_pushchars(&buf, TEXT);
 	strbuf_shrink_to(&buf, strlen(TEXT) - 1);
-	assert_return(strbuf_used(&buf) == strlen(TEXT) - 1, EXIT_FAILURE);
+	TS_ASSERT(strbuf_used(&buf) == strlen(TEXT) - 1);
 
 	return 0;
 }

--- a/testsuite/test-testsuite.c
+++ b/testsuite/test-testsuite.c
@@ -26,15 +26,9 @@ static int testsuite_uname(void)
 	struct utsname u;
 	int err = uname(&u);
 
-	if (err < 0)
-		return EXIT_FAILURE;
+	TS_ASSERT(err == 0);
 
-	if (!streq(u.release, TEST_UNAME)) {
-		const char *ldpreload = getenv("LD_PRELOAD");
-		ERR("u.release=%s should be %s\n", u.release, TEST_UNAME);
-		ERR("LD_PRELOAD=%s\n", ldpreload);
-		return EXIT_FAILURE;
-	}
+	TS_ASSERT(streq(u.release, TEST_UNAME));
 
 	return EXIT_SUCCESS;
 }
@@ -50,15 +44,12 @@ static int testsuite_rootfs_fopen(void)
 	int n;
 
 	fp = fopen(MODULE_DIRECTORY "/a", "r");
-	if (fp == NULL)
-		return EXIT_FAILURE;
+	TS_ASSERT(fp != NULL);
 
 	n = fscanf(fp, "%s", s);
-	if (n != 1)
-		return EXIT_FAILURE;
+	TS_ASSERT(n == 1);
 
-	if (!streq(s, "kmod-test-chroot-works"))
-		return EXIT_FAILURE;
+	TS_ASSERT(streq(s, "kmod-test-chroot-works"));
 
 	return EXIT_SUCCESS;
 }
@@ -73,8 +64,7 @@ static int testsuite_rootfs_open(void)
 	int fd, done;
 
 	fd = open(MODULE_DIRECTORY "/a", O_RDONLY);
-	if (fd < 0)
-		return EXIT_FAILURE;
+	TS_ASSERT(fd >= 0);
 
 	for (done = 0;;) {
 		int r = read(fd, buf + done, sizeof(buf) - 1 - done);
@@ -88,8 +78,7 @@ static int testsuite_rootfs_open(void)
 
 	buf[done] = '\0';
 
-	if (!streq(buf, "kmod-test-chroot-works\n"))
-		return EXIT_FAILURE;
+	TS_ASSERT(streq(buf, "kmod-test-chroot-works\n"));
 
 	return EXIT_SUCCESS;
 }
@@ -102,10 +91,7 @@ static int testsuite_rootfs_stat(void)
 {
 	struct stat st;
 
-	if (stat(MODULE_DIRECTORY "/a", &st) < 0) {
-		ERR("stat failed: %m\n");
-		return EXIT_FAILURE;
-	}
+	TS_ASSERT(stat(MODULE_DIRECTORY "/a", &st) == 0);
 
 	return EXIT_SUCCESS;
 }
@@ -119,10 +105,7 @@ static int testsuite_rootfs_opendir(void)
 	DIR *d;
 
 	d = opendir("/testdir");
-	if (d == NULL) {
-		ERR("opendir failed: %m\n");
-		return EXIT_FAILURE;
-	}
+	TS_ASSERT(d != NULL);
 
 	closedir(d);
 	return EXIT_SUCCESS;

--- a/testsuite/test-testsuite.c
+++ b/testsuite/test-testsuite.c
@@ -30,7 +30,7 @@ static int testsuite_uname(void)
 
 	TS_ASSERT(streq(u.release, TEST_UNAME));
 
-	return EXIT_SUCCESS;
+	return 0;
 }
 DEFINE_TEST(testsuite_uname, .description = "test if trap to uname() works",
 	    .config = {
@@ -51,7 +51,7 @@ static int testsuite_rootfs_fopen(void)
 
 	TS_ASSERT(streq(s, "kmod-test-chroot-works"));
 
-	return EXIT_SUCCESS;
+	return 0;
 }
 DEFINE_TEST(testsuite_rootfs_fopen, .description = "test if rootfs works - fopen()",
 	    .config = {
@@ -80,7 +80,7 @@ static int testsuite_rootfs_open(void)
 
 	TS_ASSERT(streq(buf, "kmod-test-chroot-works\n"));
 
-	return EXIT_SUCCESS;
+	return 0;
 }
 DEFINE_TEST(testsuite_rootfs_open, .description = "test if rootfs works - open()",
 	    .config = {
@@ -93,7 +93,7 @@ static int testsuite_rootfs_stat(void)
 
 	TS_ASSERT(stat(MODULE_DIRECTORY "/a", &st) == 0);
 
-	return EXIT_SUCCESS;
+	return 0;
 }
 DEFINE_TEST(testsuite_rootfs_stat, .description = "test if rootfs works - stat()",
 	    .config = {
@@ -108,7 +108,7 @@ static int testsuite_rootfs_opendir(void)
 	TS_ASSERT(d != NULL);
 
 	closedir(d);
-	return EXIT_SUCCESS;
+	return 0;
 }
 DEFINE_TEST(testsuite_rootfs_opendir, .description = "test if rootfs works - opendir()",
 	    .config = {

--- a/testsuite/test-util.c
+++ b/testsuite/test-util.c
@@ -62,8 +62,7 @@ static int test_freadline_wrapped(void)
 {
 	FILE *fp = fopen("/freadline_wrapped-input.txt", "re");
 
-	if (!fp)
-		return EXIT_FAILURE;
+	TS_ASSERT(fp != NULL);
 
 	while (!feof(fp) && !ferror(fp)) {
 		unsigned int num = 0;

--- a/testsuite/test-util.c
+++ b/testsuite/test-util.c
@@ -93,7 +93,7 @@ static int test_strchr_replace(void)
 	const char *res = "thiC iC a teCt Ctring";
 
 	strchr_replace(s, 's', 'C');
-	assert_return(streq(s, res), EXIT_FAILURE);
+	TS_ASSERT(streq(s, res));
 
 	return EXIT_SUCCESS;
 }
@@ -118,9 +118,9 @@ static int test_underscores(void)
 
 	for (size_t i = 0; i < ARRAY_SIZE(teststr); i++) {
 		_cleanup_free_ char *val = strdup(teststr[i].val);
-		assert_return(val != NULL, EXIT_FAILURE);
-		assert_return(!underscores(val), EXIT_FAILURE);
-		assert_return(streq(val, teststr[i].res), EXIT_FAILURE);
+		TS_ASSERT(val != NULL);
+		TS_ASSERT(!underscores(val));
+		TS_ASSERT(streq(val, teststr[i].res));
 	}
 
 	return EXIT_SUCCESS;
@@ -152,10 +152,9 @@ static int test_path_ends_with_kmod_ext(void)
 	};
 
 	for (size_t i = 0; i < ARRAY_SIZE(teststr); i++) {
-		assert_return(path_ends_with_kmod_ext(teststr[i].val,
-						      strlen(teststr[i].val)) ==
-				      teststr[i].res,
-			      EXIT_FAILURE);
+		TS_ASSERT(
+			path_ends_with_kmod_ext(teststr[i].val, strlen(teststr[i].val)) ==
+			teststr[i].res);
 	}
 
 	return EXIT_SUCCESS;
@@ -171,7 +170,7 @@ static int test_write_str_safe(void)
 	int fd;
 
 	fd = open(TEST_WRITE_STR_SAFE_FILE ".txt", O_CREAT | O_TRUNC | O_WRONLY, 0644);
-	assert_return(fd >= 0, EXIT_FAILURE);
+	TS_ASSERT(fd >= 0);
 
 	write_str_safe(fd, s, strlen(s));
 	close(fd);
@@ -197,11 +196,11 @@ static int test_uadd32_overflow(void)
 	bool overflow;
 
 	overflow = uadd32_overflow(UINT32_MAX - 1, 1, &res);
-	assert_return(!overflow, EXIT_FAILURE);
-	assert_return(res == UINT32_MAX, EXIT_FAILURE);
+	TS_ASSERT(!overflow);
+	TS_ASSERT(res == UINT32_MAX);
 
 	overflow = uadd32_overflow(UINT32_MAX, 1, &res);
-	assert_return(overflow, EXIT_FAILURE);
+	TS_ASSERT(overflow);
 
 	return EXIT_SUCCESS;
 }
@@ -214,11 +213,11 @@ static int test_uadd64_overflow(void)
 	bool overflow;
 
 	overflow = uadd64_overflow(UINT64_MAX - 1, 1, &res);
-	assert_return(!overflow, EXIT_FAILURE);
-	assert_return(res == UINT64_MAX, EXIT_FAILURE);
+	TS_ASSERT(!overflow);
+	TS_ASSERT(res == UINT64_MAX);
 
 	overflow = uadd64_overflow(UINT64_MAX, 1, &res);
-	assert_return(overflow, EXIT_FAILURE);
+	TS_ASSERT(overflow);
 
 	return EXIT_SUCCESS;
 }
@@ -231,11 +230,11 @@ static int test_umul32_overflow(void)
 	bool overflow;
 
 	overflow = umul32_overflow(UINT32_MAX / 0x10, 0x10, &res);
-	assert_return(!overflow, EXIT_FAILURE);
-	assert_return(res == (UINT32_MAX & ~0xf), EXIT_FAILURE);
+	TS_ASSERT(!overflow);
+	TS_ASSERT(res == (UINT32_MAX & ~0xf));
 
 	overflow = umul32_overflow(UINT32_MAX, 0x10, &res);
-	assert_return(overflow, EXIT_FAILURE);
+	TS_ASSERT(overflow);
 
 	return EXIT_SUCCESS;
 }
@@ -248,11 +247,11 @@ static int test_umul64_overflow(void)
 	bool overflow;
 
 	overflow = umul64_overflow(UINT64_MAX / 0x10, 0x10, &res);
-	assert_return(!overflow, EXIT_FAILURE);
-	assert_return(res == (UINT64_MAX & ~0xf), EXIT_FAILURE);
+	TS_ASSERT(!overflow);
+	TS_ASSERT(res == (UINT64_MAX & ~0xf));
 
 	overflow = umul64_overflow(UINT64_MAX, 0x10, &res);
-	assert_return(overflow, EXIT_FAILURE);
+	TS_ASSERT(overflow);
 
 	return EXIT_SUCCESS;
 }
@@ -265,31 +264,31 @@ static int test_backoff_time(void)
 
 	/* Check exponential increments */
 	get_backoff_delta_msec(now_msec() + 10, &delta);
-	assert_return(delta == 1, EXIT_FAILURE);
+	TS_ASSERT(delta == 1);
 	get_backoff_delta_msec(now_msec() + 10, &delta);
-	assert_return(delta == 2, EXIT_FAILURE);
+	TS_ASSERT(delta == 2);
 	get_backoff_delta_msec(now_msec() + 10, &delta);
-	assert_return(delta == 4, EXIT_FAILURE);
+	TS_ASSERT(delta == 4);
 	get_backoff_delta_msec(now_msec() + 10, &delta);
-	assert_return(delta == 8, EXIT_FAILURE);
+	TS_ASSERT(delta == 8);
 	get_backoff_delta_msec(now_msec() + 10, &delta);
-	assert_return(delta == 8, EXIT_FAILURE);
+	TS_ASSERT(delta == 8);
 
 	{
 		/* Check tail */
 		delta = 4;
 		get_backoff_delta_msec(now_msec() + 3, &delta);
-		assert_return(delta == 2, EXIT_FAILURE);
+		TS_ASSERT(delta == 2);
 		get_backoff_delta_msec(now_msec() + 1, &delta);
-		assert_return(delta == 1, EXIT_FAILURE);
+		TS_ASSERT(delta == 1);
 		get_backoff_delta_msec(now_msec(), &delta);
-		assert_return(delta == 0, EXIT_FAILURE);
+		TS_ASSERT(delta == 0);
 	}
 
 	/* Check when end time has passed */
 	delta = 0;
 	get_backoff_delta_msec(now_msec() - 10, &delta);
-	assert_return(delta == 0, EXIT_FAILURE);
+	TS_ASSERT(delta == 0);
 
 	return EXIT_SUCCESS;
 }

--- a/testsuite/test-util.c
+++ b/testsuite/test-util.c
@@ -47,7 +47,7 @@ static int alias_1(void)
 		printf("\n");
 	}
 
-	return EXIT_SUCCESS;
+	return 0;
 }
 DEFINE_TEST(alias_1,
 	.description = "check if alias_normalize does the right thing",
@@ -75,7 +75,7 @@ static int test_freadline_wrapped(void)
 	}
 
 	fclose(fp);
-	return EXIT_SUCCESS;
+	return 0;
 }
 DEFINE_TEST(test_freadline_wrapped,
 	.description = "check if freadline_wrapped() does the right thing",
@@ -94,7 +94,7 @@ static int test_strchr_replace(void)
 	strchr_replace(s, 's', 'C');
 	TS_ASSERT(streq(s, res));
 
-	return EXIT_SUCCESS;
+	return 0;
 }
 DEFINE_TEST(test_strchr_replace,
 	    .description = "check implementation of strchr_replace()");
@@ -122,7 +122,7 @@ static int test_underscores(void)
 		TS_ASSERT(streq(val, teststr[i].res));
 	}
 
-	return EXIT_SUCCESS;
+	return 0;
 }
 DEFINE_TEST(test_underscores, .description = "check implementation of underscores()");
 
@@ -156,7 +156,7 @@ static int test_path_ends_with_kmod_ext(void)
 			teststr[i].res);
 	}
 
-	return EXIT_SUCCESS;
+	return 0;
 }
 DEFINE_TEST(test_path_ends_with_kmod_ext,
 	    .description = "check implementation of path_ends_with_kmod_ext()");
@@ -174,7 +174,7 @@ static int test_write_str_safe(void)
 	write_str_safe(fd, s, strlen(s));
 	close(fd);
 
-	return EXIT_SUCCESS;
+	return 0;
 }
 DEFINE_TEST(test_write_str_safe,
 	.description = "check implementation of write_str_safe()",
@@ -201,7 +201,7 @@ static int test_uadd32_overflow(void)
 	overflow = uadd32_overflow(UINT32_MAX, 1, &res);
 	TS_ASSERT(overflow);
 
-	return EXIT_SUCCESS;
+	return 0;
 }
 DEFINE_TEST(test_uadd32_overflow,
 	    .description = "check implementation of uadd32_overflow()");
@@ -218,7 +218,7 @@ static int test_uadd64_overflow(void)
 	overflow = uadd64_overflow(UINT64_MAX, 1, &res);
 	TS_ASSERT(overflow);
 
-	return EXIT_SUCCESS;
+	return 0;
 }
 DEFINE_TEST(test_uadd64_overflow,
 	    .description = "check implementation of uadd64_overflow()");
@@ -235,7 +235,7 @@ static int test_umul32_overflow(void)
 	overflow = umul32_overflow(UINT32_MAX, 0x10, &res);
 	TS_ASSERT(overflow);
 
-	return EXIT_SUCCESS;
+	return 0;
 }
 DEFINE_TEST(test_umul32_overflow,
 	    .description = "check implementation of umul32_overflow()");
@@ -252,7 +252,7 @@ static int test_umul64_overflow(void)
 	overflow = umul64_overflow(UINT64_MAX, 0x10, &res);
 	TS_ASSERT(overflow);
 
-	return EXIT_SUCCESS;
+	return 0;
 }
 DEFINE_TEST(test_umul64_overflow,
 	    .description = "check implementation of umul64_overflow()");
@@ -289,7 +289,7 @@ static int test_backoff_time(void)
 	get_backoff_delta_msec(now_msec() - 10, &delta);
 	TS_ASSERT(delta == 0);
 
-	return EXIT_SUCCESS;
+	return 0;
 }
 DEFINE_TEST(test_backoff_time,
 	    .description = "check implementation of get_backoff_delta_msec()");

--- a/testsuite/test-weakdep.c
+++ b/testsuite/test-weakdep.c
@@ -24,8 +24,7 @@ static int test_weakdep(void)
 	int err;
 
 	ctx = kmod_new(NULL, NULL);
-	if (ctx == NULL)
-		return EXIT_FAILURE;
+	TS_ASSERT(ctx != NULL);
 
 	for (size_t i = 0; i < ARRAY_SIZE(mod_name); i++) {
 		struct kmod_list *list = NULL;
@@ -35,20 +34,12 @@ static int test_weakdep(void)
 
 		printf("%s:", mod_name[i]);
 		err = kmod_module_new_from_lookup(ctx, mod_name[i], &list);
-		if (list == NULL || err < 0) {
-			fprintf(stderr, "module %s not found in directory %s\n",
-				mod_name[i], ctx ? kmod_get_dirname(ctx) : "(missing)");
-			return EXIT_FAILURE;
-		}
+		TS_ASSERT(list != NULL && err == 0);
 
 		mod = kmod_module_get_module(list);
 
 		err = kmod_module_get_weakdeps(mod, &mod_list);
-		if (err) {
-			fprintf(stderr, "weak dependencies can not be read for %s (%d)\n",
-				mod_name[i], err);
-			return EXIT_FAILURE;
-		}
+		TS_ASSERT(err == 0);
 
 		kmod_list_foreach(itr, mod_list) {
 			struct kmod_module *weakdep_mod = kmod_module_get_module(itr);

--- a/testsuite/test-weakdep.c
+++ b/testsuite/test-weakdep.c
@@ -57,7 +57,7 @@ static int test_weakdep(void)
 
 	kmod_unref(ctx);
 
-	return EXIT_SUCCESS;
+	return 0;
 }
 DEFINE_TEST(test_weakdep,
 	.description = "check if libkmod breaks weakdep",

--- a/testsuite/testsuite.c
+++ b/testsuite/testsuite.c
@@ -83,7 +83,10 @@ int test_init(const struct test *start, const struct test *stop, int argc,
 	progname = argv[0];
 
 	/* An empty testsuite is not likely intended */
-	assert_return(start != stop, -EINVAL);
+	if (start == stop) {
+		ERR("Empty testsuite found. Did the compiler toolchain discard them?\n");
+		return -EINVAL;
+	}
 
 	for (;;) {
 		int c, idx = 0;

--- a/testsuite/testsuite.h
+++ b/testsuite/testsuite.h
@@ -119,8 +119,6 @@ int test_run(const struct test *t);
 #define WARN(fmt, ...) _LOG("WARN: ", fmt, ##__VA_ARGS__)
 #define ERR(fmt, ...) _LOG("ERR: ", fmt, ##__VA_ARGS__)
 
-#define assert_return(expr, r) TS_ASSERT(expr)
-
 #define TS_ASSERT(expr)                                                         \
 	do {                                                                    \
 		if ((!(expr))) {                                                \

--- a/testsuite/testsuite.h
+++ b/testsuite/testsuite.h
@@ -119,12 +119,14 @@ int test_run(const struct test *t);
 #define WARN(fmt, ...) _LOG("WARN: ", fmt, ##__VA_ARGS__)
 #define ERR(fmt, ...) _LOG("ERR: ", fmt, ##__VA_ARGS__)
 
-#define assert_return(expr, r)                                                  \
+#define assert_return(expr, r) TS_ASSERT(expr)
+
+#define TS_ASSERT(expr)                                                         \
 	do {                                                                    \
 		if ((!(expr))) {                                                \
-			ERR("Failed assertion: " #expr " %s:%d %s\n", __FILE__, \
-			    __LINE__, __PRETTY_FUNCTION__);                     \
-			return (r);                                             \
+			ERR("ASSERTION FAILED at %s:%d\n", __FILE__, __LINE__); \
+			ERR("\t" #expr "\n");                                   \
+			return EXIT_FAILURE;                                    \
 		}                                                               \
 	} while (false)
 


### PR DESCRIPTION
From the commit introducing it:

```
    The current assert_return() macro has a few short comings:
     - the name implies assert()
     - all users unnecessarily provide EXIT_FAILURE
     - the users cannot provide a message - "Failed assertion:" isn't great

    Tweak it up and in the process bump it to ALL_CAPS, to better indicate
    that it's a macro and not a function.
```

... and the follow-up commit:

```
    Swap the manual checks for the new OK() macro. In the process, we remove
    the cleanup in the error path.

    Many other tests don't bother, plus in the places that do try they don't
    always get it right/fully.
```

Before going forward and porting more tests, would be great to hear if the direction is right.

If* it is, a couple of questions:
 - would people prefer different name - OK one is based on wine, but I'm not married to it ;-)
 - how to handle the conversion - one test at a time, bulk (all assert_return -> OK, all manual -> OK), other?