### PR TITLE
ci: re-enable 32bit tests 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,18 +37,20 @@ jobs:
           - container: 'debian:unstable'
           - container: 'fedora:latest'
             only_bits: '64'
+          - container: 'ubuntu:22.04'
+          - container: 'ubuntu:24.04'
+
+          # Special configurations
+
+          # Variants with different compression options
           - container: 'fedora:latest'
             meson_setup: '-Dxz=disabled -Ddlopen=all'
             only_bits: '64'
             custom: 'no-xz-dlopen-all'
           - container: 'ubuntu:22.04'
-          - container: 'ubuntu:22.04'
             meson_setup: '-Ddlopen=zstd,zlib'
             only_bits: '64'
             custom: 'dlopen-zstd-zlib'
-          - container: 'ubuntu:24.04'
-
-          # Special configurations
 
           # Variant with lld as linker
           - container: 'archlinux:multilib-devel'


### PR DESCRIPTION
Inspired by recent news about distributions, looking at dropping 32bit/i686 support, I thought here's no need to yak shave this any more. From the first commit:

```
    Currently running 32bit tests alongside sanitizers, segfaults due to our
    syscall wrapper. Just disable the sanitizers, which means we get at
    least some 32bit test coverage.
    
    On a couple of attempts, I wasn't able to get a proper/robust solution,
    as outlined in init_module.c - we need vsyscall() which does not exist.
    
    Considering some distributions are dropping 32bit/i686 support, it may
    be that we'll nuke these builds from CI sooner than later.
```

Also had a go at fixing/enabling the clang build on Debian/bullseye, although the sanitizer is flagging a [global-buffer-overflow](https://github.com/evelikov/kmod/actions/runs/15695039963/job/44218382934), which I suspect is a side effect of partial `__attribute__((aligned(8)))` support.