### PR TITLE
testsuite: Fix build warning on kernel 6.15

### DIFF
--- a/testsuite/module-playground/mod-fake-cciss.c
+++ b/testsuite/module-playground/mod-fake-cciss.c
@@ -14,6 +14,7 @@ module_exit(test_module_exit);
 
 MODULE_AUTHOR("Lucas De Marchi <lucas.demarchi@intel.com>");
 MODULE_LICENSE("LGPL");
+MODULE_DESCRIPTION("dummy test module");
 
 MODULE_ALIAS("pci:v00000E11d0000B060sv00000E11sd00004070bc*sc*i*");
 MODULE_ALIAS("pci:v00000E11d0000B178sv00000E11sd00004080bc*sc*i*");

--- a/testsuite/module-playground/mod-fake-hpsa.c
+++ b/testsuite/module-playground/mod-fake-hpsa.c
@@ -17,6 +17,7 @@ module_exit(test_module_exit);
 
 MODULE_AUTHOR("Lucas De Marchi <lucas.demarchi@intel.com>");
 MODULE_LICENSE("LGPL");
+MODULE_DESCRIPTION("dummy test module");
 
 MODULE_ALIAS("pci:v0000103Cd0000323Asv0000103Csd00003241bc*sc*i*");
 MODULE_ALIAS("pci:v0000103Cd0000323Asv0000103Csd00003243bc*sc*i*");

--- a/testsuite/module-playground/mod-fake-scsi-mod.c
+++ b/testsuite/module-playground/mod-fake-scsi-mod.c
@@ -21,3 +21,4 @@ EXPORT_SYMBOL(dummy_export);
 
 MODULE_AUTHOR("Lucas De Marchi <lucas.demarchi@intel.com>");
 MODULE_LICENSE("LGPL");
+MODULE_DESCRIPTION("dummy test module");

--- a/testsuite/module-playground/mod-foo-a.c
+++ b/testsuite/module-playground/mod-foo-a.c
@@ -18,3 +18,4 @@ EXPORT_SYMBOL(print_fooA);
 
 MODULE_AUTHOR("Lucas De Marchi <lucas.demarchi@intel.com>");
 MODULE_LICENSE("LGPL");
+MODULE_DESCRIPTION("dummy test module");

--- a/testsuite/module-playground/mod-foo-b.c
+++ b/testsuite/module-playground/mod-foo-b.c
@@ -18,3 +18,4 @@ EXPORT_SYMBOL(print_fooB);
 
 MODULE_AUTHOR("Lucas De Marchi <lucas.demarchi@intel.com>");
 MODULE_LICENSE("LGPL");
+MODULE_DESCRIPTION("dummy test module");

--- a/testsuite/module-playground/mod-foo-c.c
+++ b/testsuite/module-playground/mod-foo-c.c
@@ -18,3 +18,4 @@ EXPORT_SYMBOL(print_fooC);
 
 MODULE_AUTHOR("Lucas De Marchi <lucas.demarchi@intel.com>");
 MODULE_LICENSE("LGPL");
+MODULE_DESCRIPTION("dummy test module");

--- a/testsuite/module-playground/mod-foo.c
+++ b/testsuite/module-playground/mod-foo.c
@@ -19,3 +19,4 @@ module_init(foo_init);
 
 MODULE_AUTHOR("Lucas De Marchi <lucas.demarchi@intel.com>");
 MODULE_LICENSE("LGPL");
+MODULE_DESCRIPTION("dummy test module");

--- a/testsuite/module-playground/mod-loop-a.c
+++ b/testsuite/module-playground/mod-loop-a.c
@@ -23,3 +23,4 @@ EXPORT_SYMBOL(printA);
 
 MODULE_AUTHOR("Lucas De Marchi <lucas.demarchi@intel.com>");
 MODULE_LICENSE("LGPL");
+MODULE_DESCRIPTION("dummy test module");

--- a/testsuite/module-playground/mod-loop-b.c
+++ b/testsuite/module-playground/mod-loop-b.c
@@ -23,3 +23,4 @@ EXPORT_SYMBOL(printB);
 
 MODULE_AUTHOR("Lucas De Marchi <lucas.demarchi@intel.com>");
 MODULE_LICENSE("LGPL");
+MODULE_DESCRIPTION("dummy test module");

--- a/testsuite/module-playground/mod-loop-c.c
+++ b/testsuite/module-playground/mod-loop-c.c
@@ -21,3 +21,4 @@ EXPORT_SYMBOL(printC);
 
 MODULE_AUTHOR("Lucas De Marchi <lucas.demarchi@intel.com>");
 MODULE_LICENSE("LGPL");
+MODULE_DESCRIPTION("dummy test module");

--- a/testsuite/module-playground/mod-loop-d.c
+++ b/testsuite/module-playground/mod-loop-d.c
@@ -21,3 +21,4 @@ EXPORT_SYMBOL(printD);
 
 MODULE_AUTHOR("Lucas De Marchi <lucas.demarchi@intel.com>");
 MODULE_LICENSE("LGPL");
+MODULE_DESCRIPTION("dummy test module");

--- a/testsuite/module-playground/mod-loop-e.c
+++ b/testsuite/module-playground/mod-loop-e.c
@@ -21,3 +21,4 @@ EXPORT_SYMBOL(printE);
 
 MODULE_AUTHOR("Lucas De Marchi <lucas.demarchi@intel.com>");
 MODULE_LICENSE("LGPL");
+MODULE_DESCRIPTION("dummy test module");

--- a/testsuite/module-playground/mod-loop-f.c
+++ b/testsuite/module-playground/mod-loop-f.c
@@ -20,3 +20,4 @@ EXPORT_SYMBOL(printF);
 
 MODULE_AUTHOR("Lucas De Marchi <lucas.demarchi@intel.com>");
 MODULE_LICENSE("LGPL");
+MODULE_DESCRIPTION("dummy test module");

--- a/testsuite/module-playground/mod-loop-g.c
+++ b/testsuite/module-playground/mod-loop-g.c
@@ -20,3 +20,4 @@ EXPORT_SYMBOL(printG);
 
 MODULE_AUTHOR("Lucas De Marchi <lucas.demarchi@intel.com>");
 MODULE_LICENSE("LGPL");
+MODULE_DESCRIPTION("dummy test module");

--- a/testsuite/module-playground/mod-loop-h.c
+++ b/testsuite/module-playground/mod-loop-h.c
@@ -21,3 +21,4 @@ EXPORT_SYMBOL(printH);
 
 MODULE_AUTHOR("Lucas De Marchi <lucas.demarchi@intel.com>");
 MODULE_LICENSE("LGPL");
+MODULE_DESCRIPTION("dummy test module");

--- a/testsuite/module-playground/mod-loop-i.c
+++ b/testsuite/module-playground/mod-loop-i.c
@@ -21,3 +21,4 @@ EXPORT_SYMBOL(printI);
 
 MODULE_AUTHOR("Lucas De Marchi <lucas.demarchi@intel.com>");
 MODULE_LICENSE("LGPL");
+MODULE_DESCRIPTION("dummy test module");

--- a/testsuite/module-playground/mod-loop-j.c
+++ b/testsuite/module-playground/mod-loop-j.c
@@ -22,3 +22,4 @@ EXPORT_SYMBOL(printJ);
 
 MODULE_AUTHOR("Lucas De Marchi <lucas.demarchi@intel.com>");
 MODULE_LICENSE("LGPL");
+MODULE_DESCRIPTION("dummy test module");

--- a/testsuite/module-playground/mod-loop-k.c
+++ b/testsuite/module-playground/mod-loop-k.c
@@ -21,3 +21,4 @@ EXPORT_SYMBOL(printK);
 
 MODULE_AUTHOR("Lucas De Marchi <lucas.demarchi@intel.com>");
 MODULE_LICENSE("LGPL");
+MODULE_DESCRIPTION("dummy test module");

--- a/testsuite/module-playground/mod-simple.c
+++ b/testsuite/module-playground/mod-simple.c
@@ -30,3 +30,4 @@ module_exit(test_module_exit);
 
 MODULE_AUTHOR("Lucas De Marchi <lucas.demarchi@intel.com>");
 MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("dummy test module");

--- a/testsuite/module-playground/mod-softdep-a.c
+++ b/testsuite/module-playground/mod-softdep-a.c
@@ -13,3 +13,4 @@ module_init(softdep_init);
 
 MODULE_AUTHOR("Dan He <dan.h.he@intel.com>");
 MODULE_LICENSE("LGPL");
+MODULE_DESCRIPTION("dummy test module");

--- a/testsuite/module-playground/mod-softdep-b.c
+++ b/testsuite/module-playground/mod-softdep-b.c
@@ -13,3 +13,4 @@ module_init(softdep_init);
 
 MODULE_AUTHOR("Dan He <dan.h.he@intel.com>");
 MODULE_LICENSE("LGPL");
+MODULE_DESCRIPTION("dummy test module");

--- a/testsuite/module-playground/mod-weakdep.c
+++ b/testsuite/module-playground/mod-weakdep.c
@@ -14,4 +14,5 @@ module_init(weakdep_init);
 
 MODULE_AUTHOR("Jose Ignacio Tornos Martinez <jtornosm@redhat.com>");
 MODULE_LICENSE("LGPL");
+MODULE_DESCRIPTION("dummy test module");
 MODULE_WEAKDEP("mod-simple");

--- a/testsuite/rootfs-pristine/test-modinfo/correct-description.txt
+++ b/testsuite/rootfs-pristine/test-modinfo/correct-description.txt
@@ -1,0 +1,1 @@
+dummy test module


### PR DESCRIPTION
The module description is now required, otherwise a warning is emitted by modpost:

	WARNING: modpost: missing MODULE_DESCRIPTION() in mod-loop-k.o

Fix all of them with:

	sed -i '/MODULE_LICENSE("LGPL");/a MODULE_DESCRIPTION("dummy test module");' testsuite/module-playground/mod-*.c
	sed -i '/MODULE_LICENSE("GPL");/a MODULE_DESCRIPTION("dummy test module");' testsuite/module-playground/mod-simple.c