### PR TITLE
Trivial documentation fixes

### DIFF
--- a/libkmod/libkmod.h
+++ b/libkmod/libkmod.h
@@ -34,7 +34,7 @@ struct kmod_ctx;
 /**
  * kmod_new:
  * @dirname: what to consider as linux module's directory, if NULL
- *           defaults to $MODULE_DIRECTORY/`uname -r`. If it's relative,
+ *           defaults to $MODULE_DIRECTORY/$(uname -r). If it's relative,
  *           it's treated as relative to the current working directory.
  *           Otherwise, give an absolute dirname.
  * @config_paths: ordered array of paths (directories or files) where

--- a/man/modprobe.8.scd
+++ b/man/modprobe.8.scd
@@ -20,7 +20,7 @@ modprobe - Add and remove modules from the Linux Kernel
 *modprobe* intelligently adds or removes a module from the Linux kernel: note
 that for convenience, there is no difference between \_ and - in module names
 (automatic underscore conversion is performed). *modprobe* looks in the module
-directory @MODULE_DIRECTORY@/`uname -r` for all the modules and other files,
+directory @MODULE_DIRECTORY@/$(uname -r) for all the modules and other files,
 except for the optional configuration files (see *modprobe.d*(5)). *modprobe* will
 also use module options specified on the kernel command line in the form of
 <module>.<option> and blacklists in the form of modprobe.blacklist=<module>.

--- a/man/modprobe.8.scd
+++ b/man/modprobe.8.scd
@@ -20,9 +20,9 @@ modprobe - Add and remove modules from the Linux Kernel
 *modprobe* intelligently adds or removes a module from the Linux kernel: note
 that for convenience, there is no difference between \_ and - in module names
 (automatic underscore conversion is performed). *modprobe* looks in the module
-directory @DISTCONFDIR@/`uname -r` for all the modules and other files, except
-for the optional configuration files (see *modprobe.d*(5)). *modprobe* will also
-use module options specified on the kernel command line in the form of
+directory @MODULE_DIRECTORY@/`uname -r` for all the modules and other files,
+except for the optional configuration files (see *modprobe.d*(5)). *modprobe* will
+also use module options specified on the kernel command line in the form of
 <module>.<option> and blacklists in the form of modprobe.blacklist=<module>.
 
 Note that unlike in 2.4 series Linux kernels (which are not supported by this

--- a/testsuite/testsuite.h
+++ b/testsuite/testsuite.h
@@ -22,7 +22,7 @@ enum test_config {
 	TC_ROOTFS = 0,
 
 	/*
-	 * What's the desired string to be returned by `uname -r`. It will
+	 * What's the desired string to be returned by $(uname -r). It will
 	 * trap calls to uname(3P) by LD_PRELOAD'ing uname.so and then filling
 	 * in the information in u.release.
 	 */

--- a/tools/modinfo.c
+++ b/tools/modinfo.c
@@ -336,7 +336,7 @@ static void help(void)
 	       "\t-0, --null                  Use \\0 instead of \\n\n"
 	       "\t-m, --modname               Handle argument as module name instead of alias or filename\n"
 	       "\t-F, --field FIELD           Print only provided FIELD\n"
-	       "\t-k, --set-version VERSION   Use VERSION instead of `uname -r`\n"
+	       "\t-k, --set-version VERSION   Use VERSION instead of $(uname -r)\n"
 	       "\t-b, --basedir DIR           Use DIR as filesystem root for " MODULE_DIRECTORY
 	       "\n"
 	       "\t-V, --version               Show version\n"

--- a/tools/modprobe.c
+++ b/tools/modprobe.c
@@ -128,7 +128,7 @@ static void help(void)
 	       "\t-C, --config FILE           Use FILE instead of default search paths\n"
 	       "\t-d, --dirname DIR           Use DIR as filesystem root for " MODULE_DIRECTORY
 	       "\n"
-	       "\t-S, --set-version VERSION   Use VERSION instead of `uname -r`\n"
+	       "\t-S, --set-version VERSION   Use VERSION instead of $(uname -r)\n"
 
 	       "\t-s, --syslog                print to syslog, not stderr\n"
 	       "\t-q, --quiet                 disable messages\n"


### PR DESCRIPTION
- `s/DISTCONFDIR/MODULE_DIRECTORY/` - silly typo introduced in the scdoc conversion
- ``s/`uname -r`/$(uname -r)/`` - former is deprecated and less widely used in kmod