### PR TITLE
Remove assert() instances from libkmod

### DIFF
--- a/libkmod/libkmod-elf.c
+++ b/libkmod/libkmod-elf.c
@@ -3,7 +3,6 @@
  * Copyright (C) 2011-2013  ProFUSION embedded systems
  */
 
-#include <assert.h>
 #include <elf.h>
 #include <endian.h>
 #include <limits.h>
@@ -146,8 +145,6 @@ static inline uint64_t elf_get_uint(const struct kmod_elf *elf, uint64_t offset,
 	const uint8_t *p;
 	uint64_t ret = 0;
 
-	assert(size <= sizeof(uint64_t));
-
 	p = elf->memory + offset;
 
 	if (elf->msb) {
@@ -173,8 +170,6 @@ static inline int elf_set_uint(const struct kmod_elf *elf, uint64_t offset, uint
 	ELFDBG(elf,
 	       "size=%" PRIu64 " offset=%" PRIu64 " value=%" PRIu64 " write memory=%p\n",
 	       size, offset, value, changed);
-
-	assert(size <= sizeof(uint64_t));
 
 	p = changed + offset;
 	if (elf->msb) {
@@ -204,8 +199,6 @@ static inline const void *elf_get_mem(const struct kmod_elf *elf, uint64_t offse
 static inline uint64_t elf_get_section_header_offset(const struct kmod_elf *elf,
 						     uint16_t idx)
 {
-	assert(idx != SHN_UNDEF);
-	assert(idx < elf->header.section.count);
 	if (idx == SHN_UNDEF || idx >= elf->header.section.count) {
 		ELFDBG(elf, "invalid section number: %" PRIu16 ", last=%" PRIu16 "\n",
 		       idx, elf->header.section.count);
@@ -661,8 +654,6 @@ int kmod_elf_strip(const struct kmod_elf *elf, unsigned int flags, const void **
 {
 	uint8_t *changed;
 	int err = 0;
-
-	assert(flags & (KMOD_INSERT_FORCE_MODVERSION | KMOD_INSERT_FORCE_VERMAGIC));
 
 	changed = memdup(elf->memory, elf->size);
 	if (changed == NULL)

--- a/libkmod/libkmod-index.c
+++ b/libkmod/libkmod-index.c
@@ -6,7 +6,6 @@
 #include <sys/param.h>
 
 #include <arpa/inet.h>
-#include <assert.h>
 #include <errno.h>
 #include <fnmatch.h>
 #include <inttypes.h>
@@ -751,8 +750,6 @@ int index_mm_open(const struct kmod_ctx *ctx, const char *filename,
 		uint32_t root_offset;
 	} hdr;
 	const void *p;
-
-	assert(pidx != NULL);
 
 	DBG(ctx, "file=%s\n", filename);
 

--- a/libkmod/libkmod-index.h
+++ b/libkmod/libkmod-index.h
@@ -26,8 +26,8 @@ void index_values_free(struct index_value *values);
 
 /* Implementation using mmap */
 struct index_mm;
-int index_mm_open(const struct kmod_ctx *ctx, const char *filename,
-		  unsigned long long *stamp, struct index_mm **pidx);
+_nonnull_all_ int index_mm_open(const struct kmod_ctx *ctx, const char *filename,
+				unsigned long long *stamp, struct index_mm **pidx);
 void index_mm_close(struct index_mm *index);
 char *index_mm_search(const struct index_mm *idx, const char *key);
 struct index_value *index_mm_searchwild(const struct index_mm *idx, const char *key);

--- a/libkmod/libkmod-module.c
+++ b/libkmod/libkmod-module.c
@@ -978,9 +978,6 @@ static int kmod_module_get_probe_list(struct kmod_module *mod, bool ignorecmd,
 {
 	int err;
 
-	assert(mod != NULL);
-	assert(list != NULL && *list == NULL);
-
 	/*
 	 * Make sure we don't get screwed by previous calls to this function
 	 */

--- a/libkmod/libkmod-module.c
+++ b/libkmod/libkmod-module.c
@@ -1243,11 +1243,8 @@ KMOD_EXPORT int kmod_module_get_softdeps(const struct kmod_module *mod,
 	const struct kmod_list *l;
 	const struct kmod_config *config;
 
-	if (mod == NULL || pre == NULL || post == NULL)
+	if (mod == NULL || pre == NULL || *pre != NULL || post == NULL || *post != NULL)
 		return -ENOENT;
-
-	assert(*pre == NULL);
-	assert(*post == NULL);
 
 	config = kmod_get_config(mod->ctx);
 
@@ -1280,10 +1277,8 @@ KMOD_EXPORT int kmod_module_get_weakdeps(const struct kmod_module *mod,
 	const struct kmod_list *l;
 	const struct kmod_config *config;
 
-	if (mod == NULL || weak == NULL)
+	if (mod == NULL || weak == NULL || *weak != NULL)
 		return -ENOENT;
-
-	assert(*weak == NULL);
 
 	config = kmod_get_config(mod->ctx);
 
@@ -1858,10 +1853,8 @@ KMOD_EXPORT int kmod_module_get_info(const struct kmod_module *mod,
 	int i, count, ret = -ENOMEM;
 	struct kmod_signature_info sig_info = {};
 
-	if (mod == NULL || list == NULL)
+	if (mod == NULL || list == NULL || *list != NULL)
 		return -ENOENT;
-
-	assert(*list == NULL);
 
 	/* remove const: this can only change internal state */
 	if (kmod_module_is_builtin((struct kmod_module *)mod)) {
@@ -2013,10 +2006,8 @@ KMOD_EXPORT int kmod_module_get_versions(const struct kmod_module *mod,
 	struct kmod_modversion *versions;
 	int i, count, ret = 0;
 
-	if (mod == NULL || list == NULL)
+	if (mod == NULL || list == NULL || *list != NULL)
 		return -ENOENT;
-
-	assert(*list == NULL);
 
 	ret = kmod_module_get_elf(mod, &elf);
 	if (ret)
@@ -2114,10 +2105,8 @@ KMOD_EXPORT int kmod_module_get_symbols(const struct kmod_module *mod,
 	struct kmod_modversion *symbols;
 	int i, count, ret = 0;
 
-	if (mod == NULL || list == NULL)
+	if (mod == NULL || list == NULL || *list != NULL)
 		return -ENOENT;
-
-	assert(*list == NULL);
 
 	ret = kmod_module_get_elf(mod, &elf);
 	if (ret)
@@ -2220,10 +2209,8 @@ KMOD_EXPORT int kmod_module_get_dependency_symbols(const struct kmod_module *mod
 	struct kmod_modversion *symbols;
 	int i, count, ret = 0;
 
-	if (mod == NULL || list == NULL)
+	if (mod == NULL || list == NULL || *list != NULL)
 		return -ENOENT;
-
-	assert(*list == NULL);
 
 	ret = kmod_module_get_elf(mod, &elf);
 	if (ret)

--- a/libkmod/libkmod-module.c
+++ b/libkmod/libkmod-module.c
@@ -3,7 +3,6 @@
  * Copyright (C) 2011-2013  ProFUSION embedded systems
  */
 
-#include <assert.h>
 #include <ctype.h>
 #include <dirent.h>
 #include <errno.h>
@@ -117,7 +116,7 @@ void kmod_module_parse_depline(struct kmod_module *mod, char *line)
 
 	if (mod->init.dep)
 		return;
-	assert(mod->dep == NULL);
+
 	mod->init.dep = true;
 
 	p = strchr(line, ':');

--- a/libkmod/libkmod-module.c
+++ b/libkmod/libkmod-module.c
@@ -805,16 +805,13 @@ struct probe_insert_cb {
 	void *data;
 };
 
-static int module_do_install_commands(struct kmod_module *mod, const char *options,
-				      struct probe_insert_cb *cb)
+static int module_do_install_commands(struct kmod_module *mod, const char *command,
+				      const char *options, struct probe_insert_cb *cb)
 {
-	const char *command = kmod_module_get_install_commands(mod);
 	char *p;
 	_cleanup_free_ char *cmd;
 	int err;
 	size_t cmdlen, options_len, varlen;
-
-	assert(command);
 
 	if (options == NULL)
 		options = "";
@@ -1073,7 +1070,7 @@ KMOD_EXPORT int kmod_module_probe_insert_module(
 				print_action(m, true, options ?: "");
 
 			if (!(flags & KMOD_PROBE_DRY_RUN))
-				err = module_do_install_commands(m, options, &cb);
+				err = module_do_install_commands(m, cmd, options, &cb);
 		} else {
 			if (print_action != NULL)
 				print_action(m, false, options ?: "");

--- a/libkmod/libkmod.c
+++ b/libkmod/libkmod.c
@@ -3,7 +3,6 @@
  * Copyright (C) 2011-2013  ProFUSION embedded systems
  */
 
-#include <assert.h>
 #include <ctype.h>
 #include <errno.h>
 #include <fnmatch.h>
@@ -359,8 +358,6 @@ static int kmod_lookup_alias_from_alias_bin(struct kmod_ctx *ctx,
 	struct index_file *idx;
 	struct index_value *realnames, *realname;
 
-	assert(*list == NULL);
-
 	if (ctx->indexes[index_number] != NULL) {
 		DBG(ctx, "use mmapped index '%s' for name=%s\n",
 		    index_files[index_number].fn, name);
@@ -485,8 +482,6 @@ int kmod_lookup_alias_from_kernel_builtin_file(struct kmod_ctx *ctx, const char 
 int kmod_lookup_alias_from_builtin_file(struct kmod_ctx *ctx, const char *name,
 					struct kmod_list **list)
 {
-	assert(*list == NULL);
-
 	if (lookup_builtin_file(ctx, name)) {
 		struct kmod_module *mod;
 		struct kmod_list *node;
@@ -529,8 +524,6 @@ int kmod_lookup_alias_from_moddep_file(struct kmod_ctx *ctx, const char *name,
 {
 	char *line;
 	int n = 0;
-
-	assert(*list == NULL);
 
 	/*
 	 * Module names do not contain ':'. Return early if we know it will
@@ -575,8 +568,6 @@ int kmod_lookup_alias_from_config(struct kmod_ctx *ctx, const char *name,
 	struct kmod_list *l;
 	int err, nmatch = 0;
 
-	assert(*list == NULL);
-
 	kmod_list_foreach(l, config->aliases) {
 		const char *aliasname = kmod_alias_get_name(l);
 		const char *modname = kmod_alias_get_modname(l);
@@ -618,8 +609,6 @@ int kmod_lookup_alias_from_commands(struct kmod_ctx *ctx, const char *name,
 	struct kmod_config *config = ctx->config;
 	struct kmod_list *l, *node;
 	int err, nmatch = 0;
-
-	assert(*list == NULL);
 
 	kmod_list_foreach(l, config->install_commands) {
 		const char *modname = kmod_command_get_modname(l);

--- a/meson.build
+++ b/meson.build
@@ -78,7 +78,6 @@ foreach tuple : _decls
   cdata.set10('HAVE_DECL_@0@'.format(decl.to_upper()), have)
 endforeach
 
-cdata.set10('HAVE_STATIC_ASSERT', cc.compiles('_Static_assert(1, "Test");', name : '_Static_assert'))
 cdata.set10('HAVE_NORETURN', cc.compiles('#include <stdlib.h>; _Noreturn int foo(void) { exit(0); }', name : '_Noreturn'))
 
 ################################################################################

--- a/shared/array.c
+++ b/shared/array.c
@@ -3,7 +3,6 @@
  * Copyright (C) 2011-2013  ProFUSION embedded systems
  */
 
-#include <assert.h>
 #include <errno.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -39,7 +38,6 @@ static void array_trim(struct array *array)
 
 void array_init(struct array *array, size_t step)
 {
-	assert(step > 0);
 	array->array = NULL;
 	array->count = 0;
 	array->total = 0;

--- a/shared/macro.h
+++ b/shared/macro.h
@@ -4,16 +4,10 @@
  */
 #pragma once
 
+#include <assert.h>
 #include <stddef.h>
 
-#if HAVE_STATIC_ASSERT
-#define assert_cc(expr) _Static_assert((expr), #expr)
-#else
-#define assert_cc(expr)                              \
-	do {                                         \
-		(void)sizeof(char[1 - 2 * !(expr)]); \
-	} while (0)
-#endif
+#define assert_cc(expr) static_assert((expr), #expr)
 
 #define check_types_match(expr1, expr2) ((typeof(expr1) *)0 != (typeof(expr2) *)0)
 

--- a/shared/strbuf.c
+++ b/shared/strbuf.c
@@ -4,7 +4,6 @@
  * Copyright (C) 2014  Intel Corporation. All rights reserved.
  */
 
-#include <assert.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
@@ -97,19 +96,16 @@ size_t strbuf_pushmem(struct strbuf *buf, const char *src, size_t sz)
 
 void strbuf_popchar(struct strbuf *buf)
 {
-	assert(buf->used > 0);
 	buf->used--;
 }
 
 void strbuf_popchars(struct strbuf *buf, size_t n)
 {
-	assert(buf->used >= n);
 	buf->used -= n;
 }
 
 void strbuf_shrink_to(struct strbuf *buf, size_t sz)
 {
-	assert(buf->used >= sz);
 	buf->used = sz;
 }
 

--- a/shared/strbuf.c
+++ b/shared/strbuf.c
@@ -83,9 +83,6 @@ bool strbuf_pushchar(struct strbuf *buf, char ch)
 
 size_t strbuf_pushmem(struct strbuf *buf, const char *src, size_t sz)
 {
-	assert(src != NULL);
-	assert(buf != NULL);
-
 	if (sz == 0)
 		return 0;
 

--- a/shared/strbuf.h
+++ b/shared/strbuf.h
@@ -51,7 +51,7 @@ void strbuf_clear(struct strbuf *buf);
 const char *strbuf_str(struct strbuf *buf);
 
 bool strbuf_pushchar(struct strbuf *buf, char ch);
-size_t strbuf_pushmem(struct strbuf *buf, const char *src, size_t sz);
+_nonnull_all_ size_t strbuf_pushmem(struct strbuf *buf, const char *src, size_t sz);
 static inline size_t strbuf_pushchars(struct strbuf *buf, const char *str)
 {
 	return strbuf_pushmem(buf, str, strlen(str));

--- a/shared/util.c
+++ b/shared/util.c
@@ -5,7 +5,6 @@
  * Copyright (C) 2013-2014  Intel Corporation. All rights reserved.
  */
 
-#include <assert.h>
 #include <ctype.h>
 #include <dlfcn.h>
 #include <errno.h>

--- a/testsuite/delete_module.c
+++ b/testsuite/delete_module.c
@@ -3,7 +3,6 @@
  * Copyright (C) 2012-2013  ProFUSION embedded systems
  */
 
-#include <assert.h>
 #include <dirent.h>
 #include <dlfcn.h>
 #include <errno.h>

--- a/testsuite/path.c
+++ b/testsuite/path.c
@@ -8,7 +8,6 @@
 #undef _FILE_OFFSET_BITS
 #undef _TIME_BITS
 
-#include <assert.h>
 #include <dirent.h>
 #include <dlfcn.h>
 #include <errno.h>

--- a/testsuite/test-strbuf.c
+++ b/testsuite/test-strbuf.c
@@ -187,19 +187,4 @@ static int test_strbuf_shrink_to(void)
 }
 DEFINE_TEST(test_strbuf_shrink_to, .description = "test strbuf_shrink_to");
 
-static int xfail_strbuf_shrink_to(void)
-{
-	_cleanup_strbuf_ struct strbuf buf;
-
-	strbuf_init(&buf);
-	strbuf_pushchar(&buf, '/');
-
-	/* This should crash on assert */
-	strbuf_shrink_to(&buf, 2);
-
-	return 0;
-}
-DEFINE_TEST(xfail_strbuf_shrink_to, .description = "xfail strbuf_shrink_to",
-	    .expected_fail = true);
-
 TESTSUITE_MAIN();

--- a/tools/modprobe.c
+++ b/tools/modprobe.c
@@ -5,7 +5,6 @@
  * Copyright (C) 2011-2013  ProFUSION embedded systems
  */
 
-#include <assert.h>
 #include <errno.h>
 #include <getopt.h>
 #include <limits.h>


### PR DESCRIPTION
As mentioned in https://github.com/kmod-project/kmod/issues/255, ideally we shouldn't be having `assert()` in a shared library.

This series removes them, leaving the ones in depmod as-is. Most instances are unreachable and error handling is added otherwise. Where possible, call sites are annotated as `_nonnull_` so the compiler flags future issues.

As a final cleanup, our `assert_cc` macro becomes a wrapper around the C11 `static_assert` (should we nuke our wrapper?) and header inclusions are purged.