### PR TITLE
Crypto bikeshedding ;-)

### DIFF
--- a/libkmod/libkmod-internal.h
+++ b/libkmod/libkmod-internal.h
@@ -177,11 +177,8 @@ struct kmod_signature_info {
 	const char *hash_algo, *id_type;
 	const char *sig;
 	size_t sig_len;
-	void (*free)(void *);
-	void *private;
 };
-_must_check_ _nonnull_all_ bool kmod_module_signature_info(const struct kmod_file *file, struct kmod_signature_info *sig_info);
-_nonnull_all_ void kmod_module_signature_info_free(struct kmod_signature_info *sig_info);
+_must_check_ _nonnull_all_ bool kmod_module_signature_info(const struct kmod_file *file, struct kmod_signature_info **sig_info);
 
 /* libkmod-builtin.c */
 _nonnull_all_ ssize_t kmod_builtin_get_modinfo(struct kmod_ctx *ctx, const char *modname, char ***modinfo);

--- a/libkmod/libkmod-internal.h
+++ b/libkmod/libkmod-internal.h
@@ -174,7 +174,7 @@ struct kmod_signature_info {
 	size_t signer_len;
 	const char *key_id;
 	size_t key_id_len;
-	const char *algo, *hash_algo, *id_type;
+	const char *hash_algo, *id_type;
 	const char *sig;
 	size_t sig_len;
 	void (*free)(void *);

--- a/libkmod/libkmod-module.c
+++ b/libkmod/libkmod-module.c
@@ -1856,7 +1856,7 @@ KMOD_EXPORT int kmod_module_get_info(const struct kmod_module *mod,
 	struct kmod_elf *elf;
 	char **strings;
 	int i, count, ret = -ENOMEM;
-	struct kmod_signature_info sig_info = {};
+	struct kmod_signature_info *sig_info = NULL;
 
 	if (mod == NULL || list == NULL)
 		return -ENOENT;
@@ -1905,36 +1905,36 @@ KMOD_EXPORT int kmod_module_get_info(const struct kmod_module *mod,
 		struct kmod_list *n;
 
 		n = kmod_module_info_append(list, "sig_id", strlen("sig_id"),
-					    sig_info.id_type, strlen(sig_info.id_type));
+					    sig_info->id_type, strlen(sig_info->id_type));
 		if (n == NULL)
 			goto list_error;
 		count++;
 
 		n = kmod_module_info_append(list, "signer", strlen("signer"),
-					    sig_info.signer, sig_info.signer_len);
+					    sig_info->signer, sig_info->signer_len);
 		if (n == NULL)
 			goto list_error;
 		count++;
 
 		n = kmod_module_info_append_hex(list, "sig_key", strlen("sig_key"),
-						sig_info.key_id, sig_info.key_id_len);
+						sig_info->key_id, sig_info->key_id_len);
 		if (n == NULL)
 			goto list_error;
 		count++;
 
 		n = kmod_module_info_append(list, "sig_hashalgo", strlen("sig_hashalgo"),
-					    sig_info.hash_algo,
-					    strlen(sig_info.hash_algo));
+					    sig_info->hash_algo,
+					    strlen(sig_info->hash_algo));
 		if (n == NULL)
 			goto list_error;
 		count++;
 
 		/*
-		 * Omit sig_info.algo for now, as these
+		 * Omit sig_info->algo for now, as these
 		 * are currently constant.
 		 */
 		n = kmod_module_info_append_hex(list, "signature", strlen("signature"),
-						sig_info.sig, sig_info.sig_len);
+						sig_info->sig, sig_info->sig_len);
 
 		if (n == NULL)
 			goto list_error;
@@ -1944,7 +1944,7 @@ KMOD_EXPORT int kmod_module_get_info(const struct kmod_module *mod,
 
 list_error:
 	/* aux structures freed in normal case also */
-	kmod_module_signature_info_free(&sig_info);
+	free(sig_info);
 
 	if (ret < 0) {
 		kmod_module_info_free_list(*list);

--- a/libkmod/libkmod-signature.c
+++ b/libkmod/libkmod-signature.c
@@ -162,7 +162,6 @@ static bool fill_pkcs7(const char *mem, off_t size, size_t sig_len,
 	ASN1_OCTET_STRING *sig;
 	BIGNUM *sno_bn;
 	X509_ALGOR *dig_alg;
-	X509_ALGOR *sig_alg;
 	const ASN1_OBJECT *o;
 	BIO *in;
 	int len;
@@ -203,7 +202,7 @@ static bool fill_pkcs7(const char *mem, off_t size, size_t sig_len,
 	if (sig == NULL)
 		goto err;
 
-	PKCS7_SIGNER_INFO_get0_algs(si, NULL, &dig_alg, &sig_alg);
+	PKCS7_SIGNER_INFO_get0_algs(si, NULL, &dig_alg, NULL);
 
 	sig_info->sig = (const char *)ASN1_STRING_get0_data(sig);
 	sig_info->sig_len = ASN1_STRING_length(sig);

--- a/libkmod/libkmod-signature.c
+++ b/libkmod/libkmod-signature.c
@@ -189,18 +189,13 @@ static bool fill_pkcs7(const char *mem, off_t size, size_t sig_len,
 		goto err;
 
 	si = sk_PKCS7_SIGNER_INFO_value(sis, 0);
-	if (si == NULL)
+	if (si == NULL || si->issuer_and_serial == NULL || si->enc_digest == NULL)
 		goto err;
 
 	is = si->issuer_and_serial;
-	if (is == NULL)
-		goto err;
 	issuer = is->issuer;
 	sno = is->serial;
-
 	sig = si->enc_digest;
-	if (sig == NULL)
-		goto err;
 
 	PKCS7_SIGNER_INFO_get0_algs(si, NULL, &dig_alg, NULL);
 

--- a/libkmod/libkmod-signature.c
+++ b/libkmod/libkmod-signature.c
@@ -276,7 +276,7 @@ err:
 	return false;
 }
 
-#else /* ENABLE OPENSSL */
+#else
 
 static bool fill_pkcs7(const char *mem, off_t size, const struct module_signature *modsig,
 		       size_t sig_len, struct kmod_signature_info *sig_info)
@@ -286,7 +286,7 @@ static bool fill_pkcs7(const char *mem, off_t size, const struct module_signatur
 	return true;
 }
 
-#endif /* ENABLE OPENSSL */
+#endif
 
 #define SIG_MAGIC "~Module signature appended~\n"
 

--- a/libkmod/libkmod-signature.c
+++ b/libkmod/libkmod-signature.c
@@ -106,7 +106,7 @@ static bool fill_default(const char *mem, off_t size,
 
 struct pkcs7_private {
 	PKCS7 *pkcs7;
-	unsigned char *key_id;
+	char *key_id;
 	BIGNUM *sno;
 	char *hash_algo;
 };
@@ -166,7 +166,7 @@ static bool fill_pkcs7(const char *mem, off_t size, size_t sig_len,
 	const ASN1_OBJECT *o;
 	BIO *in;
 	int len;
-	unsigned char *key_id_str;
+	char *key_id_str;
 	struct pkcs7_private *pvt;
 	const char *issuer_str;
 	char *hash_algo;
@@ -216,9 +216,9 @@ static bool fill_pkcs7(const char *mem, off_t size, size_t sig_len,
 	key_id_str = malloc(len);
 	if (key_id_str == NULL)
 		goto err2;
-	BN_bn2bin(sno_bn, key_id_str);
+	BN_bn2bin(sno_bn, (unsigned char *)key_id_str);
 
-	sig_info->key_id = (const char *)key_id_str;
+	sig_info->key_id = key_id_str;
 	sig_info->key_id_len = len;
 
 	issuer_str = x509_name_to_str(issuer);

--- a/libkmod/libkmod-signature.c
+++ b/libkmod/libkmod-signature.c
@@ -156,8 +156,8 @@ static bool fill_pkcs7(const char *mem, off_t size, size_t sig_len,
 	PKCS7 *pkcs7;
 	STACK_OF(PKCS7_SIGNER_INFO) * sis;
 	PKCS7_SIGNER_INFO *si;
-	PKCS7_ISSUER_AND_SERIAL *is;
-	ASN1_OCTET_STRING *sig;
+	const PKCS7_ISSUER_AND_SERIAL *is;
+	const ASN1_OCTET_STRING *sig;
 	BIGNUM *sno_bn;
 	X509_ALGOR *dig_alg;
 	const ASN1_OBJECT *o;

--- a/libkmod/libkmod-signature.c
+++ b/libkmod/libkmod-signature.c
@@ -157,8 +157,6 @@ static bool fill_pkcs7(const char *mem, off_t size, size_t sig_len,
 	STACK_OF(PKCS7_SIGNER_INFO) * sis;
 	PKCS7_SIGNER_INFO *si;
 	PKCS7_ISSUER_AND_SERIAL *is;
-	X509_NAME *issuer;
-	ASN1_INTEGER *sno;
 	ASN1_OCTET_STRING *sig;
 	BIGNUM *sno_bn;
 	X509_ALGOR *dig_alg;
@@ -193,8 +191,6 @@ static bool fill_pkcs7(const char *mem, off_t size, size_t sig_len,
 		goto err;
 
 	is = si->issuer_and_serial;
-	issuer = is->issuer;
-	sno = is->serial;
 	sig = si->enc_digest;
 
 	PKCS7_SIGNER_INFO_get0_algs(si, NULL, &dig_alg, NULL);
@@ -202,7 +198,7 @@ static bool fill_pkcs7(const char *mem, off_t size, size_t sig_len,
 	sig_info->sig = (const char *)ASN1_STRING_get0_data(sig);
 	sig_info->sig_len = ASN1_STRING_length(sig);
 
-	sno_bn = ASN1_INTEGER_to_BN(sno, NULL);
+	sno_bn = ASN1_INTEGER_to_BN(is->serial, NULL);
 	if (sno_bn == NULL)
 		goto err;
 
@@ -215,7 +211,7 @@ static bool fill_pkcs7(const char *mem, off_t size, size_t sig_len,
 	sig_info->key_id = key_id_str;
 	sig_info->key_id_len = len;
 
-	issuer_str = x509_name_to_str(issuer);
+	issuer_str = x509_name_to_str(is->issuer);
 	if (issuer_str != NULL) {
 		sig_info->signer = issuer_str;
 		sig_info->signer_len = strlen(issuer_str);

--- a/libkmod/libkmod-signature.c
+++ b/libkmod/libkmod-signature.c
@@ -104,7 +104,6 @@ static bool fill_default(const char *mem, off_t size,
 
 	sig_info->algo = pkey_algo[modsig->algo];
 	sig_info->hash_algo = pkey_hash_algo[modsig->hash];
-	sig_info->id_type = pkey_id_type[modsig->id_type];
 
 	return true;
 }
@@ -156,8 +155,8 @@ static const char *x509_name_to_str(X509_NAME *name)
 	return str;
 }
 
-static bool fill_pkcs7(const char *mem, off_t size, const struct module_signature *modsig,
-		       size_t sig_len, struct kmod_signature_info *sig_info)
+static bool fill_pkcs7(const char *mem, off_t size, size_t sig_len,
+		       struct kmod_signature_info *sig_info)
 {
 	const char *pkcs7_raw;
 	PKCS7 *pkcs7;
@@ -250,8 +249,6 @@ static bool fill_pkcs7(const char *mem, off_t size, const struct module_signatur
 	// Assign libcrypto hash algo string or number
 	sig_info->hash_algo = hash_algo;
 
-	sig_info->id_type = pkey_id_type[modsig->id_type];
-
 	pvt = malloc(sizeof(*pvt));
 	if (pvt == NULL)
 		goto err4;
@@ -278,11 +275,10 @@ err:
 
 #else
 
-static bool fill_pkcs7(const char *mem, off_t size, const struct module_signature *modsig,
-		       size_t sig_len, struct kmod_signature_info *sig_info)
+static bool fill_pkcs7(const char *mem, off_t size, size_t sig_len,
+		       struct kmod_signature_info *sig_info)
 {
 	sig_info->hash_algo = "unknown";
-	sig_info->id_type = pkey_id_type[modsig->id_type];
 	return true;
 }
 
@@ -329,9 +325,11 @@ bool kmod_module_signature_info(const struct kmod_file *file,
 	    size < (int64_t)sig_len + modsig.signer_len + modsig.key_id_len)
 		return false;
 
+	sig_info->id_type = pkey_id_type[modsig.id_type];
+
 	switch (modsig.id_type) {
 	case PKEY_ID_PKCS7:
-		return fill_pkcs7(mem, size, &modsig, sig_len, sig_info);
+		return fill_pkcs7(mem, size, sig_len, sig_info);
 	default:
 		return fill_default(mem, size, &modsig, sig_len, sig_info);
 	}

--- a/libkmod/libkmod-signature.c
+++ b/libkmod/libkmod-signature.c
@@ -28,11 +28,6 @@ enum pkey_algo {
 	PKEY_ALGO__LAST,
 };
 
-static const char *const pkey_algo[PKEY_ALGO__LAST] = {
-	[PKEY_ALGO_DSA] = "DSA",
-	[PKEY_ALGO_RSA] = "RSA",
-};
-
 enum pkey_hash_algo {
 	PKEY_HASH_MD4,
 	PKEY_HASH_MD5,
@@ -102,7 +97,6 @@ static bool fill_default(const char *mem, off_t size,
 	sig_info->signer = mem + size;
 	sig_info->signer_len = modsig->signer_len;
 
-	sig_info->algo = pkey_algo[modsig->algo];
 	sig_info->hash_algo = pkey_hash_algo[modsig->hash];
 
 	return true;
@@ -317,6 +311,9 @@ bool kmod_module_signature_info(const struct kmod_file *file,
 		return false;
 	size -= sizeof(struct module_signature);
 	memcpy(&modsig, mem + size, sizeof(struct module_signature));
+	/* The algo value seems to be hard-coded to PKEY_ALGO_RSA, so we don't bother
+	 * parsing and/or printing it.
+	 */
 	if (modsig.algo >= PKEY_ALGO__LAST || modsig.hash >= PKEY_HASH__LAST ||
 	    modsig.id_type >= PKEY_ID_TYPE__LAST)
 		return false;

--- a/libkmod/libkmod-signature.c
+++ b/libkmod/libkmod-signature.c
@@ -83,8 +83,12 @@ struct module_signature {
 
 static bool fill_default(const char *mem, off_t size,
 			 const struct module_signature *modsig, size_t sig_len,
-			 struct kmod_signature_info *sig_info)
+			 struct kmod_signature_info **out_sig_info)
 {
+	struct kmod_signature_info *sig_info = calloc(1, sizeof(*sig_info));
+	if (sig_info == NULL)
+		return false;
+
 	size -= sig_len;
 	sig_info->sig = mem + size;
 	sig_info->sig_len = sig_len;
@@ -99,30 +103,12 @@ static bool fill_default(const char *mem, off_t size,
 
 	sig_info->hash_algo = pkey_hash_algo[modsig->hash];
 
+	*out_sig_info = sig_info;
+
 	return true;
 }
 
 #if ENABLE_OPENSSL
-
-struct pkcs7_private {
-	PKCS7 *pkcs7;
-	char *key_id;
-	BIGNUM *sno;
-	char *hash_algo;
-};
-
-static void pkcs7_free(void *s)
-{
-	struct kmod_signature_info *si = s;
-	struct pkcs7_private *pvt = si->private;
-
-	PKCS7_free(pvt->pkcs7);
-	BN_free(pvt->sno);
-	free(pvt->key_id);
-	free(pvt->hash_algo);
-	free(pvt);
-	si->private = NULL;
-}
 
 static const char *x509_name_to_str(X509_NAME *name)
 {
@@ -150,8 +136,10 @@ static const char *x509_name_to_str(X509_NAME *name)
 }
 
 static bool fill_pkcs7(const char *mem, off_t size, size_t sig_len,
-		       struct kmod_signature_info *sig_info)
+		       struct kmod_signature_info **out_sig_info)
 {
+	struct kmod_signature_info *sig_info;
+	char *p;
 	const char *pkcs7_raw;
 	PKCS7 *pkcs7;
 	STACK_OF(PKCS7_SIGNER_INFO) * sis;
@@ -162,12 +150,9 @@ static bool fill_pkcs7(const char *mem, off_t size, size_t sig_len,
 	X509_ALGOR *dig_alg;
 	const ASN1_OBJECT *o;
 	BIO *in;
-	int len;
-	char *key_id_str;
-	struct pkcs7_private *pvt;
 	const char *issuer_str;
-	char *hash_algo;
 	int hash_algo_len;
+	size_t total_len;
 
 	size -= sig_len;
 	pkcs7_raw = mem + size;
@@ -175,12 +160,10 @@ static bool fill_pkcs7(const char *mem, off_t size, size_t sig_len,
 	in = BIO_new_mem_buf(pkcs7_raw, sig_len);
 
 	pkcs7 = d2i_PKCS7_bio(in, NULL);
-	if (pkcs7 == NULL) {
-		BIO_free(in);
-		return false;
-	}
-
 	BIO_free(in);
+
+	if (pkcs7 == NULL)
+		goto err;
 
 	sis = PKCS7_get_signer_info(pkcs7);
 	if (sis == NULL)
@@ -191,66 +174,86 @@ static bool fill_pkcs7(const char *mem, off_t size, size_t sig_len,
 		goto err;
 
 	is = si->issuer_and_serial;
-	sig = si->enc_digest;
 
-	PKCS7_SIGNER_INFO_get0_algs(si, NULL, &dig_alg, NULL);
+	/* Calculate the total length */
+	total_len = sizeof(struct kmod_signature_info);
 
-	sig_info->sig = (const char *)ASN1_STRING_get0_data(sig);
-	sig_info->sig_len = ASN1_STRING_length(sig);
+	/* signer */
+	issuer_str = x509_name_to_str(is->issuer);
+	if (issuer_str != NULL)
+		total_len += strlen(issuer_str);
 
+	/* key_id */
 	sno_bn = ASN1_INTEGER_to_BN(is->serial, NULL);
 	if (sno_bn == NULL)
 		goto err;
 
-	len = BN_num_bytes(sno_bn);
-	key_id_str = malloc(len);
-	if (key_id_str == NULL)
-		goto err2;
-	BN_bn2bin(sno_bn, (unsigned char *)key_id_str);
+	total_len += BN_num_bytes(sno_bn);
 
-	sig_info->key_id = key_id_str;
-	sig_info->key_id_len = len;
-
-	issuer_str = x509_name_to_str(is->issuer);
-	if (issuer_str != NULL) {
-		sig_info->signer = issuer_str;
-		sig_info->signer_len = strlen(issuer_str);
-	}
-
+	/* hash_algo */
+	PKCS7_SIGNER_INFO_get0_algs(si, NULL, &dig_alg, NULL);
 	X509_ALGOR_get0(&o, NULL, NULL, dig_alg);
-
-	// Use OBJ_obj2txt to calculate string length
 	hash_algo_len = OBJ_obj2txt(NULL, 0, o, 0);
 	if (hash_algo_len < 0)
-		goto err3;
-	hash_algo = malloc(hash_algo_len + 1);
-	if (hash_algo == NULL)
-		goto err3;
-	hash_algo_len = OBJ_obj2txt(hash_algo, hash_algo_len + 1, o, 0);
+		goto err1;
+
+	total_len += hash_algo_len + 1;
+
+	/* sig */
+	sig = si->enc_digest;
+	total_len += ASN1_STRING_length(sig);
+
+	sig_info = calloc(1, total_len);
+	if (sig_info == NULL)
+		goto err1;
+
+	p = (char *)sig_info;
+
+	p += sizeof(struct kmod_signature_info);
+
+	/* signer */
+	if (issuer_str != NULL) {
+		sig_info->signer = p;
+		sig_info->signer_len = strlen(issuer_str);
+
+		memcpy(p, issuer_str, sig_info->signer_len);
+		p += sig_info->signer_len;
+	}
+
+	/* key_id */
+	sig_info->key_id = p;
+	sig_info->key_id_len = BN_num_bytes(sno_bn);
+
+	BN_bn2bin(sno_bn, (unsigned char *)p);
+	p += sig_info->key_id_len;
+
+	/* hash_algo */
+	sig_info->hash_algo = p;
+
+	hash_algo_len = OBJ_obj2txt(p, hash_algo_len + 1, o, 0);
 	if (hash_algo_len < 0)
-		goto err4;
+		goto err2;
+	p += hash_algo_len;
 
-	// Assign libcrypto hash algo string or number
-	sig_info->hash_algo = hash_algo;
+	*p = '\0';
+	p++;
 
-	pvt = malloc(sizeof(*pvt));
-	if (pvt == NULL)
-		goto err4;
+	/* sig */
+	sig_info->sig = p;
+	sig_info->sig_len = ASN1_STRING_length(sig);
 
-	pvt->pkcs7 = pkcs7;
-	pvt->key_id = key_id_str;
-	pvt->sno = sno_bn;
-	pvt->hash_algo = hash_algo;
-	sig_info->private = pvt;
+	memcpy(p, ASN1_STRING_get0_data(sig), sig_info->sig_len);
 
-	sig_info->free = pkcs7_free;
+	BN_free(sno_bn);
+	PKCS7_free(pkcs7);
+
+	*out_sig_info = sig_info;
 
 	return true;
-err4:
-	free(hash_algo);
-err3:
-	free(key_id_str);
+
 err2:
+	free(sig_info);
+err1:
 	BN_free(sno_bn);
 err:
 	PKCS7_free(pkcs7);
@@ -260,9 +263,14 @@ err:
 #else
 
 static bool fill_pkcs7(const char *mem, off_t size, size_t sig_len,
-		       struct kmod_signature_info *sig_info)
+		       struct kmod_signature_info **out_sig_info)
 {
+	struct kmod_signature_info *sig_info = calloc(1, sizeof(*sig_info));
+	if (sig_info == NULL)
+		return false;
+
 	sig_info->hash_algo = "unknown";
+	*out_sig_info = sig_info;
 	return true;
 }
 
@@ -282,12 +290,13 @@ static bool fill_pkcs7(const char *mem, off_t size, size_t sig_len,
  */
 
 bool kmod_module_signature_info(const struct kmod_file *file,
-				struct kmod_signature_info *sig_info)
+				struct kmod_signature_info **sig_info)
 {
 	const char *mem;
 	off_t size;
 	struct module_signature modsig;
 	size_t sig_len;
+	bool ret;
 
 	size = kmod_file_get_size(file);
 	mem = kmod_file_get_contents(file);
@@ -312,18 +321,17 @@ bool kmod_module_signature_info(const struct kmod_file *file,
 	    size < (int64_t)sig_len + modsig.signer_len + modsig.key_id_len)
 		return false;
 
-	sig_info->id_type = pkey_id_type[modsig.id_type];
-
 	switch (modsig.id_type) {
 	case PKEY_ID_PKCS7:
-		return fill_pkcs7(mem, size, sig_len, sig_info);
+		ret = fill_pkcs7(mem, size, sig_len, sig_info);
+		break;
 	default:
-		return fill_default(mem, size, &modsig, sig_len, sig_info);
+		ret = fill_default(mem, size, &modsig, sig_len, sig_info);
+		break;
 	}
-}
 
-void kmod_module_signature_info_free(struct kmod_signature_info *sig_info)
-{
-	if (sig_info->free)
-		sig_info->free(sig_info);
+	if (ret)
+		(*sig_info)->id_type = pkey_id_type[modsig.id_type];
+
+	return ret;
 }


### PR DESCRIPTION
Nearly every time I skim through `libkmod-signature.c` it doesn't sit well with how different it is from the rest of the codebase. Which is not surprising, since it was written and then updated by people different from the main contributors.

This doesn't mean it's bad or wrong - simply it doesn't fit with the design/style with the rest of kmod.

This PR drops a few of the small papercuts. Where the notable surgery done in `libkmod/libkmod-signature: rework struct kmod_signature_info`.

Most of the patches are self-contained, so they can be picked individually - in case I've overdone it ;-)