### PR TITLE
util: Use const variable type in mkdir_parents

### DIFF
--- a/shared/util.c
+++ b/shared/util.c
@@ -467,7 +467,7 @@ int mkdir_p(const char *path, int len, mode_t mode)
 
 int mkdir_parents(const char *path, mode_t mode)
 {
-	char *end = strrchr(path, '/');
+	const char *end = strrchr(path, '/');
 
 	/* no parent directories */
 	if (end == NULL)


### PR DESCRIPTION
For ISO C23, the function strchr that return pointers into their input arrays now have definitions as macros that return a pointer to a const-qualified type when the in put argument is a pointer to a const-qualified type.

fixes:
```c
../shared/util.c: In function 'mkdir_parents':
../shared/util.c:470:21: warning: initialization discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  470 |         char *end = strrchr(path, '/');
      |                     ^~~~~~~
``` 