### PR TITLE
Threaded depmod, take 2

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -444,10 +444,13 @@ if get_option('tools')
     'tools/static-nodes.c',
   )
 
+  pthread_dep = dependency('threads', required : true)
+
   kmod = executable(
     'kmod',
     kmod_sources,
     link_with : [libshared, libkmod_internal],
+    dependencies : pthread_dep,
     gnu_symbol_visibility : 'hidden',
     install : true,
 )

--- a/tools/depmod.c
+++ b/tools/depmod.c
@@ -11,6 +11,7 @@
 #include <errno.h>
 #include <getopt.h>
 #include <limits.h>
+#include <pthread.h>
 #include <regex.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -1597,8 +1598,10 @@ struct module_symbols {
 	struct array symbols; /* struct symbol */
 };
 
-static int resolve_module_symbols(struct module_symbols *mod_syms)
+static void *resolve_module_symbols(void *arg)
 {
+	struct module_symbols *mod_syms = arg;
+
 	array_init(&mod_syms->symbols, 128);
 
 	for (size_t i = 0; i < mod_syms->modules_count; i++) {
@@ -1622,14 +1625,14 @@ static int resolve_module_symbols(struct module_symbols *mod_syms)
 						   mod);
 			if (sym == NULL) {
 				kmod_module_symbols_free_list(list);
-				return -ENOMEM;
+				return (void *)(intptr_t)-ENOMEM;
 			}
 
 			err = array_append(&mod_syms->symbols, sym);
 			if (err < 0) {
 				free(sym);
 				kmod_module_symbols_free_list(list);
-				return -ENOMEM;
+				return (void *)(intptr_t)-ENOMEM;
 			}
 		}
 		kmod_module_symbols_free_list(list);
@@ -1644,7 +1647,7 @@ load_info:
 
 				err = array_append(&mod->alias_values, value);
 				if (err < 0)
-					return err;
+					return (void *)(intptr_t)err;
 				continue;
 			}
 			if (streq(key, "softdep")) {
@@ -1652,7 +1655,7 @@ load_info:
 
 				err = array_append(&mod->softdep_values, value);
 				if (err < 0)
-					return err;
+					return (void *)(intptr_t)err;
 				continue;
 			}
 			if (streq(key, "weakdep")) {
@@ -1660,7 +1663,7 @@ load_info:
 
 				err = array_append(&mod->weakdep_values, value);
 				if (err < 0)
-					return err;
+					return (void *)(intptr_t)err;
 				continue;
 			}
 		}
@@ -1668,30 +1671,93 @@ load_info:
 		kmod_module_unref(mod->kmod);
 		mod->kmod = NULL;
 	}
-	return 0;
+	return (void *)(intptr_t)0;
+}
+
+static unsigned int get_cpu_count(void)
+{
+	long nproc = sysconf(_SC_NPROCESSORS_ONLN);
+	return nproc > 0 ? (unsigned int)nproc : 1;
 }
 
 static int depmod_load_modules(struct depmod *depmod)
 {
-	struct module_symbols mod_syms = {
-		.depmod = depmod,
-		.modules = (struct mod **)depmod->modules.array,
-		.modules_count = depmod->modules.count,
-	};
+	struct thread_info {
+		pthread_t tid;
+		struct module_symbols mod_syms;
+	} *tinfo;
+	unsigned int n_threads;
+	size_t modules_per_thread, last_modules_per_thread;
 	int err;
 
 	DBG("load symbols (%zu modules)\n", depmod->modules.count);
 
-	err = resolve_module_symbols(&mod_syms);
-	if (err < 0)
-		return err;
+	n_threads = get_cpu_count();
+	if (n_threads > depmod->modules.count)
+		n_threads = depmod->modules.count;
 
-	for (size_t i = 0; i < mod_syms.symbols.count; i++) {
-		struct symbol *sym = mod_syms.symbols.array[i];
+	tinfo = calloc(n_threads, sizeof(*tinfo));
+	if (tinfo == NULL)
+		return -ENOMEM;
 
-		depmod_symbol_add(depmod, sym);
+	modules_per_thread = (depmod->modules.count + n_threads - 1) / n_threads;
+	last_modules_per_thread =
+		modules_per_thread - (depmod->modules.count % n_threads);
+
+	for (unsigned int i = 0; i < n_threads; i++) {
+		struct module_symbols *mod_syms = &tinfo[i].mod_syms;
+
+		mod_syms->depmod = depmod;
+		mod_syms->modules =
+			(struct mod **)depmod->modules.array + (i * modules_per_thread);
+		mod_syms->modules_count = modules_per_thread;
+		if (i + 1 == n_threads)
+			mod_syms->modules_count = last_modules_per_thread;
+
+		err = pthread_create(&tinfo[i].tid, NULL, &resolve_module_symbols,
+				     mod_syms);
+		if (err != 0) {
+			err = -err; // Most/all pthread API returns positive error
+			n_threads = i;
+			break;
+		}
 	}
-	array_free_array(&mod_syms.symbols);
+
+	for (unsigned int i = 0; i < n_threads; i++) {
+		int local_err;
+		void *res;
+
+		local_err = pthread_join(tinfo[i].tid, &res);
+		if (err == 0) {
+			if (local_err != 0)
+				err = -local_err;
+			if ((int)(intptr_t)res != 0)
+				err = (int)(intptr_t)res;
+		}
+	}
+
+	if (err != 0) {
+		for (unsigned int i = 0; i < n_threads; i++) {
+			struct module_symbols *mod_syms = &tinfo[i].mod_syms;
+
+			for (size_t j = 0; j < mod_syms->symbols.count; j++)
+				free(mod_syms->symbols.array[j]);
+
+			array_free_array(&mod_syms->symbols);
+		}
+		free(tinfo);
+		return err;
+	}
+
+	for (unsigned int i = 0; i < n_threads; i++) {
+		struct module_symbols *mod_syms = &tinfo[i].mod_syms;
+
+		for (size_t j = 0; j < mod_syms->symbols.count; j++)
+			depmod_symbol_add(depmod, mod_syms->symbols.array[j]);
+
+		array_free_array(&mod_syms->symbols);
+	}
+	free(tinfo);
 
 	DBG("loaded symbols (%zu modules, %u symbols)\n", depmod->modules.count,
 	    hash_get_count(depmod->symbols));

--- a/tools/depmod.c
+++ b/tools/depmod.c
@@ -1548,11 +1548,11 @@ corrupted:
 	fclose(fp);
 }
 
-static int depmod_symbol_add(struct depmod *depmod, const char *name, bool prefix_skipped,
-			     uint64_t crc, const struct mod *owner)
+static struct symbol *depmod_symbol_create(struct depmod *depmod, const char *name,
+					   bool prefix_skipped, uint64_t crc,
+					   const struct mod *owner)
 {
 	size_t namelen;
-	int err;
 	struct symbol *sym;
 
 	if (!prefix_skipped && (name[0] == depmod->cfg->sym_prefix))
@@ -1561,20 +1561,22 @@ static int depmod_symbol_add(struct depmod *depmod, const char *name, bool prefi
 	namelen = strlen(name) + 1;
 	sym = malloc(sizeof(struct symbol) + namelen);
 	if (sym == NULL)
-		return -ENOMEM;
+		return NULL;
 
 	sym->owner = (struct mod *)owner;
 	sym->crc = crc;
 	memcpy(sym->name, name, namelen);
+	return sym;
+}
 
-	err = hash_add(depmod->symbols, sym->name, sym);
-	if (err < 0) {
-		free(sym);
+static int depmod_symbol_add(struct depmod *depmod, struct symbol *sym)
+{
+	int err = hash_add(depmod->symbols, sym->name, sym);
+	if (err < 0)
 		return err;
-	}
 
-	DBG("add %p sym=%s, owner=%p %s\n", sym, sym->name, owner,
-	    owner != NULL ? owner->path : "");
+	DBG("add %p sym=%s, owner=%p %s\n", sym, sym->name, sym->owner,
+	    sym->owner != NULL ? sym->owner->path : "");
 
 	return 0;
 }
@@ -1611,7 +1613,11 @@ static int depmod_load_modules(struct depmod *depmod)
 		kmod_list_foreach(l, list) {
 			const char *name = kmod_module_symbol_get_symbol(l);
 			uint64_t crc = kmod_module_symbol_get_crc(l);
-			depmod_symbol_add(depmod, name, false, crc, mod);
+			struct symbol *sym;
+
+			sym = depmod_symbol_create(depmod, name, false, crc, mod);
+			if (sym)
+				depmod_symbol_add(depmod, sym);
 		}
 		kmod_module_symbols_free_list(list);
 
@@ -2645,13 +2651,24 @@ static int depmod_output(struct depmod *depmod, FILE *out)
 
 static void depmod_add_fake_syms(struct depmod *depmod)
 {
+	struct symbol *sym;
+
 	/* __this_module is magically inserted by kernel loader. */
-	depmod_symbol_add(depmod, "__this_module", true, 0, NULL);
+	sym = depmod_symbol_create(depmod, "__this_module", true, 0, NULL);
+	if (sym)
+		depmod_symbol_add(depmod, sym);
+
 	/* On S390, this is faked up too */
-	depmod_symbol_add(depmod, "_GLOBAL_OFFSET_TABLE_", true, 0, NULL);
+	sym = depmod_symbol_create(depmod, "_GLOBAL_OFFSET_TABLE_", true, 0, NULL);
+	if (sym)
+		depmod_symbol_add(depmod, sym);
+
 	/* On PowerPC64 ABIv2, .TOC. is more or less _GLOBAL_OFFSET_TABLE_ */
-	if (!depmod_symbol_find(depmod, "TOC."))
-		depmod_symbol_add(depmod, "TOC.", true, 0, NULL);
+	if (!depmod_symbol_find(depmod, "TOC.")) {
+		sym = depmod_symbol_create(depmod, "TOC.", true, 0, NULL);
+		if (sym)
+			depmod_symbol_add(depmod, sym);
+	}
 }
 
 static int depmod_load_symvers(struct depmod *depmod, const char *filename)
@@ -2670,6 +2687,7 @@ static int depmod_load_symvers(struct depmod *depmod, const char *filename)
 
 	/* eg. "0xb352177e\tfind_first_bit\tvmlinux\tEXPORT_SYMBOL" */
 	while (fgets(line, sizeof(line), fp) != NULL) {
+		struct symbol *symbol;
 		const char *ver, *sym, *where;
 		char *verend;
 		uint64_t crc;
@@ -2693,7 +2711,9 @@ static int depmod_load_symvers(struct depmod *depmod, const char *filename)
 			continue;
 		}
 
-		depmod_symbol_add(depmod, sym, false, crc, NULL);
+		symbol = depmod_symbol_create(depmod, sym, false, crc, NULL);
+		if (symbol)
+			depmod_symbol_add(depmod, symbol);
 	}
 	depmod_add_fake_syms(depmod);
 
@@ -2721,6 +2741,7 @@ static int depmod_load_system_map(struct depmod *depmod, const char *filename)
 
 	/* eg. c0294200 R __ksymtab_devfs_alloc_devnum */
 	while (fgets(line, sizeof(line), fp) != NULL) {
+		struct symbol *sym;
 		char *p, *end;
 
 		linenum++;
@@ -2746,7 +2767,10 @@ static int depmod_load_system_map(struct depmod *depmod, const char *filename)
 		if (end != NULL)
 			*end = '\0';
 
-		depmod_symbol_add(depmod, p + ksymstr_len, true, 0, NULL);
+		sym = depmod_symbol_create(depmod, p + ksymstr_len, true, 0, NULL);
+		if (sym)
+			depmod_symbol_add(depmod, sym);
+
 		continue;
 
 invalid_syntax:

--- a/tools/depmod.c
+++ b/tools/depmod.c
@@ -1623,22 +1623,25 @@ load_info:
 			if (streq(key, "alias")) {
 				const char *value = kmod_module_info_get_value(l);
 
-				if (array_append(&mod->alias_values, value) < 0)
-					return 0;
+				err = array_append(&mod->alias_values, value);
+				if (err < 0)
+					return err;
 				continue;
 			}
 			if (streq(key, "softdep")) {
 				const char *value = kmod_module_info_get_value(l);
 
-				if (array_append(&mod->softdep_values, value) < 0)
-					return 0;
+				err = array_append(&mod->softdep_values, value);
+				if (err < 0)
+					return err;
 				continue;
 			}
 			if (streq(key, "weakdep")) {
 				const char *value = kmod_module_info_get_value(l);
 
-				if (array_append(&mod->weakdep_values, value) < 0)
-					return 0;
+				err = array_append(&mod->weakdep_values, value);
+				if (err < 0)
+					return err;
 				continue;
 			}
 		}

--- a/tools/depmod.c
+++ b/tools/depmod.c
@@ -1590,16 +1590,19 @@ static struct symbol *depmod_symbol_find(const struct depmod *depmod, const char
 	return hash_find(depmod->symbols, name);
 }
 
-static int depmod_load_modules(struct depmod *depmod)
+struct module_symbols {
+	struct depmod *depmod;
+	struct mod **modules;
+	size_t modules_count;
+	struct array symbols; /* struct symbol */
+};
+
+static int resolve_module_symbols(struct module_symbols *mod_syms)
 {
-	struct mod **itr, **itr_end;
+	array_init(&mod_syms->symbols, 128);
 
-	DBG("load symbols (%zu modules)\n", depmod->modules.count);
-
-	itr = (struct mod **)depmod->modules.array;
-	itr_end = itr + depmod->modules.count;
-	for (; itr < itr_end; itr++) {
-		struct mod *mod = *itr;
+	for (size_t i = 0; i < mod_syms->modules_count; i++) {
+		struct mod *mod = mod_syms->modules[i];
 		struct kmod_list *l, *list = NULL;
 		int err = kmod_module_get_symbols(mod->kmod, &list);
 		if (err < 0) {
@@ -1615,9 +1618,19 @@ static int depmod_load_modules(struct depmod *depmod)
 			uint64_t crc = kmod_module_symbol_get_crc(l);
 			struct symbol *sym;
 
-			sym = depmod_symbol_create(depmod, name, false, crc, mod);
-			if (sym)
-				depmod_symbol_add(depmod, sym);
+			sym = depmod_symbol_create(mod_syms->depmod, name, false, crc,
+						   mod);
+			if (sym == NULL) {
+				kmod_module_symbols_free_list(list);
+				return -ENOMEM;
+			}
+
+			err = array_append(&mod_syms->symbols, sym);
+			if (err < 0) {
+				free(sym);
+				kmod_module_symbols_free_list(list);
+				return -ENOMEM;
+			}
 		}
 		kmod_module_symbols_free_list(list);
 
@@ -1655,6 +1668,30 @@ load_info:
 		kmod_module_unref(mod->kmod);
 		mod->kmod = NULL;
 	}
+	return 0;
+}
+
+static int depmod_load_modules(struct depmod *depmod)
+{
+	struct module_symbols mod_syms = {
+		.depmod = depmod,
+		.modules = (struct mod **)depmod->modules.array,
+		.modules_count = depmod->modules.count,
+	};
+	int err;
+
+	DBG("load symbols (%zu modules)\n", depmod->modules.count);
+
+	err = resolve_module_symbols(&mod_syms);
+	if (err < 0)
+		return err;
+
+	for (size_t i = 0; i < mod_syms.symbols.count; i++) {
+		struct symbol *sym = mod_syms.symbols.array[i];
+
+		depmod_symbol_add(depmod, sym);
+	}
+	array_free_array(&mod_syms.symbols);
 
 	DBG("loaded symbols (%zu modules, %u symbols)\n", depmod->modules.count,
 	    hash_get_count(depmod->symbols));


### PR DESCRIPTION
This is a retake of https://github.com/kmod-project/kmod/pull/412, the slimmed down version in particular.

The changes:
 - split out report error on array_append failure into separate patch
 
 - reuse struct symbol, instead or rolling our own
 - split/reuse symbol creation - 2 times fewer allocations, honour sym_prefix
 - don't allocate the struct symbol(s) twice 
 - consolidate cleanup into a helper function

 - remove unused members in load_modules_work, rename
 - swap modules, start and end for modules(_start) and count
 - store thread id and "work" struct in single place - nproc fewerer calloc

 - properly check for errors on pthread_create/join

In summary, the numbers are as follows:

| master | MR, nproc 1 | MR (nproc 8), CPUs used | compression |
|--------|-------------|--------------|-------------|
| 0.44 s | 0.44 s      | 0.73 s, 1.5  | none        |
| 4.45 s | 4.45 s      | 1.40 s, 4.3  | xz          |
| 1.05 s | 1.04 s      | 0.62 s, 2.9  | zst         |


Which are mostly identical to previously, with a notable exception for uncompressed modules. Unsurprisingly adding extra threads damages performance.

Some nproc numbers from an aging 4 core + HT laptop.

| nproc | none | zst  |
|-------|------|------| 
| 1     | 0.44 | 1.04 |
| 2     | 0.39 | 0.73 |
| 4     | 0.54 | 0.63 |
| 8     | 0.73 | 0.62 |
 
 <details>

<summary>Some `perf stat -r 100` numbers</summary>

Even with the 100 repeat, the numbers are not that stable/reliable.

| compression | stat | master | MR nproc 1 | slim | MR |
| ------------|------|--------|------------|------|----|
| uncompressed | task-clock | 435,749,999 | 435,047,972 | 1,082,318,930 | 1,087,043,546 | 
| uncompressed | instructions | 1,213,446,151 | 1,202,426,481 | 1,193,567,961 | 1,192,806,832 |
| uncompressed | time elapsed | 0.43846 +- 0.00177 | 0.43802 +- 0.00184 | 0.72881 +- 0.00417 | 0.73283 +- 0.00318 |
| ------------|------|--------|------------|------|----|
| xz | task-clock | 4,450,100,429 | 4,444,117,416 | 6,063,143,589 | 6,057,782,176 |
| xz | instructions | 27,467,626,437 | 27,439,935,695 | 27,414,581,685 | 27,409,414,470|
| xz | time elapsed | 4.45702 +- 0.00579 | 4.45167 +- 0.00663 | 1.40124 +- 0.00259 | 1.40324 +- 0.00255 |
| ------------|------|--------|------------|------|----|
| zst | task-clock | 1,047,500,349 | 1,038,654,591 | 1,836,694,522 | 1,810,041,398|
| zst | instructions | 6,941,232,755 | 6,976,108,698 | 6,904,710,582 | 6,904,091,683 |
| zst | time elapsed | 1.05134 +- 0.00459 | 1.04285 +- 0.00338 | 0.63994 +- 0.00215 | 0.62171 +- 0.00400 |

</details>

<details>

<summary>Valgrind memory stats</summary>

| allocations | bytes | compression | build |
|-------------|-------|-------------|-------|
| 1,295,300 | 175,206,192 | uncompressed | master |
| 1,295,407 | 180,905,088 | uncompressed | MR nproc 1 |
| 1,322,139 | 176,862,003 | uncompressed | slim |
| 1,295,462 | 176,150,040 | uncompressed | MR |
|-----------|-------------|--------------|----|
| 1,404,387 | 53,370,466,853 | xz | master |
| 1,404,494 | 53,376,165,749 | xz | MR nproc 1 |
| 1,431,226 | 53,372,122,664 | xz | slim |
| 1,404,549 | 53,371,410,701 | xz | MR |
|-----------|-------------|--------------|----|
| 1,306,364 | 1,169,580,231 | zst | master |
| 1,306,471 | 1,175,279,127 | zst | MR nproc 1 |
| 1,333,203 | 1,171,236,042 | zst | slim |
| 1,306,526 | 1,170,524,079 | zst | MR |

Summary, relative to master
- MR, nproc 1 - extra ~100 allocs, ~5.6M bytes in total
- Slim - extra ~27k allocs, ~1.5M bytes in total
- MR - extra ~160 allocs, ~1M bytes in total

The 27k -> 160 changes are expected since we reuse `struct symbols` although why we get an extra 5MB memory for nproc is beyond me :shrug: 

</details>