### PR TITLE
libkmod: Fix open file which some char device

### DIFF
--- a/libkmod/libkmod-file.c
+++ b/libkmod/libkmod-file.c
@@ -96,6 +96,13 @@ int kmod_file_open(const struct kmod_ctx *ctx, const char *filename,
 	if (file->fd < 0)
 		return -errno;
 
+	/*
+	 * Bail out if underlying fd is not seekable  - that is not supported
+	 */
+	ret = lseek(file->fd, 0, SEEK_CUR);
+	if (ret < 0)
+		return ret;
+
 	sz = pread_str_safe(file->fd, buf, sizeof(buf), 0);
 	if (sz != (sizeof(buf) - 1)) {
 		if (sz < 0)


### PR DESCRIPTION
use lseek SEEK_CUR to get whether it is a regular file, lseek return -ESPIPE when fd is associated with a pipe, socket, or FIFO.

commit 883d931d1bd04b089b85b554d1df6f41dcf5fbf5 upstream ("modprobe: Allow passing path to module") allow to modprobe a file, but not handle opening a FIFO device such as modprobe /dev/tty1.

commit 8d03b6c7d990af301950d3ecdc4b5c69fa525928 uptream ("libkmod: Use pread where appropriate") fix some cases, such as open /dev/tty1, but not for /dev/vmnet0 or /dev/userio etc.

Can be reproduced in run lshw in root and install some vm such ad vmware, more about the case are in the Link.

Link: https://github.com/lyonel/lshw/pull/110
Link: https://bugs.launchpad.net/ubuntu/+source/lshw/+bug/2069649
Link: https://bbs.deepin.org.cn/post/291466
Reported-by: Qi Xu <xuqi@uniontech.com>
Reported-by: lionheartyu <dongshengyuan@uniontech.com>
Fixes: 883d931d1bd04 ("modprobe: Allow passing path to module")