### PR TITLE
Some missing.h polish

### DIFF
--- a/libkmod/libkmod-config.c
+++ b/libkmod/libkmod-config.c
@@ -16,6 +16,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
+#include <shared/missing.h> // For basename
 #include <shared/util.h>
 
 #include "libkmod.h"

--- a/libkmod/libkmod-elf.c
+++ b/libkmod/libkmod-elf.c
@@ -6,6 +6,7 @@
 #include <assert.h>
 #include <elf.h>
 #include <endian.h>
+#include <errno.h>
 #include <limits.h>
 #include <stdlib.h>
 #include <string.h>

--- a/libkmod/libkmod-internal.h
+++ b/libkmod/libkmod-internal.h
@@ -6,7 +6,6 @@
 #include <limits.h>
 
 #include <shared/macro.h>
-#include <shared/missing.h>
 
 #include "libkmod.h"
 

--- a/libkmod/libkmod-module.c
+++ b/libkmod/libkmod-module.c
@@ -22,6 +22,7 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 
+#include <shared/missing.h> // For finit_module
 #include <shared/strbuf.h>
 #include <shared/util.h>
 

--- a/libkmod/libkmod-module.c
+++ b/libkmod/libkmod-module.c
@@ -620,6 +620,16 @@ KMOD_EXPORT int kmod_module_remove_module(struct kmod_module *mod, unsigned int 
 
 extern long init_module(const void *mem, unsigned long len, const char *args);
 
+/*
+ * (Re-)define some linux/module.h macros.
+ *
+ * In practice, most people/distros do not have the relevant package/header during the
+ * build. The values are UAPI and cannot change, so we might as well have them locally.
+ */
+#define MODULE_INIT_IGNORE_MODVERSIONS 1
+#define MODULE_INIT_IGNORE_VERMAGIC 2
+#define MODULE_INIT_COMPRESSED_FILE 4
+
 static int do_finit_module(struct kmod_module *mod, unsigned int flags, const char *args)
 {
 	enum kmod_file_compression_type compression, kernel_compression;

--- a/libkmod/libkmod-signature.c
+++ b/libkmod/libkmod-signature.c
@@ -16,7 +16,6 @@
 #include <string.h>
 
 #include <shared/elf-note.h>
-#include <shared/missing.h>
 #include <shared/util.h>
 
 #include "libkmod-internal.h"

--- a/shared/missing.h
+++ b/shared/missing.h
@@ -3,18 +3,6 @@
 #include <unistd.h>
 #include <sys/syscall.h>
 
-/*
- * Macros pulled from linux/module.h, to avoid pulling the header.
- *
- * In practice, very few people have it installed and distros do not install the
- * relevant package during their build.
- *
- * Values are UAPI, so they cannot change.
- */
-#define MODULE_INIT_IGNORE_MODVERSIONS 1
-#define MODULE_INIT_IGNORE_VERMAGIC 2
-#define MODULE_INIT_COMPRESSED_FILE 4
-
 #ifndef __NR_finit_module
 #warning __NR_finit_module missing - kmod might not work correctly
 #define __NR_finit_module -1

--- a/shared/tmpfile-util.c
+++ b/shared/tmpfile-util.c
@@ -14,7 +14,7 @@
 #include <unistd.h>
 
 #include <shared/macro.h>
-#include <shared/missing.h>
+#include <shared/missing.h> // For basename
 #include <shared/tmpfile-util.h>
 #include <shared/util.h>
 

--- a/shared/util.c
+++ b/shared/util.c
@@ -16,7 +16,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <shared/missing.h>
+#include <shared/missing.h> // For basename
 #include <shared/util.h>
 
 #define USEC_PER_SEC 1000000ULL

--- a/testsuite/init_module.c
+++ b/testsuite/init_module.c
@@ -27,6 +27,7 @@
 #include <sys/types.h>
 #include <sys/utsname.h>
 
+#include <shared/missing.h> // For finit_module
 #include <shared/util.h>
 
 /* kmod_elf_get_section() is not exported, we need the private header */

--- a/testsuite/testsuite.c
+++ b/testsuite/testsuite.c
@@ -20,7 +20,7 @@
 #include <sys/stat.h>
 #include <sys/wait.h>
 
-#include <shared/missing.h>
+#include <shared/missing.h> // For basename
 #include <shared/util.h>
 
 #include "testsuite.h"

--- a/tools/depmod.c
+++ b/tools/depmod.c
@@ -23,6 +23,7 @@
 #include <shared/array.h>
 #include <shared/hash.h>
 #include <shared/macro.h>
+#include <shared/missing.h> // For basename
 #include <shared/strbuf.h>
 #include <shared/tmpfile-util.h>
 #include <shared/util.h>

--- a/tools/kmod.c
+++ b/tools/kmod.c
@@ -4,12 +4,12 @@
  */
 
 #include <getopt.h>
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include <shared/util.h>
-#include <shared/missing.h>
 
 #include <libkmod/libkmod.h>
 


### PR DESCRIPTION
While moving the openssl code, I've noticed that the `missing.h` handling could be flattened/improved a bit. So here it is:
 - moving the `MODULE_INIT_*` defines to their sole user
 - moving the `missing.h` inclusion where it's used and fixing the fallout

Aside: some v7.1-rc5 commits promote more of the module data/structs that we use to UAPI headers... Which means we could reuse it - either via `missing.h`, pulling a local copy or otherwise - in the not too distant future. Aka somewhat related to https://github.com/kmod-project/kmod/issues/428