### PR TITLE
mbedlts: add as alternative to openssl

### DIFF
--- a/.github/actions/setup-os/setup-alpine.sh
+++ b/.github/actions/setup-os/setup-alpine.sh
@@ -13,6 +13,7 @@ apk add \
     git \
     gtk-doc \
     linux-stable-dev \
+    mbedtls-dev \
     meson \
     openssl-dev \
     scdoc \

--- a/.github/actions/setup-os/setup-arch.sh
+++ b/.github/actions/setup-os/setup-arch.sh
@@ -18,5 +18,6 @@ pacman --noconfirm -Su \
     gtk-doc \
     linux-headers \
     lld \
+    mbedtls \
     meson \
     scdoc

--- a/.github/actions/setup-os/setup-debian.sh
+++ b/.github/actions/setup-os/setup-debian.sh
@@ -6,6 +6,14 @@
 
 export DEBIAN_FRONTEND=noninteractive
 export TZ=Etc/UTC
+
+. /etc/os-release
+
+mbedtls_pkgs=()
+if [[ "$VERSION_CODENAME" != "bookworm" ]]; then
+    mbedtls_pkgs=("libmbedtls-dev")
+fi
+
 apt-get update
 apt-get install --yes \
     bash \
@@ -19,6 +27,7 @@ apt-get install --yes \
     libzstd-dev \
     linux-headers-generic \
     meson \
+    "${mbedtls_pkgs[@]}" \
     scdoc \
     zlib1g-dev \
     zstd

--- a/.github/actions/setup-os/setup-fedora.sh
+++ b/.github/actions/setup-os/setup-fedora.sh
@@ -19,6 +19,7 @@ dnf install -y \
     libubsan \
     libzstd-devel \
     make \
+    mbedtls-devel \
     meson \
     openssl-devel \
     scdoc \

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         include:
           - container: 'ubuntu:24.04'
-            meson_setup: '-D b_sanitize=none -D build-tests=false'
+            meson_setup: '-D b_sanitize=none -D build-tests=false -Dmbedtls=disabled'
 
     container:
       image: ${{ matrix.container }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         include:
           - container: 'ubuntu:24.04'
-            meson_setup: '-D b_sanitize=none -D b_coverage=true'
+            meson_setup: '-D b_sanitize=none -D b_coverage=true -Dmbedtls=disabled'
 
     container:
       image: ${{ matrix.container }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,13 +35,15 @@ jobs:
             only_bits: '64'
           - container: 'archlinux:multilib-devel'
           - container: 'debian:bookworm-slim'
-            meson_setup: '-Dzstd=disabled -Dxz=disabled -Dzlib=disabled'
+            meson_setup: '-Dzstd=disabled -Dxz=disabled -Dzlib=disabled -Dmbedtls=disabled'
             only_compiler: 'gcc'
           - container: 'debian:unstable'
           - container: 'fedora:latest'
             only_bits: '64'
           - container: 'ubuntu:22.04'
+            meson_setup: '-Dmbedtls=disabled'
           - container: 'ubuntu:24.04'
+            meson_setup: '-Dmbedtls=disabled'
 
           # Special configurations
 
@@ -51,7 +53,7 @@ jobs:
             only_bits: '64'
             custom: 'no-xz-dlopen-all'
           - container: 'ubuntu:22.04'
-            meson_setup: '-Ddlopen=zstd,zlib'
+            meson_setup: '-Ddlopen=zstd,zlib -Dmbedtls=disabled'
             only_bits: '64'
             custom: 'dlopen-zstd-zlib'
 
@@ -73,6 +75,13 @@ jobs:
             only_bits: '64'
             only_compiler: 'gcc'
             custom: 'custom-moduledir'
+
+          # Variant without openssl - only mbedtls
+          - container: 'archlinux:multilib-devel'
+            meson_setup: '-Dopenssl=disabled'
+            only_bits: '64'
+            only_compiler: 'gcc'
+            custom: 'mbedtls-only'
 
     container:
       image: ${{ matrix.container }}
@@ -116,8 +125,8 @@ jobs:
           should_fail -D dlopen=nonexistent
           should_fail -D xz=disabled -D dlopen=xz
 
-          should_pass -D dlopen=xz
-          should_pass -D dlopen=xz -D xz=enabled
+          should_pass -D mbedtls=disabled -D dlopen=xz
+          should_pass -D mbedtls=disabled -D dlopen=xz -D xz=enabled
 
       - name: configure
         run: |
@@ -126,7 +135,7 @@ jobs:
 
             if [[ "$2" == "32" ]]; then
               echo "::notice::TODO fix and reuse the original options."
-              setup_options="$setup_options -Dzstd=disabled -Dxz=disabled -Dzlib=disabled -Dopenssl=disabled"
+              setup_options="$setup_options -Dzstd=disabled -Dxz=disabled -Dzlib=disabled -Dopenssl=disabled -Dmbedtls=disabled"
 
               echo "::notice::TODO fix and re-enable sanitizer(s)."
               setup_options="$setup_options -Db_sanitize=none"

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Optional dependencies, required with the default build configuration:
 - LZMA library
 - ZSTD library
 - OPENSSL library (signature handling in modinfo)
+- MBEDTLS library (signature handling in modinfo)
 
 All the optional dependencies are loaded on demand via `dlopen` by default. This can
 be changed via the `dlopen` build option. Typical configuration and installation:

--- a/build-dev.ini
+++ b/build-dev.ini
@@ -11,7 +11,7 @@ zstd = 'enabled'
 xz = 'enabled'
 zlib = 'enabled'
 openssl = 'enabled'
-mbedtls = 'disabled'
+mbedtls = 'enabled'
 werror = true
 b_sanitize = 'address,undefined'
 

--- a/build-dev.ini
+++ b/build-dev.ini
@@ -11,6 +11,7 @@ zstd = 'enabled'
 xz = 'enabled'
 zlib = 'enabled'
 openssl = 'enabled'
+mbedtls = 'disabled'
 werror = true
 b_sanitize = 'address,undefined'
 

--- a/libkmod/docs/meson.build
+++ b/libkmod/docs/meson.build
@@ -13,6 +13,7 @@ built_docs = gnome.gtkdoc(
     f'@project_source_root@/libkmod/libkmod-index.h',
     f'@project_source_root@/libkmod/libkmod-internal-file.h',
     f'@project_source_root@/libkmod/libkmod-internal.h',
+    f'@project_source_root@/libkmod/libkmod-internal-signature.h',
   ],
   scan_args : '--ignore-decorators="KMOD_EXPORT"',
   src_dir : f'@project_source_root@/libkmod/',

--- a/libkmod/libkmod-internal-signature.h
+++ b/libkmod/libkmod-internal-signature.h
@@ -13,3 +13,14 @@ static inline bool kmod_fill_pkcs7_openssl(const char *mem, off_t size, size_t s
 	return false;
 }
 #endif
+
+#if ENABLE_MBEDTLS
+bool kmod_fill_pkcs7_mbedtls(const char *mem, off_t size, size_t sig_len,
+			     struct kmod_signature_info **out_sig_info);
+#else
+static inline bool kmod_fill_pkcs7_mbedtls(const char *mem, off_t size, size_t sig_len,
+					   struct kmod_signature_info **out_sig_info)
+{
+	return false;
+}
+#endif

--- a/libkmod/libkmod-internal-signature.h
+++ b/libkmod/libkmod-internal-signature.h
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2026 Emil Velikov <emil.l.velikov@gmail.com>
+
+#include <libkmod/libkmod-internal.h>
+
+#if ENABLE_OPENSSL
+bool kmod_fill_pkcs7_openssl(const char *mem, off_t size, size_t sig_len,
+			     struct kmod_signature_info **out_sig_info);
+#else
+static inline bool kmod_fill_pkcs7_openssl(const char *mem, off_t size, size_t sig_len,
+					   struct kmod_signature_info **out_sig_info)
+{
+	return false;
+}
+#endif

--- a/libkmod/libkmod-signature-mbedtls.c
+++ b/libkmod/libkmod-signature-mbedtls.c
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * Copyright (C) 2026 Emil Velikov
+ */
+
+#define DLSYM_LOCALLY_ENABLED ENABLE_MBEDTLS_DLOPEN
+
+#include <inttypes.h>
+#include <mbedtls/oid.h> // for MBEDTLS_OID_DIGEST_ALG_*
+#include <mbedtls/pkcs7.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <shared/elf-note.h>
+#include <shared/util.h>
+
+#include "libkmod-internal-signature.h"
+
+/* XXX: temporary copy from libkmod-signature.c */
+enum pkey_hash_algo {
+	PKEY_HASH_MD4,
+	PKEY_HASH_MD5,
+	PKEY_HASH_SHA1,
+	PKEY_HASH_RIPE_MD_160,
+	PKEY_HASH_SHA256,
+	PKEY_HASH_SHA384,
+	PKEY_HASH_SHA512,
+	PKEY_HASH_SHA224,
+	PKEY_HASH_SM3,
+	PKEY_HASH__LAST,
+};
+
+/* XXX: ditto */
+static const char *const pkey_hash_algo[PKEY_HASH__LAST] = {
+	// clang-format off
+	[PKEY_HASH_MD4] = "md4",
+	[PKEY_HASH_MD5] = "md5",
+	[PKEY_HASH_SHA1] = "sha1",
+	[PKEY_HASH_RIPE_MD_160] = "rmd160",
+	[PKEY_HASH_SHA256] = "sha256",
+	[PKEY_HASH_SHA384] = "sha384",
+	[PKEY_HASH_SHA512] = "sha512",
+	[PKEY_HASH_SHA224] = "sha224",
+	[PKEY_HASH_SM3] = "sm3",
+	// clang-format on
+};
+
+#define DL_SYMBOL_TABLE(M)         \
+	M(mbedtls_pkcs7_init)      \
+	M(mbedtls_pkcs7_parse_der) \
+	M(mbedtls_pkcs7_free)
+
+DL_SYMBOL_TABLE(DECLARE_SYM)
+
+static int dlopen_mbedx509(void)
+{
+#if !DLSYM_LOCALLY_ENABLED
+	return 0;
+#else
+	static void *dl;
+
+	ELF_NOTE_DLOPEN("mbedtls", "Support for reading module signatures",
+			ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED, "libmbedx509.so.7");
+
+	return dlsym_many(&dl, "libmbedx509.so.7", DL_SYMBOL_TABLE(DLSYM_ARG) NULL);
+#endif
+}
+
+static int to_hash_algo(const mbedtls_pkcs7_buf *oid)
+{
+	/* MBEDTLS_OID_DIGEST_ALG_MD4 was removed around mbedtls v3.0 */
+	if (!MBEDTLS_OID_CMP(MBEDTLS_OID_DIGEST_ALG_MD5, oid))
+		return PKEY_HASH_MD5;
+
+	if (!MBEDTLS_OID_CMP(MBEDTLS_OID_DIGEST_ALG_SHA1, oid))
+		return PKEY_HASH_SHA1;
+
+	if (!MBEDTLS_OID_CMP(MBEDTLS_OID_DIGEST_ALG_RIPEMD160, oid))
+		return PKEY_HASH_RIPE_MD_160;
+
+	if (!MBEDTLS_OID_CMP(MBEDTLS_OID_DIGEST_ALG_SHA256, oid))
+		return PKEY_HASH_SHA256;
+
+	if (!MBEDTLS_OID_CMP(MBEDTLS_OID_DIGEST_ALG_SHA384, oid))
+		return PKEY_HASH_SHA384;
+
+	if (!MBEDTLS_OID_CMP(MBEDTLS_OID_DIGEST_ALG_SHA512, oid))
+		return PKEY_HASH_SHA512;
+
+	if (!MBEDTLS_OID_CMP(MBEDTLS_OID_DIGEST_ALG_SHA224, oid))
+		return PKEY_HASH_SHA224;
+
+	/* MBEDTLS_OID_DIGEST_ALG_SM3: Not available, as of 2026-02-14 */
+	return -1;
+}
+
+bool kmod_fill_pkcs7_mbedtls(const char *mem, off_t size, size_t sig_len,
+			     struct kmod_signature_info **out_sig_info)
+{
+	struct kmod_signature_info *sig_info;
+	char *p;
+	const struct mbedtls_pkcs7_signed_data *signed_data;
+	const struct mbedtls_pkcs7_signer_info *signers;
+	struct mbedtls_pkcs7 pkcs7;
+	const unsigned char *pkcs7_raw;
+	size_t total_len;
+	int hash_algo, ret;
+
+	ret = dlopen_mbedx509();
+	if (ret < 0)
+		return false;
+
+	size -= sig_len;
+	pkcs7_raw = (const unsigned char *)mem + size;
+
+	sym_mbedtls_pkcs7_init(&pkcs7);
+	ret = sym_mbedtls_pkcs7_parse_der(&pkcs7, pkcs7_raw, sig_len);
+	if (ret < 0)
+		goto err;
+
+	signed_data = &pkcs7.MBEDTLS_PRIVATE(signed_data);
+	signers = &signed_data->MBEDTLS_PRIVATE(signers);
+
+	hash_algo = to_hash_algo(&signed_data->MBEDTLS_PRIVATE(digest_alg_identifiers));
+	if (hash_algo < 0)
+		goto err;
+
+	/* Calculate the total length */
+	total_len = sizeof(struct kmod_signature_info);
+
+	/* signer */
+	total_len += signers->MBEDTLS_PRIVATE(issuer).val.len;
+
+	/* key_id */
+	total_len += signers->MBEDTLS_PRIVATE(serial).len;
+
+	/* hash_algo */
+	/* XXX: using an incomplete and not-fully correct static table */
+
+	/* sig */
+	total_len += signers->MBEDTLS_PRIVATE(sig).len;
+
+	sig_info = calloc(1, total_len);
+	if (sig_info == NULL)
+		goto err;
+
+	p = (char *)sig_info;
+
+	p += sizeof(struct kmod_signature_info);
+
+	/* signer */
+	sig_info->signer = p;
+	sig_info->signer_len = signers->MBEDTLS_PRIVATE(issuer).val.len;
+
+	memcpy(p, signers->MBEDTLS_PRIVATE(issuer).val.p, sig_info->signer_len);
+	p += sig_info->signer_len;
+
+	/* key_id */
+	sig_info->key_id = p;
+	sig_info->key_id_len = signers->MBEDTLS_PRIVATE(serial).len;
+
+	memcpy(p, signers->MBEDTLS_PRIVATE(serial).p, sig_info->key_id_len);
+	p += sig_info->key_id_len;
+
+	/* hash_algo */
+	sig_info->hash_algo = pkey_hash_algo[hash_algo];
+
+	/* sig */
+	sig_info->sig = p;
+	sig_info->sig_len = signers->MBEDTLS_PRIVATE(sig).len;
+
+	memcpy(p, signers->MBEDTLS_PRIVATE(sig).p, sig_info->sig_len);
+
+	sym_mbedtls_pkcs7_free(&pkcs7);
+	*out_sig_info = sig_info;
+
+	return true;
+
+err:
+	sym_mbedtls_pkcs7_free(&pkcs7);
+	return false;
+}

--- a/libkmod/libkmod-signature-openssl.c
+++ b/libkmod/libkmod-signature-openssl.c
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2013 Michal Marek, SUSE
+
+#define DLSYM_LOCALLY_ENABLED ENABLE_OPENSSL_DLOPEN
+
+#include <inttypes.h>
+#include <openssl/pkcs7.h>
+#include <openssl/ssl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <shared/elf-note.h>
+#include <shared/util.h>
+
+#include "libkmod-internal-signature.h"
+
+#define DL_SYMBOL_TABLE(M)             \
+	M(ASN1_INTEGER_to_BN)          \
+	M(ASN1_STRING_get0_data)       \
+	M(ASN1_STRING_length)          \
+	M(BIO_free)                    \
+	M(BIO_new_mem_buf)             \
+	M(BN_bn2bin)                   \
+	M(BN_free)                     \
+	M(BN_num_bits)                 \
+	M(d2i_PKCS7_bio)               \
+	M(OBJ_obj2nid)                 \
+	M(OBJ_obj2txt)                 \
+	M(OPENSSL_sk_value)            \
+	M(PKCS7_free)                  \
+	M(PKCS7_get_signer_info)       \
+	M(PKCS7_SIGNER_INFO_get0_algs) \
+	M(X509_ALGOR_get0)             \
+	M(X509_NAME_entry_count)       \
+	M(X509_NAME_ENTRY_get_data)    \
+	M(X509_NAME_ENTRY_get_object)  \
+	M(X509_NAME_get_entry)
+
+DL_SYMBOL_TABLE(DECLARE_SYM)
+
+/* Portion of the libcrypto/openssl API is nested inline functions and/or macros. As such, we
+ * need to copy/paste a few so our forwarding works.
+ */
+#define sym_BN_num_bytes(a) ((sym_BN_num_bits(a) + 7) / 8)
+#define sym_sk_PKCS7_SIGNER_INFO_value(sk, idx)     \
+	((PKCS7_SIGNER_INFO *)sym_OPENSSL_sk_value( \
+		ossl_check_const_PKCS7_SIGNER_INFO_sk_type(sk), (idx)))
+
+static int dlopen_crypto(void)
+{
+#if !DLSYM_LOCALLY_ENABLED
+	return 0;
+#else
+	static void *dl;
+
+	ELF_NOTE_DLOPEN("openssl", "Support for reading module signatures",
+			ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED, "libcrypto.so.3");
+
+	return dlsym_many(&dl, "libcrypto.so.3", DL_SYMBOL_TABLE(DLSYM_ARG) NULL);
+#endif
+}
+
+static const char *x509_name_to_str(X509_NAME *name)
+{
+	int i;
+	X509_NAME_ENTRY *e;
+	ASN1_STRING *d;
+	ASN1_OBJECT *o;
+	int nid = -1;
+	const char *str;
+
+	for (i = 0; i < sym_X509_NAME_entry_count(name); i++) {
+		e = sym_X509_NAME_get_entry(name, i);
+		o = sym_X509_NAME_ENTRY_get_object(e);
+		nid = sym_OBJ_obj2nid(o);
+		if (nid == NID_commonName)
+			break;
+	}
+	if (nid == -1)
+		return NULL;
+
+	d = sym_X509_NAME_ENTRY_get_data(e);
+	str = (const char *)sym_ASN1_STRING_get0_data(d);
+
+	return str;
+}
+
+bool kmod_fill_pkcs7_openssl(const char *mem, off_t size, size_t sig_len,
+			     struct kmod_signature_info **out_sig_info)
+{
+	struct kmod_signature_info *sig_info;
+	char *p;
+	const char *pkcs7_raw;
+	PKCS7 *pkcs7;
+	STACK_OF(PKCS7_SIGNER_INFO) * sis;
+	PKCS7_SIGNER_INFO *si;
+	const PKCS7_ISSUER_AND_SERIAL *is;
+	const ASN1_OCTET_STRING *sig;
+	BIGNUM *sno_bn;
+	X509_ALGOR *dig_alg;
+	const ASN1_OBJECT *o;
+	BIO *in;
+	const char *issuer_str;
+	int hash_algo_len;
+	size_t total_len;
+	int ret;
+
+	ret = dlopen_crypto();
+	if (ret < 0)
+		return false;
+
+	size -= sig_len;
+	pkcs7_raw = mem + size;
+
+	in = sym_BIO_new_mem_buf(pkcs7_raw, sig_len);
+
+	pkcs7 = sym_d2i_PKCS7_bio(in, NULL);
+	sym_BIO_free(in);
+
+	if (pkcs7 == NULL)
+		goto err;
+
+	sis = sym_PKCS7_get_signer_info(pkcs7);
+	if (sis == NULL)
+		goto err;
+
+	si = sym_sk_PKCS7_SIGNER_INFO_value(sis, 0);
+	if (si == NULL || si->issuer_and_serial == NULL || si->enc_digest == NULL)
+		goto err;
+
+	is = si->issuer_and_serial;
+
+	/* Calculate the total length */
+	total_len = sizeof(struct kmod_signature_info);
+
+	/* signer */
+	issuer_str = x509_name_to_str(is->issuer);
+	if (issuer_str != NULL)
+		total_len += strlen(issuer_str);
+
+	/* key_id */
+	sno_bn = sym_ASN1_INTEGER_to_BN(is->serial, NULL);
+	if (sno_bn == NULL)
+		goto err;
+
+	total_len += sym_BN_num_bytes(sno_bn);
+
+	/* hash_algo */
+	sym_PKCS7_SIGNER_INFO_get0_algs(si, NULL, &dig_alg, NULL);
+	sym_X509_ALGOR_get0(&o, NULL, NULL, dig_alg);
+	hash_algo_len = sym_OBJ_obj2txt(NULL, 0, o, 0);
+	if (hash_algo_len < 0)
+		goto err1;
+
+	total_len += hash_algo_len + 1;
+
+	/* sig */
+	sig = si->enc_digest;
+	total_len += sym_ASN1_STRING_length(sig);
+
+	sig_info = calloc(1, total_len);
+	if (sig_info == NULL)
+		goto err1;
+
+	p = (char *)sig_info;
+
+	p += sizeof(struct kmod_signature_info);
+
+	/* signer */
+	if (issuer_str != NULL) {
+		sig_info->signer = p;
+		sig_info->signer_len = strlen(issuer_str);
+
+		memcpy(p, issuer_str, sig_info->signer_len);
+		p += sig_info->signer_len;
+	}
+
+	/* key_id */
+	sig_info->key_id = p;
+	sig_info->key_id_len = sym_BN_num_bytes(sno_bn);
+
+	sym_BN_bn2bin(sno_bn, (unsigned char *)p);
+	p += sig_info->key_id_len;
+
+	/* hash_algo */
+	sig_info->hash_algo = p;
+
+	hash_algo_len = sym_OBJ_obj2txt(p, hash_algo_len + 1, o, 0);
+	if (hash_algo_len < 0)
+		goto err2;
+	p += hash_algo_len;
+
+	*p = '\0';
+	p++;
+
+	/* sig */
+	sig_info->sig = p;
+	sig_info->sig_len = sym_ASN1_STRING_length(sig);
+
+	memcpy(p, sym_ASN1_STRING_get0_data(sig), sig_info->sig_len);
+
+	sym_BN_free(sno_bn);
+	sym_PKCS7_free(pkcs7);
+
+	*out_sig_info = sig_info;
+
+	return true;
+
+err2:
+	free(sig_info);
+err1:
+	sym_BN_free(sno_bn);
+err:
+	sym_PKCS7_free(pkcs7);
+	return false;
+}

--- a/libkmod/libkmod-signature.c
+++ b/libkmod/libkmod-signature.c
@@ -169,6 +169,8 @@ bool kmod_module_signature_info(const struct kmod_file *file,
 	case PKEY_ID_PKCS7:
 		ret = kmod_fill_pkcs7_openssl(mem, size, sig_len, sig_info);
 		if (!ret)
+			ret = kmod_fill_pkcs7_mbedtls(mem, size, sig_len, sig_info);
+		if (!ret)
 			ret = kmod_fill_pkcs7_dummy(mem, size, sig_len, sig_info);
 		break;
 	default:

--- a/libkmod/libkmod-signature.c
+++ b/libkmod/libkmod-signature.c
@@ -3,23 +3,15 @@
  * Copyright (C) 2013 Michal Marek, SUSE
  */
 
-#define DLSYM_LOCALLY_ENABLED ENABLE_OPENSSL_DLOPEN
-
 #include <endian.h>
 #include <inttypes.h>
-#if ENABLE_OPENSSL
-#include <openssl/pkcs7.h>
-#include <openssl/ssl.h>
-#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#include <shared/elf-note.h>
-#include <shared/missing.h>
 #include <shared/util.h>
 
-#include "libkmod-internal.h"
+#include "libkmod-internal-signature.h"
 
 /* These types and tables were copied from the 3.7 kernel sources.
  * As this is just description of the signature format, it should not be
@@ -111,213 +103,8 @@ static bool fill_default(const char *mem, off_t size,
 	return true;
 }
 
-#if ENABLE_OPENSSL
-
-#define DL_SYMBOL_TABLE(M)             \
-	M(ASN1_INTEGER_to_BN)          \
-	M(ASN1_STRING_get0_data)       \
-	M(ASN1_STRING_length)          \
-	M(BIO_free)                    \
-	M(BIO_new_mem_buf)             \
-	M(BN_bn2bin)                   \
-	M(BN_free)                     \
-	M(BN_num_bits)                 \
-	M(d2i_PKCS7_bio)               \
-	M(OBJ_obj2nid)                 \
-	M(OBJ_obj2txt)                 \
-	M(OPENSSL_sk_value)            \
-	M(PKCS7_free)                  \
-	M(PKCS7_get_signer_info)       \
-	M(PKCS7_SIGNER_INFO_get0_algs) \
-	M(X509_ALGOR_get0)             \
-	M(X509_NAME_entry_count)       \
-	M(X509_NAME_ENTRY_get_data)    \
-	M(X509_NAME_ENTRY_get_object)  \
-	M(X509_NAME_get_entry)
-
-DL_SYMBOL_TABLE(DECLARE_SYM)
-
-/* Portion of the libcrypto/openssl API is nested inline functions and/or macros. As such, we
- * need to copy/paste a few so our forwarding works.
- */
-#define sym_BN_num_bytes(a) ((sym_BN_num_bits(a) + 7) / 8)
-#define sym_sk_PKCS7_SIGNER_INFO_value(sk, idx)     \
-	((PKCS7_SIGNER_INFO *)sym_OPENSSL_sk_value( \
-		ossl_check_const_PKCS7_SIGNER_INFO_sk_type(sk), (idx)))
-
-static int dlopen_crypto(void)
-{
-#if !DLSYM_LOCALLY_ENABLED
-	return 0;
-#else
-	static void *dl;
-
-	ELF_NOTE_DLOPEN("openssl", "Support for reading module signatures",
-			ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED, "libcrypto.so.3");
-
-	return dlsym_many(&dl, "libcrypto.so.3", DL_SYMBOL_TABLE(DLSYM_ARG) NULL);
-#endif
-}
-
-static const char *x509_name_to_str(X509_NAME *name)
-{
-	int i;
-	X509_NAME_ENTRY *e;
-	ASN1_STRING *d;
-	ASN1_OBJECT *o;
-	int nid = -1;
-	const char *str;
-
-	for (i = 0; i < sym_X509_NAME_entry_count(name); i++) {
-		e = sym_X509_NAME_get_entry(name, i);
-		o = sym_X509_NAME_ENTRY_get_object(e);
-		nid = sym_OBJ_obj2nid(o);
-		if (nid == NID_commonName)
-			break;
-	}
-	if (nid == -1)
-		return NULL;
-
-	d = sym_X509_NAME_ENTRY_get_data(e);
-	str = (const char *)sym_ASN1_STRING_get0_data(d);
-
-	return str;
-}
-
-static bool fill_pkcs7(const char *mem, off_t size, size_t sig_len,
-		       struct kmod_signature_info **out_sig_info)
-{
-	struct kmod_signature_info *sig_info;
-	char *p;
-	const char *pkcs7_raw;
-	PKCS7 *pkcs7;
-	STACK_OF(PKCS7_SIGNER_INFO) * sis;
-	PKCS7_SIGNER_INFO *si;
-	const PKCS7_ISSUER_AND_SERIAL *is;
-	const ASN1_OCTET_STRING *sig;
-	BIGNUM *sno_bn;
-	X509_ALGOR *dig_alg;
-	const ASN1_OBJECT *o;
-	BIO *in;
-	const char *issuer_str;
-	int hash_algo_len;
-	size_t total_len;
-	int ret;
-
-	ret = dlopen_crypto();
-	if (ret < 0)
-		return false;
-
-	size -= sig_len;
-	pkcs7_raw = mem + size;
-
-	in = sym_BIO_new_mem_buf(pkcs7_raw, sig_len);
-
-	pkcs7 = sym_d2i_PKCS7_bio(in, NULL);
-	sym_BIO_free(in);
-
-	if (pkcs7 == NULL)
-		goto err;
-
-	sis = sym_PKCS7_get_signer_info(pkcs7);
-	if (sis == NULL)
-		goto err;
-
-	si = sym_sk_PKCS7_SIGNER_INFO_value(sis, 0);
-	if (si == NULL || si->issuer_and_serial == NULL || si->enc_digest == NULL)
-		goto err;
-
-	is = si->issuer_and_serial;
-
-	/* Calculate the total length */
-	total_len = sizeof(struct kmod_signature_info);
-
-	/* signer */
-	issuer_str = x509_name_to_str(is->issuer);
-	if (issuer_str != NULL)
-		total_len += strlen(issuer_str);
-
-	/* key_id */
-	sno_bn = sym_ASN1_INTEGER_to_BN(is->serial, NULL);
-	if (sno_bn == NULL)
-		goto err;
-
-	total_len += sym_BN_num_bytes(sno_bn);
-
-	/* hash_algo */
-	sym_PKCS7_SIGNER_INFO_get0_algs(si, NULL, &dig_alg, NULL);
-	sym_X509_ALGOR_get0(&o, NULL, NULL, dig_alg);
-	hash_algo_len = sym_OBJ_obj2txt(NULL, 0, o, 0);
-	if (hash_algo_len < 0)
-		goto err1;
-
-	total_len += hash_algo_len + 1;
-
-	/* sig */
-	sig = si->enc_digest;
-	total_len += sym_ASN1_STRING_length(sig);
-
-	sig_info = calloc(1, total_len);
-	if (sig_info == NULL)
-		goto err1;
-
-	p = (char *)sig_info;
-
-	p += sizeof(struct kmod_signature_info);
-
-	/* signer */
-	if (issuer_str != NULL) {
-		sig_info->signer = p;
-		sig_info->signer_len = strlen(issuer_str);
-
-		memcpy(p, issuer_str, sig_info->signer_len);
-		p += sig_info->signer_len;
-	}
-
-	/* key_id */
-	sig_info->key_id = p;
-	sig_info->key_id_len = sym_BN_num_bytes(sno_bn);
-
-	sym_BN_bn2bin(sno_bn, (unsigned char *)p);
-	p += sig_info->key_id_len;
-
-	/* hash_algo */
-	sig_info->hash_algo = p;
-
-	hash_algo_len = sym_OBJ_obj2txt(p, hash_algo_len + 1, o, 0);
-	if (hash_algo_len < 0)
-		goto err2;
-	p += hash_algo_len;
-
-	*p = '\0';
-	p++;
-
-	/* sig */
-	sig_info->sig = p;
-	sig_info->sig_len = sym_ASN1_STRING_length(sig);
-
-	memcpy(p, sym_ASN1_STRING_get0_data(sig), sig_info->sig_len);
-
-	sym_BN_free(sno_bn);
-	sym_PKCS7_free(pkcs7);
-
-	*out_sig_info = sig_info;
-
-	return true;
-
-err2:
-	free(sig_info);
-err1:
-	sym_BN_free(sno_bn);
-err:
-	sym_PKCS7_free(pkcs7);
-	return false;
-}
-
-#else
-
-static bool fill_pkcs7(const char *mem, off_t size, size_t sig_len,
-		       struct kmod_signature_info **out_sig_info)
+static bool kmod_fill_pkcs7_dummy(const char *mem, off_t size, size_t sig_len,
+				  struct kmod_signature_info **out_sig_info)
 {
 	struct kmod_signature_info *sig_info = calloc(1, sizeof(*sig_info));
 	if (sig_info == NULL)
@@ -327,8 +114,6 @@ static bool fill_pkcs7(const char *mem, off_t size, size_t sig_len,
 	*out_sig_info = sig_info;
 	return true;
 }
-
-#endif
 
 #define SIG_MAGIC "~Module signature appended~\n"
 
@@ -382,7 +167,9 @@ bool kmod_module_signature_info(const struct kmod_file *file,
 
 	switch (modsig.id_type) {
 	case PKEY_ID_PKCS7:
-		ret = fill_pkcs7(mem, size, sig_len, sig_info);
+		ret = kmod_fill_pkcs7_openssl(mem, size, sig_len, sig_info);
+		if (!ret)
+			ret = kmod_fill_pkcs7_dummy(mem, size, sig_len, sig_info);
 		break;
 	default:
 		ret = fill_default(mem, size, &modsig, sig_len, sig_info);

--- a/meson.build
+++ b/meson.build
@@ -274,6 +274,7 @@ _moar_deps = [
   ['xz',      'liblzma',   '>= 4.99'],
   ['zlib',    'zlib',      '>= 0'],
   ['openssl', 'libcrypto', '>= 3.0.0'],
+  ['mbedtls', 'mbedx509',  '>= 3.6.0'],
 ]
 
 foreach tuple : _moar_deps
@@ -296,7 +297,7 @@ foreach tuple : _moar_deps
   cdata.set10('ENABLE_' + opt.to_upper() + '_DLOPEN', have and dlopen)
 
   if have
-    if opt == 'openssl'
+    if opt == 'openssl' or opt == 'mbedtls'
       signatures += ['PKCS7']
     else
       compressions += [f'@opt@']
@@ -390,6 +391,11 @@ endif
 if dep_map.get('openssl').found()
   libkmod_files += files('libkmod/libkmod-signature-openssl.c')
   libkmod_deps += dep_map['openssl']
+endif
+
+if dep_map.get('mbedtls').found()
+  libkmod_files += files('libkmod/libkmod-signature-mbedtls.c')
+  libkmod_deps += dep_map['mbedtls']
 endif
 
 install_headers('libkmod/libkmod.h')

--- a/meson.build
+++ b/meson.build
@@ -148,8 +148,8 @@ endif
 # Options
 ################################################################################
 
-module_compressions = ''
-module_signatures = ''
+compressions = []
+signatures = []
 
 features = []
 dep_map = {}
@@ -295,15 +295,22 @@ foreach tuple : _moar_deps
   cdata.set10('ENABLE_' + opt.to_upper(), have)
   cdata.set10('ENABLE_' + opt.to_upper() + '_DLOPEN', have and dlopen)
 
-  if opt == 'openssl'
-    module_signatures = have ? 'PKCS7 legacy' : 'legacy'
-  elif have
-    module_compressions += f'@opt@ '
+  if have
+    if opt == 'openssl'
+      signatures += ['PKCS7']
+    else
+      compressions += [f'@opt@']
+    endif
   endif
 
   features += ['@0@@1@'.format(have ? '+' : '-', opt.to_upper())]
   dep_map += {opt : dep}
 endforeach
+
+signatures += ['legacy']
+
+module_compressions = ' '.join(compressions)
+module_signatures = ' '.join(signatures)
 
 #-------------------------------------------------------------------------------
 # Config output

--- a/meson.build
+++ b/meson.build
@@ -388,6 +388,7 @@ if dep_map.get('zlib').found()
 endif
 
 if dep_map.get('openssl').found()
+  libkmod_files += files('libkmod/libkmod-signature-openssl.c')
   libkmod_deps += dep_map['openssl']
 endif
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -61,6 +61,13 @@ option(
 )
 
 option(
+  'mbedtls',
+  type : 'feature',
+  value : 'disabled',
+  description : 'MbedTLS support, PKCS7 signatures. Default: disabled',
+)
+
+option(
   'tools',
   type : 'boolean',
   value : true,
@@ -70,7 +77,7 @@ option(
 option(
   'dlopen',
   type : 'array',
-  choices : ['zstd', 'xz', 'zlib', 'openssl', 'all'],
+  choices : ['zstd', 'xz', 'zlib', 'openssl', 'mbedtls', 'all'],
   value : ['all'],
   description : 'Libraries to dlopen rather than linking. Default: "all"',
 )

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -63,8 +63,8 @@ option(
 option(
   'mbedtls',
   type : 'feature',
-  value : 'disabled',
-  description : 'MbedTLS support, PKCS7 signatures. Default: disabled',
+  value : 'enabled',
+  description : 'MbedTLS support, PKCS7 signatures. Default: enabled',
 )
 
 option(

--- a/testsuite/test-modinfo.c
+++ b/testsuite/test-modinfo.c
@@ -30,7 +30,7 @@
 #define DEFINE_MODINFO_GENERIC_TEST(_field) \
 	DEFINE_MODINFO_TEST(_field, , "/mod-simple.ko")
 
-#if ENABLE_OPENSSL
+#if ENABLE_OPENSSL || ENABLE_MBEDTLS
 #define DEFINE_MODINFO_SIGN_TEST(_field)                             \
 	DEFINE_MODINFO_TEST(_field, -openssl, "/mod-simple-sha1.ko", \
 			    "/mod-simple-sha256.ko", "/mod-simple-pkcs7.ko")


### PR DESCRIPTION
XXX: make the meson options mutually exclusive, rebase onto other MRs

In a recent conversation improving the depmod runtime, we noticed that kmod_module_signature_info() normally takes 20-25% of the total runtime for uncompressed.

The related attempts at using threads, also indicated that OpenSSL may not be thread-safe... At least, not the way we use it.

Enter Mbed TLS (formerly known as polarssl), self described as:

Mbed TLS is a C library that implements X.509 certificate manipulation ... ... Its small code footprint makes it suitable for embedded systems. ...

There are 3 major versions, all of which are supported AFAICT:
 - 2 circa 2015 - available in Debian 12/oldstable (+earlier) and Ubuntu 24.04 (+ earlier)
 - 3 circa 2021 - available in Debian 13+, Ubuntu 25.04+ and everywhere*
 - 4 Oct 2025 - very minimal distribution adoption

In practical terms, using MbedTLS has proven to be a much shorter and simpler implementation. Where the ~20% time spent in kmod_module_signature_info() was reduced to practically zero. With the overall execution time dropping respectively - 0.43s -> 0.35s.

Another way to look at it:
 - ~50k fewer instructions are executed, per module
 - ~55 fewer memory allocations are made, per module
 - ~2KB less memory is allocated, per module

Also, Helgrind seems quite happy.

There are some down sides through - ignoring the Ubuntu 25.04+ only availability.
 - MD4 support was removed with v3.0
 - SM3 support is not available - neither in v3 nor v4
 - there is no algo to string API, so we need a local mapping