### PR TITLE
ci: Fix alpine setup

### DIFF
--- a/.github/actions/setup-os/setup-alpine.sh
+++ b/.github/actions/setup-os/setup-alpine.sh
@@ -12,7 +12,7 @@ apk add \
     clang \
     git \
     gtk-doc \
-    linux-edge-dev \
+    linux-stable-dev \
     meson \
     openssl-dev \
     scdoc \


### PR DESCRIPTION
linux-edge-dev is failing in alpine:

	ERROR: unable to select packages:
	  linux-edge-dev (no such package):
	    required by: world[linux-edge-dev]
	Error: Process completed with exit code 1.

Use linux-stable instead.