### PR TITLE
Add build-id to modinfo

### DIFF
--- a/libkmod/libkmod-elf.c
+++ b/libkmod/libkmod-elf.c
@@ -14,6 +14,7 @@
 
 #include "libkmod.h"
 #include "libkmod-internal.h"
+#include <wchar.h>
 
 /* as defined in module-init-tools */
 struct kmod_modversion32 {
@@ -32,6 +33,7 @@ enum kmod_elf_section {
 	KMOD_ELF_SECTION_STRTAB,
 	KMOD_ELF_SECTION_SYMTAB,
 	KMOD_ELF_SECTION_VERSIONS,
+	KMOD_ELF_SECTION_BUILD_ID,
 	KMOD_ELF_SECTION_MAX,
 };
 
@@ -41,6 +43,7 @@ static const char *const section_name_map[] = {
 	[KMOD_ELF_SECTION_STRTAB] = ".strtab",
 	[KMOD_ELF_SECTION_SYMTAB] = ".symtab",
 	[KMOD_ELF_SECTION_VERSIONS] = "__versions",
+	[KMOD_ELF_SECTION_BUILD_ID] = ".note.gnu.build-id",
 };
 
 struct kmod_elf {
@@ -1251,4 +1254,55 @@ int kmod_elf_get_dependency_symbols(const struct kmod_elf *elf,
 	}
 	free(visited_versions);
 	return count;
+}
+
+#ifndef NT_GNU_BUILD_ID
+#define NT_GNU_BUILD_ID 3
+#endif
+
+/*
+ * Read the .notes.gnu.build-id section that is added by the linker via --build-id. The
+ * section format follows the one defined in shared/elf-note.h, with name == "GNU\0",
+ * type == NT_GNU_BUILD_ID and desc being the hash.
+ */
+int kmod_elf_get_build_id(const struct kmod_elf *elf, const void **hash, size_t *hash_len)
+{
+	uint64_t off, size;
+	uint32_t namesz, descsz, type;
+	const char *name;
+
+	*hash = NULL;
+	*hash_len = 0;
+
+	off = elf->sections[KMOD_ELF_SECTION_BUILD_ID].offset;
+	size = elf->sections[KMOD_ELF_SECTION_BUILD_ID].size;
+	if (off == 0 || size == 0)
+		return -ENODATA;
+
+	if (size < 12) {
+		ELFDBG(elf, "build-id section is too small: %" PRIu64 "\n", size);
+		return -EINVAL;
+	}
+
+	namesz = elf_get_uint32(elf, off);
+	descsz = elf_get_uint32(elf, off + 4);
+	type = elf_get_uint32(elf, off + 8);
+
+	if (size < 12 + namesz + descsz) {
+		ELFDBG(elf, "build-id section is too small: %" PRIu64 "\n", size);
+		return -EINVAL;
+	}
+
+	name = elf_get_mem(elf, off + 12);
+
+	if (type != NT_GNU_BUILD_ID || namesz != 4 || memcmp(name, "GNU\0", 4)) {
+		ELFDBG(elf, "Invalid buid-id section: type %" PRIu32 ", name %.3s\n",
+		       type, name);
+		return -EINVAL;
+	}
+
+	*hash = elf_get_mem(elf, off + 16);
+	*hash_len = descsz;
+
+	return 0;
 }

--- a/libkmod/libkmod-elf.c
+++ b/libkmod/libkmod-elf.c
@@ -162,6 +162,11 @@ static uint64_t elf_get_uint(const struct kmod_elf *elf, uint64_t offset, uint16
 	return ret;
 }
 
+static inline uint32_t elf_get_uint32(const struct kmod_elf *elf, uint64_t offset)
+{
+	return elf_get_uint(elf, offset, 4);
+}
+
 static int elf_set_uint(const struct kmod_elf *elf, uint64_t offset, uint64_t size,
 			uint64_t value, uint8_t *changed)
 {
@@ -796,7 +801,8 @@ static uint64_t kmod_elf_resolve_crc(const struct kmod_elf *elf, uint64_t crc,
 		return (uint64_t)-1;
 	}
 
-	crc = elf_get_uint(elf, off + crc, sizeof(uint32_t));
+	crc = elf_get_uint32(elf, off + crc);
+
 	return crc;
 }
 

--- a/libkmod/libkmod-elf.c
+++ b/libkmod/libkmod-elf.c
@@ -125,8 +125,7 @@ static int elf_identify(struct kmod_elf *elf, const void *memory, uint64_t size)
 	return 0;
 }
 
-static inline bool elf_range_valid(const struct kmod_elf *elf, uint64_t offset,
-				   uint64_t size)
+static bool elf_range_valid(const struct kmod_elf *elf, uint64_t offset, uint64_t size)
 {
 	uint64_t min_size;
 
@@ -140,8 +139,7 @@ static inline bool elf_range_valid(const struct kmod_elf *elf, uint64_t offset,
 	return true;
 }
 
-static inline uint64_t elf_get_uint(const struct kmod_elf *elf, uint64_t offset,
-				    uint16_t size)
+static uint64_t elf_get_uint(const struct kmod_elf *elf, uint64_t offset, uint16_t size)
 {
 	const uint8_t *p;
 	uint64_t ret = 0;
@@ -164,8 +162,8 @@ static inline uint64_t elf_get_uint(const struct kmod_elf *elf, uint64_t offset,
 	return ret;
 }
 
-static inline int elf_set_uint(const struct kmod_elf *elf, uint64_t offset, uint64_t size,
-			       uint64_t value, uint8_t *changed)
+static int elf_set_uint(const struct kmod_elf *elf, uint64_t offset, uint64_t size,
+			uint64_t value, uint8_t *changed)
 {
 	uint8_t *p;
 	size_t i;
@@ -201,8 +199,7 @@ static inline const void *elf_get_mem(const struct kmod_elf *elf, uint64_t offse
  * Returns offset to section header for section with given index or 0 on error
  * (offset 0 cannot be a valid section offset because ELF header is located there).
  */
-static inline uint64_t elf_get_section_header_offset(const struct kmod_elf *elf,
-						     uint16_t idx)
+static uint64_t elf_get_section_header_offset(const struct kmod_elf *elf, uint16_t idx)
 {
 	assert(idx != SHN_UNDEF);
 	assert(idx < elf->header.section.count);
@@ -215,9 +212,8 @@ static inline uint64_t elf_get_section_header_offset(const struct kmod_elf *elf,
 	       (uint64_t)(idx * elf->header.section.entry_size);
 }
 
-static inline int elf_get_section_info(const struct kmod_elf *elf, uint16_t idx,
-				       uint64_t *offset, uint64_t *size,
-				       const char **name)
+static int elf_get_section_info(const struct kmod_elf *elf, uint16_t idx,
+				uint64_t *offset, uint64_t *size, const char **name)
 {
 	uint64_t nameoff;
 	uint64_t off = elf_get_section_header_offset(elf, idx);

--- a/libkmod/libkmod-elf.c
+++ b/libkmod/libkmod-elf.c
@@ -162,6 +162,11 @@ static uint64_t elf_get_uint(const struct kmod_elf *elf, uint64_t offset, uint16
 	return ret;
 }
 
+static inline uint32_t elf_get_u32(const struct kmod_elf *elf, uint64_t offset)
+{
+	return elf_get_uint(elf, offset, sizeof(uint32_t));
+}
+
 static int elf_set_uint(const struct kmod_elf *elf, uint64_t offset, uint64_t size,
 			uint64_t value, uint8_t *changed)
 {
@@ -791,7 +796,8 @@ static uint64_t kmod_elf_resolve_crc(const struct kmod_elf *elf, uint64_t crc,
 		return (uint64_t)-1;
 	}
 
-	crc = elf_get_uint(elf, off + crc, sizeof(uint32_t));
+	crc = elf_get_u32(elf, off + crc);
+
 	return crc;
 }
 

--- a/libkmod/libkmod-elf.c
+++ b/libkmod/libkmod-elf.c
@@ -32,6 +32,7 @@ enum kmod_elf_section {
 	KMOD_ELF_SECTION_STRTAB,
 	KMOD_ELF_SECTION_SYMTAB,
 	KMOD_ELF_SECTION_VERSIONS,
+	KMOD_ELF_SECTION_BUILD_ID,
 	KMOD_ELF_SECTION_MAX,
 };
 
@@ -41,6 +42,7 @@ static const char *const section_name_map[] = {
 	[KMOD_ELF_SECTION_STRTAB] = ".strtab",
 	[KMOD_ELF_SECTION_SYMTAB] = ".symtab",
 	[KMOD_ELF_SECTION_VERSIONS] = "__versions",
+	[KMOD_ELF_SECTION_BUILD_ID] = ".note.gnu.build-id",
 };
 
 struct kmod_elf {
@@ -1246,4 +1248,63 @@ int kmod_elf_get_dependency_symbols(const struct kmod_elf *elf,
 	}
 	free(visited_versions);
 	return count;
+}
+
+#ifndef NT_GNU_BUILD_ID
+#define NT_GNU_BUILD_ID 3
+#endif
+
+/*
+ * Read the .notes.gnu.build-id section that is added by the linker via --build-id. The
+ * section format follows the one defined in shared/elf-note.h, with name == "GNU\0",
+ * type == NT_GNU_BUILD_ID and desc being the hash.
+ */
+int kmod_elf_get_build_id(const struct kmod_elf *elf, const void **hash, size_t *hash_len)
+{
+	uint32_t namesz, descsz, type;
+	uint64_t off, size;
+	const char *name;
+
+	off = elf->sections[KMOD_ELF_SECTION_BUILD_ID].offset;
+	size = elf->sections[KMOD_ELF_SECTION_BUILD_ID].size;
+	if (off == 0 || size == 0)
+		/*
+		 * Conditionally available since 4.10 if toolchain supports it.
+		 * Unconditionally available since 5.10:
+		 * kernel- commit 89ff7131f78a ("kbuild: add --hash-style= and
+		 * --build-id unconditionally"). Just return an error and don't
+		 * log anything.
+		 */
+		return -ENODATA;
+
+	if (size < 3 * sizeof(uint32_t)) {
+		ELFDBG(elf, "build-id section is too small: %" PRIu64 "\n", size);
+		return -EINVAL;
+	}
+
+	namesz = elf_get_u32(elf, off);
+	off += sizeof(uint32_t);
+	descsz = elf_get_u32(elf, off);
+	off += sizeof(uint32_t);
+	type = elf_get_u32(elf, off);
+	off += sizeof(uint32_t);
+
+	if (size < 3 * sizeof(uint32_t) + namesz + descsz) {
+		ELFDBG(elf, "build-id section is too small: %" PRIu64 "\n", size);
+		return -EINVAL;
+	}
+
+	name = elf_get_mem(elf, off);
+
+	if (type != NT_GNU_BUILD_ID || !streq(name, "GNU")) {
+		ELFDBG(elf, "Invalid build-id section: type %" PRIu32 ", name %.3s\n",
+		       type, name);
+		return -EINVAL;
+	}
+
+	off += namesz;
+	*hash = elf_get_mem(elf, off);
+	*hash_len = descsz;
+
+	return 0;
 }

--- a/libkmod/libkmod-internal.h
+++ b/libkmod/libkmod-internal.h
@@ -160,6 +160,7 @@ _must_check_ _nonnull_all_ int kmod_elf_get_modinfo_strings(const struct kmod_el
 _must_check_ _nonnull_all_ int kmod_elf_get_modversions(const struct kmod_elf *elf, struct kmod_modversion **array);
 _must_check_ _nonnull_all_ int kmod_elf_get_symbols(const struct kmod_elf *elf, struct kmod_modversion **array);
 _must_check_ _nonnull_all_ int kmod_elf_get_dependency_symbols(const struct kmod_elf *elf, struct kmod_modversion **array);
+_must_check_ _nonnull_all_ int kmod_elf_get_build_id(const struct kmod_elf *elf, const void **hash, size_t *hash_len);
 _must_check_ _nonnull_all_ int kmod_elf_strip(const struct kmod_elf *elf, unsigned int flags, const void **stripped);
 
 /*

--- a/libkmod/libkmod-internal.h
+++ b/libkmod/libkmod-internal.h
@@ -156,6 +156,7 @@ _must_check_ _nonnull_all_ int kmod_elf_get_modinfo_strings(const struct kmod_el
 _must_check_ _nonnull_all_ int kmod_elf_get_modversions(const struct kmod_elf *elf, struct kmod_modversion **array);
 _must_check_ _nonnull_all_ int kmod_elf_get_symbols(const struct kmod_elf *elf, struct kmod_modversion **array);
 _must_check_ _nonnull_all_ int kmod_elf_get_dependency_symbols(const struct kmod_elf *elf, struct kmod_modversion **array);
+_must_check_ _nonnull_all_ int kmod_elf_get_build_id(const struct kmod_elf *elf, const void **hash, size_t *hash_len);
 _must_check_ _nonnull_all_ int kmod_elf_strip(const struct kmod_elf *elf, unsigned int flags, const void **stripped);
 
 /*

--- a/libkmod/libkmod-module.c
+++ b/libkmod/libkmod-module.c
@@ -1853,7 +1853,7 @@ list_error:
 KMOD_EXPORT int kmod_module_get_info(const struct kmod_module *mod,
 				     struct kmod_list **list)
 {
-	struct kmod_elf *elf;
+	struct kmod_elf *elf = NULL;
 	char **strings;
 	int i, count, ret = -ENOMEM;
 	struct kmod_signature_info sig_info = {};
@@ -1899,6 +1899,22 @@ KMOD_EXPORT int kmod_module_get_info(const struct kmod_module *mod,
 		n = kmod_module_info_append(list, key, keylen, value, valuelen);
 		if (n == NULL)
 			goto list_error;
+	}
+
+	if (elf != NULL) {
+		const void *build_id;
+		size_t build_id_len;
+
+		if (kmod_elf_get_build_id(elf, &build_id, &build_id_len) == 0) {
+			struct kmod_list *n;
+
+			n = kmod_module_info_append_hex(list, "build-id",
+							strlen("build-id"), build_id,
+							build_id_len);
+			if (n == NULL)
+				goto list_error;
+			count++;
+		}
 	}
 
 	if (mod->file && kmod_module_signature_info(mod->file, &sig_info)) {

--- a/libkmod/libkmod-module.c
+++ b/libkmod/libkmod-module.c
@@ -1914,6 +1914,22 @@ KMOD_EXPORT int kmod_module_get_info(const struct kmod_module *mod,
 			goto list_error;
 	}
 
+	if (mod->elf) {
+		const void *build_id;
+		size_t build_id_len;
+
+		if (kmod_elf_get_build_id(mod->elf, &build_id, &build_id_len) == 0) {
+			struct kmod_list *n;
+
+			n = kmod_module_info_append_hex(list, "build-id",
+							strlen("build-id"), build_id,
+							build_id_len);
+			if (n == NULL)
+				goto list_error;
+			count++;
+		}
+	}
+
 	if (mod->file && kmod_module_signature_info(mod->file, &sig_info)) {
 		struct kmod_list *n;
 


### PR DESCRIPTION
Kernel uses -Wl,--build-id in the build system, which causes a .notes.gnu.build-id section to be created containing. This can then be used by people developing modules to make sure the running module is the one that was last built.

I used to rely on srcversion for that purpose, but it has 2 issues:
1) It doesn't change if the compilation options change
2) It may be [going away in a future kernel version](https://lore.kernel.org/all/2026031303-prelaunch-creation-3fce@gregkh/)

As per last commit message, this can already be used as is, but is rather cumbersome. I will add more commits later to probably have a `modinfo -F raw-build-id` that simply dumps the section, which would allow to compare with the sysfs with something like:

```
cmp <(cat /sys/module/foobar/notes/.note.gnu.build-id) <(modinfo -F raw-build-id foobar)
```

I'm on the fence about that because we could simply leave modinfo alone for that and add built-in tool:

```
$ kmod build-id --check --verbose foobar
live: a:b:c:...
file: a:b:c:...
match: ok
$ echo $?
0
```