### PR TITLE
testsuite: Fix build with gcc < 15

### DIFF
--- a/testsuite/init_module.c
+++ b/testsuite/init_module.c
@@ -339,7 +339,7 @@ TS_EXPORT long int syscall(long int __sysno, ...)
 #endif
 		errno = ENOSYS;
 		return -1;
-	case __NR_finit_module:
+	case __NR_finit_module:;
 		const char *args;
 		int flags;
 		int fd;
@@ -354,7 +354,7 @@ TS_EXPORT long int syscall(long int __sysno, ...)
 
 		va_end(ap);
 		return ret;
-	case __NR_gettid:
+	case __NR_gettid:;
 		static long (*nextlib_syscall)(long number, ...);
 
 		if (nextlib_syscall == NULL) {


### PR DESCRIPTION
Variable declaration inside a switch case works with gcc 15, but fails pretty much everywhere else with a message like below:

	../testsuite/init_module.c: In function ‘syscall’:
	../testsuite/init_module.c:343:3: error: a label can only be part of a statement and a declaration is not a statement
	  343 |   const char *args;
	      |   ^~~~~

Add an empty statement to fix it.