### PR TITLE
Modinfo rework

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -2,5 +2,4 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-caf
 parm

--- a/libkmod/valgrind/kmod.supp
+++ b/libkmod/valgrind/kmod.supp
@@ -1,7 +1,13 @@
 {
-   ignore-leaked-dlopen-handles
+   ignore-leaked-dlopen-handles 1
    Memcheck:Leak
    ...
    fun:dlopen@@GLIBC_2.34
+}
+{
+   ignore-leaked-dlopen-handles 2
+   Memcheck:Leak
+   ...
+   fun:_dl_open
 }
 

--- a/shared/macro.h
+++ b/shared/macro.h
@@ -31,6 +31,9 @@
 
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]) + _array_size_chk(arr))
 
+#define _ALIGN_MASK(x, _MASK) (((x) + (_MASK)) & ~(_MASK))
+#define ALIGN(x, B) _ALIGN_MASK(x, (typeof(x))(B) - 1)
+
 #define XSTRINGIFY(x) #x
 #define STRINGIFY(x) XSTRINGIFY(x)
 

--- a/shared/strbuf.c
+++ b/shared/strbuf.c
@@ -33,7 +33,7 @@ static bool buf_realloc(struct strbuf *buf, size_t sz)
 	return true;
 }
 
-static bool strbuf_reserve_extra(struct strbuf *buf, size_t n)
+bool strbuf_reserve_extra(struct strbuf *buf, size_t n)
 {
 	if (n < buf->size - buf->used)
 		return true;

--- a/shared/strbuf.c
+++ b/shared/strbuf.c
@@ -19,13 +19,11 @@ static bool buf_realloc(struct strbuf *buf, size_t sz)
 {
 	void *tmp = realloc(buf->heap ? buf->bytes : NULL, sz);
 
-	if (sz > 0) {
-		if (tmp == NULL)
-			return false;
+	if (tmp == NULL)
+		return false;
 
-		if (!buf->heap)
-			memcpy(tmp, buf->bytes, MIN(buf->size, sz));
-	}
+	if (!buf->heap)
+		memcpy(tmp, buf->bytes, MIN(buf->size, sz));
 
 	buf->heap = true;
 	buf->bytes = tmp;

--- a/shared/strbuf.c
+++ b/shared/strbuf.c
@@ -39,10 +39,12 @@ static bool strbuf_reserve_extra(struct strbuf *buf, size_t n)
 	if (n < buf->size - buf->used)
 		return true;
 
-	if (uaddsz_overflow(buf->used, n, &n) || n >= SIZE_MAX - BUF_STEP)
+	/* Reserve extra space for the \0 byte */
+	if (uaddsz_overflow(n, 1, &n) || uaddsz_overflow(buf->used, n, &n) ||
+	    n > SIZE_MAX - BUF_STEP)
 		return false;
 
-	if (++n % BUF_STEP)
+	if (n % BUF_STEP)
 		n = ((n / BUF_STEP) + 1) * BUF_STEP;
 
 	return buf_realloc(buf, n);

--- a/shared/strbuf.c
+++ b/shared/strbuf.c
@@ -10,8 +10,9 @@
 #include <string.h>
 #include <sys/param.h>
 
-#include "util.h"
+#include "macro.h"
 #include "strbuf.h"
+#include "util.h"
 
 #define BUF_STEP 128
 
@@ -42,8 +43,7 @@ static bool strbuf_reserve_extra(struct strbuf *buf, size_t n)
 	    n > SIZE_MAX - BUF_STEP)
 		return false;
 
-	if (n % BUF_STEP)
-		n = ((n / BUF_STEP) + 1) * BUF_STEP;
+	n = ALIGN(n, BUF_STEP);
 
 	return buf_realloc(buf, n);
 }

--- a/shared/strbuf.h
+++ b/shared/strbuf.h
@@ -83,8 +83,7 @@ void strbuf_popchar(struct strbuf *buf);
  *
  * Example:
  *
- * 	struct strbuf buf;
- * 	strbuf_init(&buf);
+ * 	DECLARE_STRBUF(buf);
  * 	strbuf_pushchars(&buf, "foobar");
  * 	strbuf_popchars(&buf, 5);
  *

--- a/shared/strbuf.h
+++ b/shared/strbuf.h
@@ -50,6 +50,16 @@ void strbuf_clear(struct strbuf *buf);
  */
 const char *strbuf_str(struct strbuf *buf);
 
+/*
+ * Reserve/allocate extra space to buf.
+ *
+ * Check the current buf size and re-allocate, as needed. Therefore follow-up pushes of the
+ * given size (or less) are guaranteed to a) not require re-allocation and b) succeed.
+ *
+ * The terminating \0 byte will be handled internally.
+ */
+bool strbuf_reserve_extra(struct strbuf *buf, size_t n);
+
 bool strbuf_pushchar(struct strbuf *buf, char ch);
 size_t strbuf_pushmem(struct strbuf *buf, const char *src, size_t sz);
 static inline size_t strbuf_pushchars(struct strbuf *buf, const char *str)

--- a/testsuite/test-shared.c
+++ b/testsuite/test-shared.c
@@ -626,6 +626,30 @@ static int test_strbuf_used(void)
 }
 DEFINE_TEST(test_strbuf_used, .description = "test strbuf_used");
 
+static int test_strbuf_reserve_extra(void)
+{
+	DECLARE_STRBUF(buf);
+	const char *str;
+	size_t size;
+
+	strbuf_reserve_extra(&buf, strlen(TEXT));
+	size = buf.size;
+	str = buf.bytes;
+	TS_ASSERT(size >= strlen(TEXT) + 1);
+
+	strbuf_pushchars(&buf, TEXT);
+	TS_ASSERT(size == buf.size);
+	TS_ASSERT(str == buf.bytes);
+
+	strbuf_clear(&buf);
+	strbuf_pushchars(&buf, TEXT);
+	TS_ASSERT(size == buf.size);
+	TS_ASSERT(str == buf.bytes);
+
+	return 0;
+}
+DEFINE_TEST(test_strbuf_reserve_extra, .description = "test strbuf_reserve_extra");
+
 static int test_strbuf_shrink_to(void)
 {
 	_cleanup_strbuf_ struct strbuf buf;

--- a/testsuite/test-shared.c
+++ b/testsuite/test-shared.c
@@ -475,11 +475,9 @@ static const char *TEXT =
 
 static int test_strbuf_pushchar(void)
 {
-	_cleanup_strbuf_ struct strbuf buf;
+	DECLARE_STRBUF(buf);
 	const char *result;
 	const char *c;
-
-	strbuf_init(&buf);
 
 	for (c = TEXT; *c != '\0'; c++)
 		strbuf_pushchar(&buf, *c);
@@ -494,13 +492,12 @@ DEFINE_TEST(test_strbuf_pushchar, .description = "test strbuf_{pushchar, str, st
 
 static int test_strbuf_pushchars(void)
 {
-	_cleanup_strbuf_ struct strbuf buf;
+	DECLARE_STRBUF(buf);
 	const char *result;
 	char *saveptr = NULL, *str;
 	const char *c;
 	size_t lastwordlen = 0;
 
-	strbuf_init(&buf);
 	str = strdup(TEXT);
 	for (c = strtok_r(str, " ", &saveptr); c != NULL;
 	     c = strtok_r(NULL, " ", &saveptr)) {
@@ -589,9 +586,8 @@ DEFINE_TEST(test_strbuf_with_heap, .description = "test strbuf with heap only");
 
 static int test_strbuf_pushmem(void)
 {
-	_cleanup_strbuf_ struct strbuf buf;
+	DECLARE_STRBUF(buf);
 
-	strbuf_init(&buf);
 	strbuf_pushmem(&buf, "", 0);
 	strbuf_pushmem(&buf, TEXT, strlen(TEXT) + 1);
 
@@ -603,9 +599,8 @@ DEFINE_TEST(test_strbuf_pushmem, .description = "test strbuf_reserve");
 
 static int test_strbuf_used(void)
 {
-	_cleanup_strbuf_ struct strbuf buf;
+	DECLARE_STRBUF(buf);
 
-	strbuf_init(&buf);
 	TS_ASSERT(strbuf_used(&buf) == 0);
 
 	strbuf_pushchars(&buf, TEXT);
@@ -652,9 +647,8 @@ DEFINE_TEST(test_strbuf_reserve_extra, .description = "test strbuf_reserve_extra
 
 static int test_strbuf_shrink_to(void)
 {
-	_cleanup_strbuf_ struct strbuf buf;
+	DECLARE_STRBUF(buf);
 
-	strbuf_init(&buf);
 	strbuf_shrink_to(&buf, 0);
 	TS_ASSERT(strbuf_used(&buf) == 0);
 
@@ -668,9 +662,8 @@ DEFINE_TEST(test_strbuf_shrink_to, .description = "test strbuf_shrink_to");
 
 static int xfail_strbuf_shrink_to(void)
 {
-	_cleanup_strbuf_ struct strbuf buf;
+	DECLARE_STRBUF(buf);
 
-	strbuf_init(&buf);
 	strbuf_pushchar(&buf, '/');
 
 	/* This should crash on assert */

--- a/tools/modinfo.c
+++ b/tools/modinfo.c
@@ -187,16 +187,18 @@ static int modinfo_do(struct kmod_module *mod)
 	if (is_builtin) {
 		if (field == NULL)
 			print_line("name", kmod_module_get_name(mod));
-		else if (field != NULL && streq(field, "name"))
+		else if (streq(field, "name")) {
 			print_line(NULL, kmod_module_get_name(mod));
+			return 0;
+		}
 		filename = "(builtin)";
 	}
 
-	if (field != NULL && streq(field, "filename")) {
+	if (field == NULL)
+		print_line("filename", filename);
+	else if (streq(field, "filename")) {
 		print_line(NULL, filename);
 		return 0;
-	} else if (field == NULL) {
-		print_line("filename", filename);
 	}
 
 	err = kmod_module_get_info(mod, &list);
@@ -223,10 +225,11 @@ static int modinfo_do(struct kmod_module *mod)
 		const char *value = kmod_module_info_get_value(l);
 
 		if (field != NULL) {
-			if (streq(field, key)) {
+			if (streq(field, key))
 				print_line(NULL, value);
-			}
-		} else if (streq(key, "parm")) {
+			continue;
+		}
+		if (streq(key, "parm")) {
 			err = process_parm(parm_desc, value, &params);
 			if (err < 0)
 				goto end;

--- a/tools/modinfo.c
+++ b/tools/modinfo.c
@@ -28,19 +28,19 @@ static const char *field;
 struct param {
 	struct param *next;
 	const char *name;
-	const char *param;
+	const char *desc;
 	const char *type;
 	int namelen;
-	int paramlen;
+	int desclen;
 	int typelen;
 };
 
-static int add_param(const char *name, size_t namelen, const char *param, size_t paramlen,
+static int add_param(const char *name, size_t namelen, const char *desc, size_t desclen,
 		     const char *type, size_t typelen, struct param **list)
 {
 	struct param *it;
 
-	if (namelen > INT_MAX || paramlen > INT_MAX || typelen > INT_MAX) {
+	if (namelen > INT_MAX || desclen > INT_MAX || typelen > INT_MAX) {
 		return -EINVAL;
 	}
 
@@ -57,15 +57,15 @@ static int add_param(const char *name, size_t namelen, const char *param, size_t
 		*list = it;
 		it->name = name;
 		it->namelen = namelen;
-		it->param = NULL;
+		it->desc = NULL;
 		it->type = NULL;
-		it->paramlen = 0;
+		it->desclen = 0;
 		it->typelen = 0;
 	}
 
-	if (param != NULL) {
-		it->param = param;
-		it->paramlen = paramlen;
+	if (desc != NULL) {
+		it->desc = desc;
+		it->desclen = desclen;
 	}
 
 	if (type != NULL) {
@@ -78,8 +78,8 @@ static int add_param(const char *name, size_t namelen, const char *param, size_t
 
 static int process_parm(const char *key, const char *value, struct param **params)
 {
-	const char *name, *param, *type;
-	size_t namelen, paramlen, typelen;
+	const char *name, *desc, *type;
+	size_t namelen, desclen, typelen;
 	const char *colon = strchr(value, ':');
 	int ret;
 
@@ -96,18 +96,18 @@ static int process_parm(const char *key, const char *value, struct param **param
 	name = value;
 	namelen = colon - value;
 	if (streq(key, "parm")) {
-		param = colon + 1;
-		paramlen = strlen(param);
+		desc = colon + 1;
+		desclen = strlen(desc);
 		type = NULL;
 		typelen = 0;
 	} else {
-		param = NULL;
-		paramlen = 0;
+		desc = NULL;
+		desclen = 0;
 		type = colon + 1;
 		typelen = strlen(type);
 	}
 
-	ret = add_param(name, namelen, param, paramlen, type, typelen, params);
+	ret = add_param(name, namelen, desc, desclen, type, typelen, params);
 	if (ret < 0) {
 		ERR("Unable to add parameter: %s\n", strerror(-ret));
 		return -ENOMEM;
@@ -137,14 +137,14 @@ static int modinfo_params_do(const struct kmod_list *list)
 		struct param *p = params;
 		params = p->next;
 
-		if (p->param == NULL)
+		if (p->desc == NULL)
 			printf("%.*s: (%.*s)%c", p->namelen, p->name, p->typelen, p->type,
 			       separator);
 		else if (p->type != NULL)
-			printf("%.*s:%.*s (%.*s)%c", p->namelen, p->name, p->paramlen,
-			       p->param, p->typelen, p->type, separator);
+			printf("%.*s:%.*s (%.*s)%c", p->namelen, p->name, p->desclen,
+			       p->desc, p->typelen, p->type, separator);
 		else
-			printf("%.*s:%.*s%c", p->namelen, p->name, p->paramlen, p->param,
+			printf("%.*s:%.*s%c", p->namelen, p->name, p->desclen, p->desc,
 			       separator);
 
 		free(p);
@@ -234,15 +234,15 @@ static int modinfo_do(struct kmod_module *mod)
 		struct param *p = params;
 		params = p->next;
 
-		if (p->param == NULL)
+		if (p->desc == NULL)
 			printf("%-16s%.*s: (%.*s)%c", "parm:", p->namelen, p->name,
 			       p->typelen, p->type, separator);
 		else if (p->type != NULL)
 			printf("%-16s%.*s:%.*s (%.*s)%c", "parm:", p->namelen, p->name,
-			       p->paramlen, p->param, p->typelen, p->type, separator);
+			       p->desclen, p->desc, p->typelen, p->type, separator);
 		else
 			printf("%-16s%.*s:%.*s%c", "parm:", p->namelen, p->name,
-			       p->paramlen, p->param, separator);
+			       p->desclen, p->desc, separator);
 
 		free(p);
 	}

--- a/tools/modinfo.c
+++ b/tools/modinfo.c
@@ -176,6 +176,8 @@ end:
 
 static int modinfo_do(struct kmod_module *mod)
 {
+	const bool print_all = field == NULL;
+	const bool print_parm = !print_all && streq(field, "parm");
 	struct kmod_list *l, *list = NULL;
 	struct param *params = NULL;
 	int err, is_builtin;
@@ -185,7 +187,7 @@ static int modinfo_do(struct kmod_module *mod)
 
 	/* TODO: align builtin vs not wrt listing "name:" via kmod_module_get_info() */
 	if (is_builtin) {
-		if (field == NULL)
+		if (print_all)
 			print_line("name", kmod_module_get_name(mod));
 		else if (streq(field, "name")) {
 			print_line(NULL, kmod_module_get_name(mod));
@@ -194,7 +196,7 @@ static int modinfo_do(struct kmod_module *mod)
 		filename = "(builtin)";
 	}
 
-	if (field == NULL)
+	if (print_all)
 		print_line("filename", filename);
 	else if (streq(field, "filename")) {
 		print_line(NULL, filename);
@@ -215,7 +217,7 @@ static int modinfo_do(struct kmod_module *mod)
 		return err;
 	}
 
-	if (field != NULL && streq(field, "parm")) {
+	if (print_parm) {
 		err = modinfo_params_do(list);
 		goto end;
 	}
@@ -224,7 +226,7 @@ static int modinfo_do(struct kmod_module *mod)
 		const char *key = kmod_module_info_get_key(l);
 		const char *value = kmod_module_info_get_value(l);
 
-		if (field != NULL) {
+		if (!print_all) {
 			if (streq(field, key))
 				print_line(NULL, value);
 			continue;
@@ -242,7 +244,7 @@ static int modinfo_do(struct kmod_module *mod)
 		}
 	}
 
-	if (field != NULL)
+	if (!print_all)
 		goto end;
 
 	while (params != NULL) {

--- a/tools/modinfo.c
+++ b/tools/modinfo.c
@@ -88,6 +88,11 @@ static int process_parm(const char *key, const char *value, struct param **param
 		return 0;
 	}
 
+	if (colon == value) {
+		ERR("Missing param name in value \"%s\"\n", value);
+		return 0;
+	}
+
 	name = value;
 	namelen = colon - value;
 	if (streq(key, "parm")) {

--- a/tools/modinfo.c
+++ b/tools/modinfo.c
@@ -32,8 +32,6 @@ struct param {
 	const char *desc;
 	const char *type;
 	int namelen;
-	int desclen;
-	int typelen;
 };
 
 enum parm_info {
@@ -44,9 +42,7 @@ enum parm_info {
 static int add_param(const char *name, size_t namelen, enum parm_info parm_info,
 		     const char *value, struct param *params, unsigned int params_count)
 {
-	size_t valuelen = strlen(value);
-
-	if (namelen > INT_MAX || valuelen > INT_MAX)
+	if (namelen > INT_MAX)
 		return -EINVAL;
 
 	/* We are guaranteed to have a match, or at least one empty entry */
@@ -64,11 +60,9 @@ static int add_param(const char *name, size_t namelen, enum parm_info parm_info,
 		switch (parm_info) {
 		case (parm_desc):
 			it->desc = value;
-			it->desclen = (int)valuelen;
 			break;
 		case (parm_type):
 			it->type = value;
-			it->typelen = (int)valuelen;
 			break;
 		}
 		break;
@@ -255,11 +249,11 @@ static int modinfo_do(struct kmod_module *mod)
 		strbuf_pushchar(&buf, ':');
 
 		if (p->desc != NULL)
-			strbuf_pushmem(&buf, p->desc, p->desclen);
+			strbuf_pushchars(&buf, p->desc);
 
 		if (p->type != NULL) {
 			strbuf_pushchars(&buf, " (");
-			strbuf_pushmem(&buf, p->type, p->typelen);
+			strbuf_pushchars(&buf, p->type);
 			strbuf_pushchars(&buf, ")");
 		}
 

--- a/tools/modinfo.c
+++ b/tools/modinfo.c
@@ -229,7 +229,7 @@ static int modinfo_do(struct kmod_module *mod)
 		params = p->next;
 
 		if (p->param == NULL)
-			printf("%-16s%.*s:%.*s%c", "parm:", p->namelen, p->name,
+			printf("%-16s%.*s: (%.*s)%c", "parm:", p->namelen, p->name,
 			       p->typelen, p->type, separator);
 		else if (p->type != NULL)
 			printf("%-16s%.*s:%.*s (%.*s)%c", "parm:", p->namelen, p->name,

--- a/tools/modinfo.c
+++ b/tools/modinfo.c
@@ -169,6 +169,7 @@ static int modinfo_do(struct kmod_module *mod)
 
 	is_builtin = (filename == NULL);
 
+	/* TODO: align builtin vs not wrt listing "name:" via kmod_module_get_info() */
 	if (is_builtin) {
 		if (field == NULL)
 			printf("%-16s%s%c", "name:", kmod_module_get_name(mod), separator);

--- a/tools/modinfo.c
+++ b/tools/modinfo.c
@@ -35,14 +35,19 @@ struct param {
 	int typelen;
 };
 
-static int add_param(const char *name, size_t namelen, const char *desc, size_t desclen,
-		     const char *type, size_t typelen, struct param **list)
+enum parm_info {
+	parm_desc,
+	parm_type,
+};
+
+static int add_param(const char *name, size_t namelen, enum parm_info parm_info,
+		     const char *value, struct param **list)
 {
+	size_t valuelen = strlen(value);
 	struct param *it;
 
-	if (namelen > INT_MAX || desclen > INT_MAX || typelen > INT_MAX) {
+	if (namelen > INT_MAX || valuelen > INT_MAX)
 		return -EINVAL;
-	}
 
 	for (it = *list; it != NULL; it = it->next) {
 		if (it->namelen == (int)namelen && memcmp(it->name, name, namelen) == 0)
@@ -63,28 +68,29 @@ static int add_param(const char *name, size_t namelen, const char *desc, size_t 
 		it->typelen = 0;
 	}
 
-	if (desc != NULL) {
-		it->desc = desc;
-		it->desclen = desclen;
-	}
-
-	if (type != NULL) {
-		it->type = type;
-		it->typelen = typelen;
+	switch (parm_info) {
+	case (parm_desc):
+		it->desc = value;
+		it->desclen = (int)valuelen;
+		break;
+	case (parm_type):
+		it->type = value;
+		it->typelen = (int)valuelen;
+		break;
 	}
 
 	return 0;
 }
 
-static int process_parm(const char *key, const char *value, struct param **params)
+static int process_parm(enum parm_info parm_info, const char *value, struct param **params)
 {
-	const char *name, *desc, *type;
-	size_t namelen, desclen, typelen;
+	const char *name;
+	size_t namelen;
 	const char *colon = strchr(value, ':');
 	int ret;
 
 	if (colon == NULL) {
-		ERR("Found invalid \"%s=%s\": missing ':'\n", key, value);
+		ERR("Missing ':' in value \"%s\"\n", value);
 		return 0;
 	}
 
@@ -95,19 +101,7 @@ static int process_parm(const char *key, const char *value, struct param **param
 
 	name = value;
 	namelen = colon - value;
-	if (streq(key, "parm")) {
-		desc = colon + 1;
-		desclen = strlen(desc);
-		type = NULL;
-		typelen = 0;
-	} else {
-		desc = NULL;
-		desclen = 0;
-		type = colon + 1;
-		typelen = strlen(type);
-	}
-
-	ret = add_param(name, namelen, desc, desclen, type, typelen, params);
+	ret = add_param(name, namelen, parm_info, colon + 1, params);
 	if (ret < 0) {
 		ERR("Unable to add parameter: %s\n", strerror(-ret));
 		return -ENOMEM;
@@ -125,12 +119,15 @@ static int modinfo_params_do(const struct kmod_list *list)
 	kmod_list_foreach(l, list) {
 		const char *key = kmod_module_info_get_key(l);
 		const char *value = kmod_module_info_get_value(l);
-		if (!streq(key, "parm") && !streq(key, "parmtype"))
-			continue;
-
-		err = process_parm(key, value, &params);
-		if (err < 0)
-			goto end;
+		if (streq(key, "parm")) {
+			err = process_parm(parm_desc, value, &params);
+			if (err < 0)
+				goto end;
+		} else if (streq(key, "parmtype")) {
+			err = process_parm(parm_type, value, &params);
+			if (err < 0)
+				goto end;
+		}
 	}
 
 	while (params != NULL) {
@@ -213,8 +210,12 @@ static int modinfo_do(struct kmod_module *mod)
 				/* filtered output contains no key, just value */
 				printf("%s%c", value, separator);
 			}
-		} else if (streq(key, "parm") || streq(key, "parmtype")) {
-			err = process_parm(key, value, &params);
+		} else if (streq(key, "parm")) {
+			err = process_parm(parm_desc, value, &params);
+			if (err < 0)
+				goto end;
+		} else if (streq(key, "parmtype")) {
+			err = process_parm(parm_type, value, &params);
 			if (err < 0)
 				goto end;
 		} else if (separator == '\0') {

--- a/tools/modinfo.c
+++ b/tools/modinfo.c
@@ -3,6 +3,7 @@
  * kmod-modinfo - query kernel module information using libkmod.
  *
  * Copyright (C) 2011-2013 ProFUSION embedded systems
+ * Copyright (C) 2026 Emil Velikov
  */
 
 #include <errno.h>
@@ -16,6 +17,7 @@
 #include <sys/stat.h>
 #include <sys/utsname.h>
 
+#include <shared/strbuf.h>
 #include <shared/util.h>
 
 #include <libkmod/libkmod.h>
@@ -26,7 +28,6 @@ static char separator = '\n';
 static const char *field;
 
 struct param {
-	struct param *next;
 	const char *name;
 	const char *desc;
 	const char *type;
@@ -41,48 +42,43 @@ enum parm_info {
 };
 
 static int add_param(const char *name, size_t namelen, enum parm_info parm_info,
-		     const char *value, struct param **list)
+		     const char *value, struct param *params, unsigned int params_count)
 {
 	size_t valuelen = strlen(value);
-	struct param *it;
 
 	if (namelen > INT_MAX || valuelen > INT_MAX)
 		return -EINVAL;
 
-	for (it = *list; it != NULL; it = it->next) {
-		if (it->namelen == (int)namelen && memcmp(it->name, name, namelen) == 0)
-			break;
-	}
+	/* We are guaranteed to have a match, or at least one empty entry */
+	for (unsigned int i = 0; i < params_count; i++) {
+		struct param *it = &params[i];
 
-	if (it == NULL) {
-		it = malloc(sizeof(struct param));
-		if (it == NULL)
-			return -ENOMEM;
-		it->next = *list;
-		*list = it;
+		if (it->name != NULL && (it->namelen != (int)namelen ||
+					 memcmp(it->name, name, namelen) != 0)) {
+			continue;
+		}
+
 		it->name = name;
 		it->namelen = namelen;
-		it->desc = NULL;
-		it->type = NULL;
-		it->desclen = 0;
-		it->typelen = 0;
-	}
 
-	switch (parm_info) {
-	case (parm_desc):
-		it->desc = value;
-		it->desclen = (int)valuelen;
-		break;
-	case (parm_type):
-		it->type = value;
-		it->typelen = (int)valuelen;
+		switch (parm_info) {
+		case (parm_desc):
+			it->desc = value;
+			it->desclen = (int)valuelen;
+			break;
+		case (parm_type):
+			it->type = value;
+			it->typelen = (int)valuelen;
+			break;
+		}
 		break;
 	}
 
 	return 0;
 }
 
-static int process_parm(enum parm_info parm_info, const char *value, struct param **params)
+static int process_parm(enum parm_info parm_info, const char *value, struct param *params,
+			unsigned int params_count)
 {
 	const char *name;
 	size_t namelen;
@@ -101,7 +97,7 @@ static int process_parm(enum parm_info parm_info, const char *value, struct para
 
 	name = value;
 	namelen = colon - value;
-	ret = add_param(name, namelen, parm_info, colon + 1, params);
+	ret = add_param(name, namelen, parm_info, colon + 1, params, params_count);
 	if (ret < 0) {
 		ERR("Unable to add parameter: %s\n", strerror(-ret));
 		return -ENOMEM;
@@ -127,59 +123,14 @@ static void print_line(const char *key, const char *value)
 	}
 }
 
-static int modinfo_params_do(const struct kmod_list *list)
-{
-	const struct kmod_list *l;
-	struct param *params = NULL;
-	int err = 0;
-
-	kmod_list_foreach(l, list) {
-		const char *key = kmod_module_info_get_key(l);
-		const char *value = kmod_module_info_get_value(l);
-		if (streq(key, "parm")) {
-			err = process_parm(parm_desc, value, &params);
-			if (err < 0)
-				goto end;
-		} else if (streq(key, "parmtype")) {
-			err = process_parm(parm_type, value, &params);
-			if (err < 0)
-				goto end;
-		}
-	}
-
-	while (params != NULL) {
-		struct param *p = params;
-		params = p->next;
-
-		if (p->desc == NULL)
-			printf("%.*s: (%.*s)%c", p->namelen, p->name, p->typelen, p->type,
-			       separator);
-		else if (p->type != NULL)
-			printf("%.*s:%.*s (%.*s)%c", p->namelen, p->name, p->desclen,
-			       p->desc, p->typelen, p->type, separator);
-		else
-			printf("%.*s:%.*s%c", p->namelen, p->name, p->desclen, p->desc,
-			       separator);
-
-		free(p);
-	}
-
-end:
-	while (params != NULL) {
-		void *tmp = params;
-		params = params->next;
-		free(tmp);
-	}
-
-	return err;
-}
-
 static int modinfo_do(struct kmod_module *mod)
 {
+	DECLARE_STRBUF_WITH_STACK(buf, 256);
 	const bool print_all = field == NULL;
 	const bool print_parm = !print_all && streq(field, "parm");
 	struct kmod_list *l, *list = NULL;
 	struct param *params = NULL;
+	unsigned int params_count = 0;
 	int err, is_builtin;
 	const char *filename = kmod_module_get_path(mod);
 
@@ -217,59 +168,106 @@ static int modinfo_do(struct kmod_module *mod)
 		return err;
 	}
 
-	if (print_parm) {
-		err = modinfo_params_do(list);
-		goto end;
+	if (print_all || print_parm) {
+		size_t count = 0;
+		size_t longest_desc = 0;
+		size_t longest_type = 0;
+		bool can_reserve;
+
+		/*
+		 * Usually parm/parmtype come in pairs, where we print once per pair.
+		 *
+		 * Get worst case scenario & longest entry, for sufficiently large buffers.
+		 */
+		kmod_list_foreach(l, list) {
+			const char *key = kmod_module_info_get_key(l);
+			size_t *longest_value;
+
+			if (streq(key, "parm"))
+				longest_value = &longest_desc;
+			else if (streq(key, "parmtype"))
+				longest_value = &longest_type;
+			else
+				continue;
+
+			const char *value = kmod_module_info_get_value(l);
+			size_t len = strlen(value);
+
+			count++;
+
+			if (len > *longest_value)
+				*longest_value = len;
+		}
+
+		/* XXX: do we want to emit a warning/error here? */
+		params_count = (count > UINT_MAX) ? UINT_MAX : (unsigned int)count;
+
+		if (params_count) {
+			params = calloc(params_count, sizeof(*params));
+
+			/*
+			 * The "name:" exists in both parm&parmtype, so don't worry if we
+			 * overallocate.
+			 */
+			can_reserve =
+				strbuf_reserve_extra(&buf, longest_desc + strlen(" ()") +
+								   longest_type);
+			if (params == NULL || !can_reserve) {
+				err = -ENOMEM;
+				goto end;
+			}
+		}
 	}
 
 	kmod_list_foreach(l, list) {
 		const char *key = kmod_module_info_get_key(l);
 		const char *value = kmod_module_info_get_value(l);
+		enum parm_info parm_info;
 
-		if (!print_all) {
+		if (!print_all && !print_parm) {
 			if (streq(field, key))
 				print_line(NULL, value);
 			continue;
 		}
+
 		if (streq(key, "parm")) {
-			err = process_parm(parm_desc, value, &params);
-			if (err < 0)
-				goto end;
+			parm_info = parm_desc;
 		} else if (streq(key, "parmtype")) {
-			err = process_parm(parm_type, value, &params);
-			if (err < 0)
-				goto end;
+			parm_info = parm_type;
 		} else {
-			print_line(key, value);
+			if (print_all)
+				print_line(key, value);
+			continue;
 		}
+
+		err = process_parm(parm_info, value, params, params_count);
+		if (err < 0)
+			goto end;
 	}
 
-	if (!print_all)
-		goto end;
+	for (unsigned int i = 0; i < params_count; i++) {
+		struct param *p = &params[i];
+		if (p->name == NULL)
+			continue;
 
-	while (params != NULL) {
-		struct param *p = params;
-		params = p->next;
+		strbuf_clear(&buf);
+		strbuf_pushmem(&buf, p->name, p->namelen);
+		strbuf_pushchar(&buf, ':');
 
-		if (p->desc == NULL)
-			printf("%-16s%.*s: (%.*s)%c", "parm:", p->namelen, p->name,
-			       p->typelen, p->type, separator);
-		else if (p->type != NULL)
-			printf("%-16s%.*s:%.*s (%.*s)%c", "parm:", p->namelen, p->name,
-			       p->desclen, p->desc, p->typelen, p->type, separator);
-		else
-			printf("%-16s%.*s:%.*s%c", "parm:", p->namelen, p->name,
-			       p->desclen, p->desc, separator);
+		if (p->desc != NULL)
+			strbuf_pushmem(&buf, p->desc, p->desclen);
 
-		free(p);
+		if (p->type != NULL) {
+			strbuf_pushchars(&buf, " (");
+			strbuf_pushmem(&buf, p->type, p->typelen);
+			strbuf_pushchars(&buf, ")");
+		}
+
+		print_line(print_parm ? NULL : "parm", strbuf_str(&buf));
 	}
 
 end:
-	while (params != NULL) {
-		void *tmp = params;
-		params = params->next;
-		free(tmp);
-	}
+	free(params);
 	kmod_module_info_free_list(list);
 
 	return err;

--- a/tools/modinfo.c
+++ b/tools/modinfo.c
@@ -110,6 +110,23 @@ static int process_parm(enum parm_info parm_info, const char *value, struct para
 	return 0;
 }
 
+static void print_line(const char *key, const char *value)
+{
+	if (key == NULL) {
+		printf("%s%c", value, separator);
+		return;
+	}
+
+	if (separator == '\0') {
+		printf("%s=%s%c", key, value, separator);
+	} else {
+		size_t keylen = strlen(key);
+		if (keylen > 15)
+			keylen = 15;
+		printf("%s:%-*s%s%c", key, 15 - (int)keylen, "", value, separator);
+	}
+}
+
 static int modinfo_params_do(const struct kmod_list *list)
 {
 	const struct kmod_list *l;
@@ -169,17 +186,17 @@ static int modinfo_do(struct kmod_module *mod)
 	/* TODO: align builtin vs not wrt listing "name:" via kmod_module_get_info() */
 	if (is_builtin) {
 		if (field == NULL)
-			printf("%-16s%s%c", "name:", kmod_module_get_name(mod), separator);
+			print_line("name", kmod_module_get_name(mod));
 		else if (field != NULL && streq(field, "name"))
-			printf("%s%c", kmod_module_get_name(mod), separator);
+			print_line(NULL, kmod_module_get_name(mod));
 		filename = "(builtin)";
 	}
 
 	if (field != NULL && streq(field, "filename")) {
-		printf("%s%c", filename, separator);
+		print_line(NULL, filename);
 		return 0;
 	} else if (field == NULL) {
-		printf("%-16s%s%c", "filename:", filename, separator);
+		print_line("filename", filename);
 	}
 
 	err = kmod_module_get_info(mod, &list);
@@ -207,8 +224,7 @@ static int modinfo_do(struct kmod_module *mod)
 
 		if (field != NULL) {
 			if (streq(field, key)) {
-				/* filtered output contains no key, just value */
-				printf("%s%c", value, separator);
+				print_line(NULL, value);
 			}
 		} else if (streq(key, "parm")) {
 			err = process_parm(parm_desc, value, &params);
@@ -218,13 +234,8 @@ static int modinfo_do(struct kmod_module *mod)
 			err = process_parm(parm_type, value, &params);
 			if (err < 0)
 				goto end;
-		} else if (separator == '\0') {
-			printf("%s=%s%c", key, value, separator);
 		} else {
-			size_t keylen = strlen(key);
-			if (keylen > 15)
-				keylen = 15;
-			printf("%s:%-*s%s%c", key, 15 - (int)keylen, "", value, separator);
+			print_line(key, value);
 		}
 	}
 

--- a/tools/modinfo.c
+++ b/tools/modinfo.c
@@ -39,18 +39,15 @@ enum parm_info {
 	parm_type,
 };
 
-static int add_param(const char *name, size_t namelen, enum parm_info parm_info,
-		     const char *value, struct param *params, unsigned int params_count)
+static void add_param(const char *name, int namelen, enum parm_info parm_info,
+		      const char *value, struct param *params, unsigned int params_count)
 {
-	if (namelen > INT_MAX)
-		return -EINVAL;
-
 	/* We are guaranteed to have a match, or at least one empty entry */
 	for (unsigned int i = 0; i < params_count; i++) {
 		struct param *it = &params[i];
 
-		if (it->name != NULL && (it->namelen != (int)namelen ||
-					 memcmp(it->name, name, namelen) != 0)) {
+		if (it->name != NULL &&
+		    (it->namelen != namelen || memcmp(it->name, name, namelen) != 0)) {
 			continue;
 		}
 
@@ -67,37 +64,28 @@ static int add_param(const char *name, size_t namelen, enum parm_info parm_info,
 		}
 		break;
 	}
-
-	return 0;
 }
 
-static int process_parm(enum parm_info parm_info, const char *value, struct param *params,
-			unsigned int params_count)
+static void process_parm(enum parm_info parm_info, const char *value,
+			 struct param *params, unsigned int params_count)
 {
 	const char *name;
-	size_t namelen;
+	int namelen;
 	const char *colon = strchr(value, ':');
-	int ret;
 
 	if (colon == NULL) {
 		ERR("Missing ':' in value \"%s\"\n", value);
-		return 0;
+		return;
 	}
 
 	if (colon == value) {
 		ERR("Missing param name in value \"%s\"\n", value);
-		return 0;
+		return;
 	}
 
 	name = value;
-	namelen = colon - value;
-	ret = add_param(name, namelen, parm_info, colon + 1, params, params_count);
-	if (ret < 0) {
-		ERR("Unable to add parameter: %s\n", strerror(-ret));
-		return -ENOMEM;
-	}
-
-	return 0;
+	namelen = (int)(colon - value);
+	add_param(name, namelen, parm_info, colon + 1, params, params_count);
 }
 
 static void print_line(const char *key, const char *value)
@@ -234,9 +222,12 @@ static int modinfo_do(struct kmod_module *mod)
 			continue;
 		}
 
-		err = process_parm(parm_info, value, params, params_count);
-		if (err < 0)
-			goto end;
+		if (strlen(value) > INT_MAX) {
+			ERR("%s's value is longer than INT_MAX\n",
+			    parm_info == parm_desc ? "parm" : "parmtype");
+			continue;
+		}
+		process_parm(parm_info, value, params, params_count);
 	}
 
 	for (unsigned int i = 0; i < params_count; i++) {


### PR DESCRIPTION
Here's a series addressing most of the formatting issues raised in https://github.com/kmod-project/kmod/issues/434. In particular the formatting code is unified and beaten into shape to use consistent formatting. With the outstanding bits being:

- the module description string is free-form and can have misc whitespace characters - `\t`, `\n` et al
- the `signature` value is still has multi-line/wrapped/tabbed formatting

In all fairness, I'm inclined to leave those as-is and let other handle them in a future PR.

The first 3 commits are something we'd probably want for the stable 34.x branch assuming there will be another release. Although, in that case we should probably check the other PRs for similar non-invasive fixes.

For the PR itself - it mostly small prep and fixup patches with the most sizable change being `modinfo: rework parm handling`.

Resolves: https://github.com/kmod-project/kmod/issues/434