### PR TITLE
ci: swap bullseye for bookworm

### DIFF
--- a/.github/actions/setup-os/setup-debian.sh
+++ b/.github/actions/setup-os/setup-debian.sh
@@ -6,15 +6,6 @@
 
 export DEBIAN_FRONTEND=noninteractive
 export TZ=Etc/UTC
-
-. /etc/os-release
-
-backports_pkgs=()
-if [[ "$VERSION_CODENAME" == "bullseye" ]]; then
-    echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
-    backports_pkgs=("meson" "ninja-build")
-fi
-
 apt-get update
 apt-get install --yes \
     bash \
@@ -31,7 +22,3 @@ apt-get install --yes \
     scdoc \
     zlib1g-dev \
     zstd
-
-if (( ${#backports_pkgs[@]} )); then
-    apt-get install --yes -t "${VERSION_CODENAME}"-backports "${backports_pkgs[@]}"
-fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
             meson_setup: '-Db_sanitize=none'
             only_bits: '64'
           - container: 'archlinux:multilib-devel'
-          - container: 'debian:bullseye-slim'
+          - container: 'debian:bookworm-slim'
             meson_setup: '-Dzstd=disabled -Dxz=disabled -Dzlib=disabled'
             only_compiler: 'gcc'
           - container: 'debian:unstable'


### PR DESCRIPTION
The former has been EOL for a bit now and somewhat recently has been (re)moved from the repos -> our CI was failing.

Swap for bookworm, which gives us the "try a slightly older distro" coverage, while still being green in CI.