### PR TITLE
testsuite/test-modprobe: reinstate chdir error path

### DIFF
--- a/testsuite/test-modprobe.c
+++ b/testsuite/test-modprobe.c
@@ -395,6 +395,7 @@ static int modprobe_module_from_relpath(void)
 {
 	if (chdir("/home/foo") != 0) {
 		perror("failed to change into /home/foo");
+		return EXIT_FAILURE;
 	}
 
 	return EXEC_TOOL(modprobe, "./mod-simple.ko");


### PR DESCRIPTION
Earlier commit used a global sed to remove the no-longer needed exit(EXIT_FAILURE) calls. In the process it also removed one instance in the error path, which should remain.

Fixes: e09acf2e ("testsuite: remove exit from EXEC_TOOL tests")