### PR TITLE
Ci updates

### DIFF
--- a/.github/actions/setup-os/setup-ubuntu.sh
+++ b/.github/actions/setup-os/setup-ubuntu.sh
@@ -6,6 +6,14 @@
 
 export DEBIAN_FRONTEND=noninteractive
 export TZ=Etc/UTC
+
+. /etc/os-release
+
+mbedtls_pkgs=()
+if [[ "$VERSION_CODENAME" == "resolute" ]]; then
+    mbedtls_pkgs=("libmbedtls-dev")
+fi
+
 apt-get update
 apt-get install --yes \
     bash \
@@ -21,6 +29,7 @@ apt-get install --yes \
     libzstd-dev \
     linux-headers-generic \
     meson \
+    "${mbedtls_pkgs[@]}" \
     scdoc \
     zlib1g-dev \
     zstd

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   stylecheck:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: git fetch --depth=1 origin ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
       actions: read
       security-events: write
@@ -31,8 +31,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - container: 'ubuntu:24.04'
-            meson_setup: '-D b_sanitize=none -D build-tests=false -Dmbedtls=disabled'
+          - container: 'ubuntu:26.04'
+            meson_setup: '-D b_sanitize=none -D build-tests=false'
 
     container:
       image: ${{ matrix.container }}

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   spellcheck:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579 # v2.2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -52,4 +52,4 @@ jobs:
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: builddir/meson-logs/coverage.xml
+          files: builddir/meson-logs/coverage.xml

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -53,3 +53,4 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: builddir/meson-logs/coverage.xml
+          plugins: gcov

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,13 +22,13 @@ env:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     strategy:
       fail-fast: false
       matrix:
         include:
-          - container: 'ubuntu:24.04'
+          - container: 'ubuntu:26.04'
             meson_setup: '-D b_sanitize=none -D b_coverage=true -Dmbedtls=disabled'
 
     container:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,9 +17,9 @@ concurrency:
 
 jobs:
   docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     container:
-      image: 'ubuntu:24.04'
+      image: 'ubuntu:26.04'
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,7 @@ jobs:
             meson_setup: '-Dmbedtls=disabled'
           - container: 'ubuntu:24.04'
             meson_setup: '-Dmbedtls=disabled'
+          - container: 'ubuntu:26.04'
 
           # Special configurations
 


### PR DESCRIPTION
Few commits inspired while looking at the code coverage action, namely:

- we can add/bump ubuntu container/runners to 26.04 - much new, so shiny - also mbedtls v3
- ~~codecov action warns about missing python-coverage, even though it should (tm) be using gcov~~ explicitly specify `gcov` as the only plugin - moar codecov v5 "deprecation" snafu
- codecov v5 removed support for `file`, which they listed as "changed" and "deprecated" :stuck_out_tongue: 

Hope this is enough to get it working reliably :crossed_fingers: since the alternative might be a bug in their server code.