### PR TITLE
shared: util.c: fix buffer overflow in alias_normalize()

### DIFF
--- a/shared/util.c
+++ b/shared/util.c
@@ -79,10 +79,12 @@ int alias_normalize(const char *alias, char buf[static PATH_MAX], size_t *len)
 		case ']':
 			return -EINVAL;
 		case '[':
-			while (alias[i] != ']' && alias[i] != '\0') {
+			while (i < PATH_MAX - 1 && alias[i] != ']' && alias[i] != '\0') {
 				buf[i] = alias[i];
 				i++;
 			}
+			if (i >= PATH_MAX - 1)
+                		return -EINVAL;
 
 			if (alias[i] != ']')
 				return -EINVAL;


### PR DESCRIPTION
The while-loop inside the '[' case of alias_normalize() increments the index 'i' without checking against PATH_MAX bounds. If the input string contains an opening '[' followed by many characters without a closing ']', the index can exceed PATH_MAX-1, causing a buffer overflow when writing to buf[i].

This can be triggered by a malicious module alias string, potentially leading to stack corruption, denial of service, or arbitrary code execution depending on memory layout and compiler protections.

Fix by:
  1. Adding bounds check to the while-loop condition: while (i < PATH_MAX - 1 && alias[i] != ']' && alias[i] != '\0')
  2. Validating 'i' after the loop before accessing buf[i]
  3. Adding final bounds check before null-terminating the buffer

Reported-by: static analysis tool

Signed-off-by: Anton Moryakov <ant.v.moryakov@gmail.com>
